### PR TITLE
fix executeScriptInTestPage

### DIFF
--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -113,7 +113,9 @@ function putTestPageWindowIntoCorrectState() {
 function executeScriptInTestPage() {
   let setupTestPage = allBehaviors[currentTestedBehavior].setupTestPage;
   if (setupTestPage) {
-    if (testPageWindow.document.readyState !== 'complete') {
+    if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
+        || testPageWindow.document.readyState !== 'complete'
+    ) {
       window.setTimeout(() => {
 	executeScriptInTestPage();
       }, 100);


### PR DESCRIPTION
JS injection into examples was failing, which was causing check boxes to not receive focus when the test page was opened. This was happening in Chrome; I didn't check other browsers.

After debugging, I discovered that (at least in chrome) the new window first loads the `about:blank` page and then loads the proper URL. Therefore when we check the `readyState`, it was evaluated as `complete`, but the window was still pointed to `about:blank`.  So our code was being injected to the `about:blank` page, and was obviously failing.

 This simply adds another check to ensure that the window's `origin` matches the same `origin` as the parent window before executing our script in the test page.