### PR TITLE
#58 Removing functionality to accept mutliple test modes

### DIFF
--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -52,7 +52,10 @@ fse.readdirSync(testDir).forEach(function (subDir) {
 
 	const userInstruction = testData.specific_user_instruction;
 	const task = testData.task;
-	const mode = testData.mode[0];
+
+	// This is temporary while transitioning from lists to strings
+	const mode = typeof testData.mode === 'string' ? testData.mode : testData.mode[0];
+
 	const ATTests = [];
 
 	// TODO: These apply_to strings are not standarized yet.

--- a/tests/checkbox/navigate-through-checkbox-group-interaction.html
+++ b/tests/checkbox/navigate-through-checkbox-group-interaction.html
@@ -11,7 +11,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to checkbox group",
     specific_user_instruction: "navigate through boundaries of checkbox group",
     output_assertions: [

--- a/tests/checkbox/navigate-through-checkbox-group.html
+++ b/tests/checkbox/navigate-through-checkbox-group.html
@@ -11,7 +11,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to checkbox group",
     specific_user_instruction: "navigate through boundaries of checkbox group",
     output_assertions: [

--- a/tests/checkbox/navigate-to-checked-checkbox-interaction.html
+++ b/tests/checkbox/navigate-to-checked-checkbox-interaction.html
@@ -15,7 +15,7 @@
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox (which is now checked)",
     output_assertions: [

--- a/tests/checkbox/navigate-to-checked-checkbox.html
+++ b/tests/checkbox/navigate-to-checked-checkbox.html
@@ -15,7 +15,7 @@
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox (which is now checked)",
     output_assertions: [

--- a/tests/checkbox/navigate-to-unchecked-checkbox-interaction.html
+++ b/tests/checkbox/navigate-to-unchecked-checkbox-interaction.html
@@ -10,7 +10,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox",
     output_assertions: [

--- a/tests/checkbox/navigate-to-unchecked-checkbox.html
+++ b/tests/checkbox/navigate-to-unchecked-checkbox.html
@@ -10,7 +10,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to checkbox",
     specific_user_instruction: "navigate to the first checkbox",
     output_assertions: [

--- a/tests/checkbox/operate-checkbox-interaction.html
+++ b/tests/checkbox/operate-checkbox-interaction.html
@@ -10,7 +10,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "operate checkbox",
     specific_user_instruction: "check and uncheck the first checkbox",
     output_assertions: [

--- a/tests/checkbox/operate-checkbox.html
+++ b/tests/checkbox/operate-checkbox.html
@@ -10,7 +10,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "operate checkbox",
     specific_user_instruction: "check and uncheck the first checkbox",
     output_assertions: [

--- a/tests/checkbox/read-checkbox-group-interaction.html
+++ b/tests/checkbox/read-checkbox-group-interaction.html
@@ -11,7 +11,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read the checkbox group",
     specific_user_instruction: "when focus or cursor is on a checkbox, read the group",
     output_assertions: [

--- a/tests/checkbox/read-checkbox-group.html
+++ b/tests/checkbox/read-checkbox-group.html
@@ -11,7 +11,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read the checkbox group",
     specific_user_instruction: "when focus or cursor is on a checkbox, read the group",
     output_assertions: [

--- a/tests/checkbox/read-checkbox-interaction.html
+++ b/tests/checkbox/read-checkbox-interaction.html
@@ -14,7 +14,7 @@
       checkboxes[0].focus();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox",
     output_assertions: [

--- a/tests/checkbox/read-checkbox.html
+++ b/tests/checkbox/read-checkbox.html
@@ -14,7 +14,7 @@
       checkboxes[0].focus();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox",
     output_assertions: [

--- a/tests/checkbox/read-checked-checkbox-interaction.html
+++ b/tests/checkbox/read-checked-checkbox-interaction.html
@@ -16,7 +16,7 @@
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
     output_assertions: [

--- a/tests/checkbox/read-checked-checkbox.html
+++ b/tests/checkbox/read-checked-checkbox.html
@@ -16,7 +16,7 @@
       checkboxes[0].setAttribute('aria-checked', 'true');
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read checkbox",
     specific_user_instruction: "when the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/activate-switches-mode.html
+++ b/tests/combobox-autocomplete-both/activate-switches-mode.html
@@ -14,7 +14,7 @@
 
   verifyATBehavior({
     applies_to: ["NVDA", "JAWS"],
-    mode: ["reading"],
+    mode: "reading",
     task: "activate combobox",
     specific_user_instruction: "activate the 'state' combobox",
     additional_assertions: {

--- a/tests/combobox-autocomplete-both/navigate-switches-mode.html
+++ b/tests/combobox-autocomplete-both/navigate-switches-mode.html
@@ -14,7 +14,7 @@
 
   verifyATBehavior({
     applies_to: ["NVDA", "JAWS"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to combobox with keys that switch modes",
     specific_user_instruction: "navigate to the 'state' combobox",
     additional_assertions: {

--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox-interaction.html
@@ -13,7 +13,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-empty-combobox.html
@@ -13,7 +13,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox-interaction.html
@@ -18,7 +18,7 @@
       combobox.value = 'Alabama';
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-combobox.html
@@ -18,7 +18,7 @@
       combobox.value = 'Alabama';
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox-interaction.html
@@ -20,7 +20,7 @@
       expandButton.click();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/navigate-to-filled-open-combobox.html
@@ -20,7 +20,7 @@
       expandButton.click();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "navigate to combobox",
     specific_user_instruction: "navigate to the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/navigate-to-popup.html
+++ b/tests/combobox-autocomplete-both/navigate-to-popup.html
@@ -20,7 +20,7 @@
       combobox.focus();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "open combobox from input",
     specific_user_instruction: "Navigate into the popup from the empty combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox-interaction.html
@@ -13,7 +13,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-empty-combobox.html
+++ b/tests/combobox-autocomplete-both/read-empty-combobox.html
@@ -13,7 +13,7 @@
 
   verifyATBehavior({
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox-interaction.html
@@ -18,7 +18,7 @@
       combobox.value = 'Alabama';
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-combobox.html
@@ -18,7 +18,7 @@
       combobox.value = 'Alabama';
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox-interaction.html
@@ -20,7 +20,7 @@
       expandButton.click();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["interaction"],
+    mode: "interaction",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/combobox-autocomplete-both/read-filled-open-combobox.html
+++ b/tests/combobox-autocomplete-both/read-filled-open-combobox.html
@@ -20,7 +20,7 @@
       expandButton.click();
     },
     applies_to: ["Desktop Screen Readers"],
-    mode: ["reading"],
+    mode: "reading",
     task: "read combobox",
     specific_user_instruction: "When the focus or reading cursor is on the 'state' combobox, read the 'state' combobox",
     output_assertions: [

--- a/tests/resources/TEMPLATE_TEST_FILE.html
+++ b/tests/resources/TEMPLATE_TEST_FILE.html
@@ -6,17 +6,17 @@
 <link rel="help" href="https://w3c.github.io/aria/#ARIA-ROLE">
 <link rel="help" href="https://w3c.github.io/aria/#ARIA-ATTRIBUTE">
 <script type="module">
-  import { verifyATBehavoir, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
+  import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
   import * as keys from "../resources/keys.mjs";
 
-  verifyATBehavoir({
+  verifyATBehavior({
 
     // If this test requires set up steps, then they should be encoded here.
     setupTestPage: function setupTestPage(testPageDocument) {
       return;
     },
 
-    mode: ["reading"],              // Only list one mode, "reading" or "interaction".
+    mode: "reading",              // Only list one mode, "reading" or "interaction".
     task: "",                       // The key used to get the appropraite key commands from ../resources/at-commands.mjs
     specific_user_instruction: "",  // A more detailed, human understandable description of the task
     output_assertions: [

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -339,7 +339,6 @@ Were there additional undesirable behaviors? <span class="required">(required)</
 
   // Submit button
   let el = document.createElement('button');
-  el.innerText = "Perform the next behavior test";
   el.innerText = "Review Results";
   el.addEventListener('click', submitResult);
   recordEl.append(el);
@@ -480,17 +479,20 @@ function validateResults() {
       document.querySelector(`#cmd-${c}-problem .required`).classList.add('highlight-required');
       focusEl = focusEl || document.querySelector(`#cmd-${c}-problem input[type="radio"]`);
     }
-    else if (problemRadio && problemSelected) {
+    else if (document.querySelector(`input#problem-${c}-false:checked`) || (problemRadio && problemSelected)) {
       document.querySelector(`#cmd-${c}-problem .required`).classList.remove('highlight-required');
-      focusEl = focusEl || document.querySelector(`#cmd-${c}-problem input[type="select"]`);
+      undesirableFieldset.classList.remove('highlight-required');
     }
+
     if (otherSelected) {
       if (!otherText) {
 	document.querySelector(`#cmd-${c}-problem .required-other`).classList.add('highlight-required');
+	undesirableFieldset.classList.add('highlight-required');
 	focusEl = focusEl || document.querySelector(`#cmd-${c}-problem select`);
       }
       else {
 	document.querySelector(`#cmd-${c}-problem .required-other`).classList.remove('highlight-required');
+	undesirableFieldset.classList.remove('highlight-required');
       }
     }
   }

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -126,8 +126,11 @@ function executeScriptInTestPage() {
 }
 
 export function verifyATBehavior(atBehavior) {
-  let newBehavior = Object.assign({}, atBehavior, { mode: atBehavior.mode });
-  newBehavior.commands = getATCommands(atBehavior.mode, atBehavior.task, at);
+  // This is temporary until transition is complete from multiple modes to one mode
+  let mode = typeof atBehavior.mode === 'string' ? atBehavior.mode : atBehavior.mode[0];
+
+  let newBehavior = Object.assign({}, atBehavior, { mode: mode });
+  newBehavior.commands = getATCommands(mode, atBehavior.task, at);
   newBehavior.output_assertions = newBehavior.output_assertions ? newBehavior.output_assertions : [];
   newBehavior.additional_assertions = newBehavior.additional_assertions
     ? atBehavior.additional_assertions[at.toLowerCase()] || []
@@ -175,7 +178,7 @@ function displayInstructionsForBehaviorTest() {
 
   let instructionsEl = document.getElementById('instructions');
   instructionsEl.innerHTML = `
-<h1 id="behavior-header" tabindex="0">Testing task: ${behavior.task}</h1>
+<h1 id="behavior-header" tabindex="0">Testing task: ${document.title}</h1>
 <p>How does ${at} respond after task "${userInstructions}" is performed in ${mode} mode?</p>
 <h2>Test instructions</h2>
 <ol>


### PR DESCRIPTION
This PR resolves #58, whereby only one test definition should be passed to `verifyATBehavior`