### PR TITLE
Fix combobox tests

### DIFF
--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
@@ -1,33 +1,25 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Navigating to empty, editable combobox conveys role, name, editability, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-controls">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 <script type="module">
-  // Applies to: Desktop Screen Readers
+  // Applies to: Screen Readers
 
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
-    setupTestPage: function setupTestPage(testPageDocument) {
-      const combobox = testPageDocument.querySelector('[role="combobox"]');
-      combobox.focus();
-      combobox.value = 'A';
-      const expandButton = testPageDocument.querySelector('button');
-      expandButton.click();
-    },
-    mode: ["reading"],
-    task: "read combobox",
-    specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
+    mode: ["interaction"],
+    task: "navigate to combobox",
+    specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],
       [1, "The name 'State' is spoken"],
       [1, "Users are informed they can edit text in the combobox"],
-      [1, "The value 'A' is spoken"],
-      [2, "The expanded state of the combobox is conveyed"]
+      [2, "The collapsed state of the combobox is conveyed."]
     ]
   });
 

--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Navigating to empty, editable combobox conveys role, name, editability, and state.</title>
+<title>Navigating to empty, editable combobox conveys role, name, editability, and state in reading mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -12,7 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
-    mode: ["reading", "interaction"],
+    mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Navigating to filled, editable, collapsed combobox conveys role, name, editability, value, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-controls">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 <script type="module">
-  // Applies to: Desktop Screen Readers
+  // Applies to: Screen Readers
 
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
@@ -15,19 +15,17 @@
     setupTestPage: function setupTestPage(testPageDocument) {
       const combobox = testPageDocument.querySelector('[role="combobox"]');
       combobox.focus();
-      combobox.value = 'A';
-      const expandButton = testPageDocument.querySelector('button');
-      expandButton.click();
+      combobox.value = 'Alabama';
     },
-    mode: ["reading"],
-    task: "read combobox",
-    specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
+    mode: ["interaction"],
+    task: "navigate to combobox",
+    specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],
       [1, "The name 'State' is spoken"],
       [1, "Users are informed they can edit text in the combobox"],
-      [1, "The value 'A' is spoken"],
-      [2, "The expanded state of the combobox is conveyed"]
+      [1, "The value 'Alabama' is spoken"],
+      [2, "The collapsed state of the combobox is conveyed"]
     ]
   });
 

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Navigating to filled, editable, collapsed combobox conveys role, name, editability, value, and state.</title>
+<title>Navigating to filled, editable, collapsed combobox conveys role, name, editability, value, and state in reading mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -17,7 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
-    mode: ["reading", "interaction"],
+    mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Navigating to filled, editable, open combobox conveys role, name, editability, value, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-controls">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 <script type="module">
-  // Applies to: Desktop Screen Readers
+  // Applies to: Screen Readers
 
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
@@ -19,9 +19,9 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
-    mode: ["reading"],
-    task: "read combobox",
-    specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
+    mode: ["interaction"],
+    task: "navigate to combobox",
+    specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],
       [1, "The name 'State' is spoken"],

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Navigating to filled, editable, open combobox conveys role, name, editability, value, and state.</title>
+<title>Navigating to filled, editable, open combobox conveys role, name, editability, value, and state in reading mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -19,7 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
-    mode: ["reading", "interaction"],
+    mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Reading empty, editable combobox conveys role, name, editability, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -12,22 +12,14 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
-    setupTestPage: function setupTestPage(testPageDocument) {
-      const combobox = testPageDocument.querySelector('[role="combobox"]');
-      combobox.focus();
-      combobox.value = 'A';
-      const expandButton = testPageDocument.querySelector('button');
-      expandButton.click();
-    },
-    mode: ["reading"],
+    mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],
       [1, "The name 'State' is spoken"],
       [1, "Users are informed they can edit text in the combobox"],
-      [1, "The value 'A' is spoken"],
-      [2, "The expanded state of the combobox is conveyed"]
+      [2, "The collapsed state of the combobox is conveyed"]
     ]
   });
 

