### PR TITLE
Add support file

### DIFF
--- a/tests/support.json
+++ b/tests/support.json
@@ -1,0 +1,30 @@
+{
+  "ats": [
+    {
+      "name": "VoiceOver for MacOS",
+      "key": "voiceover"
+    },
+    {
+      "name": "NVDA",
+      "key": "nvda"
+    },
+    {
+      "name": "JAWS",
+      "key": "jaws"
+    }
+  ],
+  "examples": [
+    {
+      "directory": "checkbox",
+      "name": "Checkbox Example (Two State)"
+    },
+    {
+      "directory": "menubar-edit",
+      "name": "Editor Menubar Example"
+    },
+    {
+      "directory": "combobox-autocomplete-both",
+      "name": "Editable Combobox With Both List and Inline Autocomplete Example"
+    }
+  ]
+}


### PR DESCRIPTION
Hey all,

The runner needs to know which ATs are supported and what to call them, and this should be kept in sync with the test suite. I'm suggesting adding this "support.json" file in the test directory that for now should be edited when there are new test plans or support for new ATs.

The file has two things:
1. an "ats" object that is a list of support ATs. Each supported AT has a human readable name and a key. The key is provided by a URL param in order to open the test to perform for a specific assistive technology.
2. an "examples" object. The examples object maps the directory names to a human readable name for the example. Eventually, we should have a programmatic way to get this information, but for now that is blocked on #133, at least.

