### PR TITLE
Add 'applies_to' key to keep track of which AT the test tests

### DIFF
--- a/tests/checkbox/navigate-through-checkbox-group-interaction.html
+++ b/tests/checkbox/navigate-through-checkbox-group-interaction.html
@@ -10,6 +10,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to checkbox group",
     specific_user_instruction: "navigate through boundaries of checkbox group",

--- a/tests/checkbox/navigate-through-checkbox-group.html
+++ b/tests/checkbox/navigate-through-checkbox-group.html
@@ -10,6 +10,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to checkbox group",
     specific_user_instruction: "navigate through boundaries of checkbox group",

--- a/tests/checkbox/navigate-to-checkbox-interaction.html
+++ b/tests/checkbox/navigate-to-checkbox-interaction.html
@@ -9,6 +9,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox",

--- a/tests/checkbox/navigate-to-checkbox.html
+++ b/tests/checkbox/navigate-to-checkbox.html
@@ -9,6 +9,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox",

--- a/tests/checkbox/navigate-to-checked-checkbox-interaction.html
+++ b/tests/checkbox/navigate-to-checked-checkbox-interaction.html
@@ -14,6 +14,7 @@
       const checkboxes = testPageDocument.querySelectorAll('[role="checkbox"]');
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox (which is now checked)",

--- a/tests/checkbox/navigate-to-checked-checkbox.html
+++ b/tests/checkbox/navigate-to-checked-checkbox.html
@@ -14,6 +14,7 @@
       const checkboxes = testPageDocument.querySelectorAll('[role="checkbox"]');
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox (which is now checked)",

--- a/tests/checkbox/operate-checkbox-interaction.html
+++ b/tests/checkbox/operate-checkbox-interaction.html
@@ -9,6 +9,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "operate checkbox",
     specific_user_instruction: "check and uncheck the first checkbox",

--- a/tests/checkbox/operate-checkbox.html
+++ b/tests/checkbox/operate-checkbox.html
@@ -9,6 +9,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "operate checkbox",
     specific_user_instruction: "check and uncheck the first checkbox",

--- a/tests/checkbox/read-checkbox-group-interaction.html
+++ b/tests/checkbox/read-checkbox-group-interaction.html
@@ -10,6 +10,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read the checkbox group",
     specific_user_instruction: "when focus or cursor is on a checkbox, read the group",

--- a/tests/checkbox/read-checkbox-group.html
+++ b/tests/checkbox/read-checkbox-group.html
@@ -10,6 +10,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read the checkbox group",
     specific_user_instruction: "when focus or cursor is on a checkbox, read the group",

--- a/tests/checkbox/read-checkbox-interaction.html
+++ b/tests/checkbox/read-checkbox-interaction.html
@@ -13,6 +13,7 @@
       const checkboxes = testPageDocument.querySelectorAll('[role="checkbox"]');
       checkboxes[0].focus();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox",

--- a/tests/checkbox/read-checkbox.html
+++ b/tests/checkbox/read-checkbox.html
@@ -13,6 +13,7 @@
       const checkboxes = testPageDocument.querySelectorAll('[role="checkbox"]');
       checkboxes[0].focus();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox",

--- a/tests/checkbox/read-checked-checkbox-interaction.html
+++ b/tests/checkbox/read-checked-checkbox-interaction.html
@@ -15,6 +15,7 @@
       checkboxes[0].focus();
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",

--- a/tests/checkbox/read-checked-checkbox.html
+++ b/tests/checkbox/read-checked-checkbox.html
@@ -15,6 +15,7 @@
       checkboxes[0].focus();
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",

--- a/tests/combobox-autocomplete-both/activate-switches-mode.html
+++ b/tests/combobox-autocomplete-both/activate-switches-mode.html
@@ -13,6 +13,7 @@
   import * as keys from "../resources/keys.mjs";
 
   verifyATBehavior({
+    applies_to: ["NVDA", "JAWS"],
     mode: ["reading"],
     task: "activate combobox",
     specific_user_instruction: "activate the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-switches-mode.html
+++ b/tests/combobox-autocomplete-both/navigate-switches-mode.html
@@ -13,6 +13,7 @@
   import * as keys from "../resources/keys.mjs";
 
   verifyATBehavior({
+    applies_to: ["NVDA", "JAWS"],
     mode: ["reading"],
     task: "navigate to combobox with keys that switch modes",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
@@ -12,6 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
@@ -12,6 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
@@ -17,6 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
@@ -17,6 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
@@ -19,6 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
@@ -19,6 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",

--- a/tests/combobox-autocomplete-both/navigate-to-popup.html
+++ b/tests/combobox-autocomplete-both/navigate-to-popup.html
@@ -19,6 +19,7 @@
       const combobox = testPageDocument.querySelector('[role="combobox"]');
       combobox.focus();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "open combobox from input",
     specific_user_instruction: "Navigate into the popup from the empty combobox",

--- a/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
@@ -12,6 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",

--- a/tests/combobox-autocomplete-both/read-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox.html
@@ -12,6 +12,7 @@
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
   verifyATBehavior({
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",

--- a/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
@@ -17,6 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",

--- a/tests/combobox-autocomplete-both/read-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox.html
@@ -17,6 +17,7 @@
       combobox.focus();
       combobox.value = 'Alabama';
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
@@ -19,6 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["interaction"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox.html
@@ -19,6 +19,7 @@
       const expandButton = testPageDocument.querySelector('button');
       expandButton.click();
     },
+    applies_to: ["Desktop Screen Readers"],
     mode: ["reading"],
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",


### PR DESCRIPTION
Hey @jongund -- I added an `applies_to`, like we discussed in the email. You could just edit your template and add a new row to include this information. For almost all the tests we write the value will be `["Desktop Screen Readers"]` unless the test only applies to a subset of screen readers, in which case it should list the screen readers it applies too, such as: `["NVDA", "JAWS"]`