--- a/tests/combobox-autocomplete-both/read-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable combobox conveys role, name, editability, and state.</title>
+<title>Reading empty, editable combobox conveys role, name, editability, and state in reading mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -12,7 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
-    mode: ["reading", "interaction"],
+    mode: ["reading"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Reading empty, editable combobox conveys role, name, editability, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -15,19 +15,17 @@
     setupTestPage: function setupTestPage(testPageDocument) {
       const combobox = testPageDocument.querySelector('[role="combobox"]');
       combobox.focus();
-      combobox.value = 'A';
-      const expandButton = testPageDocument.querySelector('button');
-      expandButton.click();
+      combobox.value = 'Alabama';
     },
-    mode: ["reading"],
+    mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],
       [1, "The name 'State' is spoken"],
       [1, "Users are informed they can edit text in the combobox"],
-      [1, "The value 'A' is spoken"],
-      [2, "The expanded state of the combobox is conveyed"]
+      [1, "The value 'Alabama' is spoken"],
+      [2, "The collapsed state of the combobox is conveyed"]
     ]
   });
 

--- a/tests/combobox-autocomplete-both/read-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox.html
@@ -18,7 +18,7 @@
       combobox.value = 'Alabama';
     },
     mode: ["reading", "interaction"],
-    task: "read the combobox",
+    task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],

--- a/tests/combobox-autocomplete-both/read-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable combobox conveys role, name, editability, and state.</title>
+<title>Reading empty, editable combobox conveys role, name, editability, and state in reading mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -17,7 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
-    mode: ["reading", "interaction"],
+    mode: ["reading"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Reading empty, editable, open combobox conveys role, name, editability, and state in reading mode.</title>
+<title>Reading empty, editable, open combobox conveys role, name, editability, and state in interaction mode.</title>
 <link rel="author" title="Matt King" href="mailto:a11ythinker@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/wai-aria-practices-1.1/#combobox">
 <link rel="help" href="https://w3c.github.io/aria/#combobox">
@@ -19,7 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
-    mode: ["reading"],
+    mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox.html
@@ -20,7 +20,7 @@
       expandButton.click();
     },
     mode: ["reading", "interaction"],
-    task: "read the combobox",
+    task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [
       [1, "The role 'combobox' is conveyed"],

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -27,14 +27,14 @@ const AT_COMMAND_MAP = {
   "read combobox": {
     reading: {
       jaws: [
-        keys.INSERT_TAB,
-        keys.INSERT_UP
+        keys.INS_TAB,
+        keys.INS_UP
       ]
     },
     interaction: {
       jaws: [
-        keys.INSERT_TAB,
-        keys.INSERT_UP
+        keys.INS_TAB,
+        keys.INS_UP
       ]
     }
   },
@@ -248,12 +248,3 @@ export function isKnownAT(at) {
   return KNOWN_ATS[at.toLowerCase()];
 }
 
-export function getAdditionalAssertions(atAdditionalAssertions, key, mode) {
-  let assertions = [];
-  for (let assertion of atAdditionalAssertions) {
-    if (assertion.keys.includes(key) && assertion.mode === mode) {
-      assertions.push(assertion.assertion);
-    }
-  }
-  return assertions;
-}

--- a/tests/resources/keys.mjs
+++ b/tests/resources/keys.mjs
@@ -25,5 +25,6 @@ export const LEFT                             = "Left Arrow";
 export const RIGHT                            = "Right Arrow";
 export const SPACE                            = "Space";
 export const TAB_AND_SHIFT_TAB                = "Tab / Shift+Tab";
+export const UP                               = "Up Arrow";
 export const UP_AND_DOWN                      = "Up Arrow / Down Arrow";
 export const X_AND_SHIFT_X                    = "X / Shift+X";


### PR DESCRIPTION
Some task to key commands were broken from typos, and the reading and interaction tests needed to be broken into separate files.