### PR TITLE
Update support file with 'applies_to' information

### DIFF
--- a/tests/support.json
+++ b/tests/support.json
@@ -1,7 +1,7 @@
 {
   "ats": [
     {
-      "name": "VoiceOver for MacOS",
+      "name": "VoiceOver for macOS",
       "key": "voiceover"
     },
     {
@@ -15,12 +15,12 @@
   ],
   "applies_to": {
     "Desktop Screen Readers": [
-      "VoiceOver for MacOS",
+      "VoiceOver for macOS",
       "NVDA",
       "JAWS"
     ],
     "Screen Readers": [
-      "VoiceOver for MacOS",
+      "VoiceOver for macOS",
       "NVDA",
       "JAWS"
     ]

--- a/tests/support.json
+++ b/tests/support.json
@@ -2,7 +2,7 @@
   "ats": [
     {
       "name": "VoiceOver for macOS",
-      "key": "voiceover"
+      "key": "voiceover-macos"
     },
     {
       "name": "NVDA",

--- a/tests/support.json
+++ b/tests/support.json
@@ -13,13 +13,28 @@
       "key": "jaws"
     }
   ],
+  "applies_to": [
+    "Desktop Screen Readers": [
+      "VoiceOver for MacOS",
+      "NVDA",
+      "JAWS"
+    ],
+    "Screen Readers": [
+      "VoiceOver for MacOS",
+      "NVDA",
+      "JAWS"
+    ],
+    "VoiceOver": [
+      "VoiceOver for MacOS"
+    ]
+  ],
   "examples": [
     {
       "directory": "checkbox",
       "name": "Checkbox Example (Two State)"
     },
     {
-      "directory": "menubar-edit",
+      "directory": "menubar-editor",
       "name": "Editor Menubar Example"
     },
     {

--- a/tests/support.json
+++ b/tests/support.json
@@ -23,9 +23,6 @@
       "VoiceOver for MacOS",
       "NVDA",
       "JAWS"
-    ],
-    "VoiceOver": [
-      "VoiceOver for MacOS"
     ]
   },
   "examples": [

--- a/tests/support.json
+++ b/tests/support.json
@@ -13,7 +13,7 @@
       "key": "jaws"
     }
   ],
-  "applies_to": [
+  "applies_to": {
     "Desktop Screen Readers": [
       "VoiceOver for MacOS",
       "NVDA",
@@ -27,7 +27,7 @@
     "VoiceOver": [
       "VoiceOver for MacOS"
     ]
-  ],
+  },
   "examples": [
     {
       "directory": "checkbox",


### PR DESCRIPTION
Adding more information to this file that I think would be necessary in order to consume and run these tests by any third party! The extra information is the relationship between "applies_to" values in the tests.

What values can be put in the "applies_to" field was discussed in this issue: https://github.com/w3c/aria-at/issues/108

But I do have one question. We see in the tests an applies_to value of "VoiceOver". Is there a chance, @mcking65, that we should have a category call "VoiceOver" the refers to both "VoiceOver for MacOS" and "VoiceOver for iOS" -- or should those tests be update to revert to just "VoiceOver for MacOS"? These are "Test 2" and "Test 4" in the [combobox test plan](https://w3c.github.io/aria-at/review/combobox-autocomplete-both.html).