### PR TITLE
Use JSON to pass test data to the harness

### DIFF
--- a/scripts/create-tests.js
+++ b/scripts/create-tests.js
@@ -52,8 +52,11 @@ const atCommandsFile = path.join(testDirectory, 'data', 'commands.csv');
 const referencesFile = path.join(testDirectory, 'data', 'references.csv');
 const javascriptDirectory = path.join(testDirectory, 'data', 'js');
 const indexFile = path.join(testDirectory,'index.html');
+const scriptsFile = path.join(testDirectory,'scripts.js');
 
 const keyDefs = {};
+
+let scripts = [];
 
 try {
   fse.statSync(testDirectory);
@@ -225,26 +228,23 @@ function createTestFile (test, refs, commands) {
         if (v1 === v2.toLowerCase()) {
           return v2;
         }
-      };
+      }
       return false;
     }
 
     // check for individual assistive technologies
-
     let items = values.split(',');
-    let str = '[';
-    items.forEach(function (item) {
+    let newValues = [];
+    items.filter(item => {
       let value = checkValue(item);
       if (!value) {
         addTestError(test.testId, '"' + item + '" is not valid value for "appliesTo" property.')
       }
-      str += '"' + value + '"';
-      if (items[items.length-1] !== item) {
-        str += ',';
-      }
+
+      newValues.push(value);
     });
-    str += ']';
-    return str;
+
+    return newValues;
   }
 
   function addAssertion(a) {
@@ -264,7 +264,7 @@ function createTestFile (test, refs, commands) {
     }
 
     if (a.length) {
-      assertions += `      [${level}, "${str}"],\n`
+      assertions.push([level, str]);
     }
   }
 
@@ -292,7 +292,7 @@ function createTestFile (test, refs, commands) {
     return links;
   }
 
-  function getSetupScript (fname) {
+  function addSetupScript (scriptName, fname) {
 
     let script = '';
     if (fname.length) {
@@ -310,14 +310,13 @@ function createTestFile (test, refs, commands) {
           const lines = data.split(/\r?\n/);
           lines.forEach((line) => {
             if (line.trim().length)
-            script += '      ' + line.trim() + '\n';
+            script += '\t' + line.trim() + '\n';
           });
       } catch (err) {
           console.error(err);
       }
 
-      script = `setupTestPage: function setupTestPage(testPageDocument) {
-${script}    },`
+      scripts.push(`\t${scriptName}: function(testPageDocument){\n${script}}`);
     }
 
     return script;
@@ -328,14 +327,14 @@ ${script}    },`
     if (typeof desc === 'string') {
       let d = desc.trim();
       if (d.length) {
-        str = `\n    setup_script_description: "${d}",\n    `;
+        str = d;
       }
     }
 
     return str;
   }
 
-  let assertions = '';
+  let assertions = [];
   let setupFileName = '';
   let id = test.testId;
   if (parseInt(test.testId) < 10) {
@@ -351,42 +350,36 @@ ${script}    },`
     }
   }
 
-  let task        = getTask(test.task);
   let references  = getReferences(refs.example, test.refs);
-  let mode        = getModeValue(test.mode);
-  let appliesTo   = getAppliesToValues(test.appliesTo);
-  let setupScript = getSetupScript(setupFileName);
-  let setupScriptDescription = getSetupScriptDescription(test.setupScriptDescription);
+  addSetupScript(test.setupScript, setupFileName);
 
-  addAssertion(test.assertion1);
-  addAssertion(test.assertion2);
-  addAssertion(test.assertion3);
-  addAssertion(test.assertion4);
-  addAssertion(test.assertion5);
-  addAssertion(test.assertion6);
-
-  if (assertions.length > 1) {
-    assertions = assertions.substring(0,assertions.length-2);
+  for (let i=1; i<6; i++) {
+    addAssertion(test["assertion"+i]);
   }
+
+  let testData = {
+    setup_script_description: getSetupScriptDescription(test.setupScriptDescription),
+    setupTestPage: test.setupScript,
+    applies_to: getAppliesToValues(test.appliesTo),
+    mode: getModeValue(test.mode),
+    task: getTask(test.task),
+    specific_user_instruction: test.instructions,
+    output_assertions: assertions
+  };
 
   let testHTML = `
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>${test.title}</title>
 ${references}
+<script id="test-data" type="application/json">
+${JSON.stringify(testData, null, 2)}
+</script>
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({${setupScriptDescription}${setupScript}
-    applies_to: ${appliesTo},
-    mode: "${mode}",
-    task: "${task}",
-    specific_user_instruction: "${test.instructions}",
-    output_assertions: [
-${assertions}
-    ]
-  });
-
+  verifyATBehavior();
   displayTestPageAndInstructions("${refs.reference}");
 
 </script>
@@ -472,6 +465,13 @@ ${links}
    fse.writeFileSync(indexFile, indexHTML, 'utf8');
 }
 
+function createScriptsFile() {
+  let js = 'var scripts = {\n';
+  js += scripts.join(',\n');
+  js += '\n};';
+  fse.writeFileSync(scriptsFile, js, 'utf8');
+}
+
 // Process CSV files
 
 var refs = {};
@@ -534,6 +534,8 @@ fs.createReadStream(referencesFile)
             });
 
             createIndexFile(indexOfURLs);
+
+            createScriptsFile();
 
             if (errorCount) {
               console.log('\n\n*** ' + errorCount + ' Errors in tests and/or commands ***');

--- a/scripts/create-tests.js
+++ b/scripts/create-tests.js
@@ -384,9 +384,8 @@ ${references}
     .then(response => response.json()) // parse the JSON from the server
     .then(data => {
       verifyATBehavior(data);
+      displayTestPageAndInstructions("${refs.reference}");
     });
-  
-  displayTestPageAndInstructions("${refs.reference}");
 
 </script>
 `;

--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -68,18 +68,7 @@ fse.readdirSync(testDir).forEach(function (subDir) {
 	  }
 	}
 
-	// Get data for declarative tests
-	const jsString = root.querySelector('script').innerHTML;
-        const re = /verifyATBehavior\({([\w\W]+)}\);/g;
-        const match = re.exec(jsString);
-        const verifyATBehaviorArgument = match[1];
-
-	if (!verifyATBehaviorArgument) {
-	  throw("Cannot match verifyATBehavior arguments for file: ", test);
-	}
-
-        let testData;
-        eval('testData = {' + verifyATBehaviorArgument + '}');
+	let testData = JSON.parse(fse.readFileSync(path.join(subDirFullPath, path.parse(test).name+'.json'), 'utf8'));
 
 	const userInstruction = testData.specific_user_instruction;
 	const task = testData.task;

--- a/tests/checkbox/index.html
+++ b/tests/checkbox/index.html
@@ -47,7 +47,7 @@
 <body>
   <h1>Index of Test Files</h1>
   <p>This is useful for viewing the local files on a local web server and provides links that will work when the local version of the
-  test runner is being executed, using <code>npm run start</code> from the root director: <code>C:\inetpub\wwwroot\aria-at\</code>.</p>
+  test runner is being executed, using <code>npm run start</code> from the root director: <code>/Users/zcorpan/git/w3c/aria-at/</code>.</p>
   <table>
     <thead>
       <tr>

--- a/tests/checkbox/scripts.js
+++ b/tests/checkbox/scripts.js
@@ -1,0 +1,30 @@
+var scripts = {
+	checkFirstCheckbox: function(testPageDocument){
+	// Set aria-checked on first checkbox
+	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
+},
+	checkFirstCheckbox: function(testPageDocument){
+	// Set aria-checked on first checkbox
+	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
+},
+	moveFocusToFirstCheckbox: function(testPageDocument){
+	// Move focus to first checkbox
+	testPageDocument.querySelector('[role="checkbox"]').focus();
+},
+	moveFocusToFirstCheckbox: function(testPageDocument){
+	// Move focus to first checkbox
+	testPageDocument.querySelector('[role="checkbox"]').focus();
+},
+	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
+	// Move focus and set aria-checked on first checkbox
+	const checkbox = testPageDocument.querySelector('[role="checkbox"]');
+	checkbox.focus();
+	checkbox.setAttribute('aria-checked', 'true');
+},
+	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
+	// Move focus and set aria-checked on first checkbox
+	const checkbox = testPageDocument.querySelector('[role="checkbox"]');
+	checkbox.focus();
+	checkbox.setAttribute('aria-checked', 'true');
+}
+};

--- a/tests/checkbox/test-01-navigate-into-checkbox-group-interaction.html
+++ b/tests/checkbox/test-01-navigate-into-checkbox-group-interaction.html
@@ -7,21 +7,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#group">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "navigate into checkbox group",
-    specific_user_instruction: "Navigate into a checkbox group",
-    output_assertions: [
-      [1, "Role 'group' is conveyed"],
-      [1, "Group name 'Sandwich Condiments' is conveyed"],
-      [1, "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-01-navigate-into-checkbox-group-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-01-navigate-into-checkbox-group-interaction.json
+++ b/tests/checkbox/test-01-navigate-into-checkbox-group-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "navigate into checkbox group",
+  "specific_user_instruction": "Navigate into a checkbox group",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "1",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ],
+    [
+      "1",
+      "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-02-navigate-into-checkbox-group-reading.html
+++ b/tests/checkbox/test-02-navigate-into-checkbox-group-reading.html
@@ -7,21 +7,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#group">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate into checkbox group",
-    specific_user_instruction: "Navigate into a checkbox group",
-    output_assertions: [
-      [1, "Role 'group' is conveyed"],
-      [1, "Group name 'Sandwich Condiments' is conveyed"],
-      [1, "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-02-navigate-into-checkbox-group-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-02-navigate-into-checkbox-group-reading.json
+++ b/tests/checkbox/test-02-navigate-into-checkbox-group-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate into checkbox group",
+  "specific_user_instruction": "Navigate into a checkbox group",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "1",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ],
+    [
+      "1",
+      "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-03-navigate-out-of-checkbox-group-interaction.html
+++ b/tests/checkbox/test-03-navigate-out-of-checkbox-group-interaction.html
@@ -7,21 +7,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#group">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "navigate out of checkbox group",
-    specific_user_instruction: "Navigate out of checkbox group",
-    output_assertions: [
-      [2, "Role 'group' is conveyed"],
-      [2, "Group name 'Sandwich Condiments' is conveyed"],
-      [2, "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-03-navigate-out-of-checkbox-group-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-03-navigate-out-of-checkbox-group-interaction.json
+++ b/tests/checkbox/test-03-navigate-out-of-checkbox-group-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "navigate out of checkbox group",
+  "specific_user_instruction": "Navigate out of checkbox group",
+  "output_assertions": [
+    [
+      "2",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "2",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ],
+    [
+      "2",
+      "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-04-navigate-out-of-checkbox-group-reading.html
+++ b/tests/checkbox/test-04-navigate-out-of-checkbox-group-reading.html
@@ -7,21 +7,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#group">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate out of checkbox group",
-    specific_user_instruction: "Navigate out of checkbox group",
-    output_assertions: [
-      [1, "Role 'group' is conveyed"],
-      [1, "Group name 'Sandwich Condiments' is conveyed"],
-      [1, "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-04-navigate-out-of-checkbox-group-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-04-navigate-out-of-checkbox-group-reading.json
+++ b/tests/checkbox/test-04-navigate-out-of-checkbox-group-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate out of checkbox group",
+  "specific_user_instruction": "Navigate out of checkbox group",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "1",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ],
+    [
+      "1",
+      "Boundaries of the group (before the first checkbox and after the last checkbox) are conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html
+++ b/tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Mark the first checkbox as checked",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set aria-checked on first checkbox
-      testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
-    },
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "navigate to checked checkbox",
-    specific_user_instruction: "Navigate to the first checkbox (which is now checked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-05-navigate-to-checked-checkbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.json
+++ b/tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "Mark the first checkbox as checked",
+  "setupTestPage": "checkFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "navigate to checked checkbox",
+  "specific_user_instruction": "Navigate to the first checkbox (which is now checked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-06-navigate-to-checked-checkbox-reading.html
+++ b/tests/checkbox/test-06-navigate-to-checked-checkbox-reading.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Mark the first checkbox as checked",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set aria-checked on first checkbox
-      testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to checked checkbox",
-    specific_user_instruction: "Navigate to the first checkbox (which is now checked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-06-navigate-to-checked-checkbox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-06-navigate-to-checked-checkbox-reading.json
+++ b/tests/checkbox/test-06-navigate-to-checked-checkbox-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "Mark the first checkbox as checked",
+  "setupTestPage": "checkFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to checked checkbox",
+  "specific_user_instruction": "Navigate to the first checkbox (which is now checked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-07-navigate-to-unchecked-checkbox-interaction.html
+++ b/tests/checkbox/test-07-navigate-to-unchecked-checkbox-interaction.html
@@ -6,21 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "navigate to unchecked checkbox",
-    specific_user_instruction: "Navigate to the first checkbox (which is now unchecked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-07-navigate-to-unchecked-checkbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-07-navigate-to-unchecked-checkbox-interaction.json
+++ b/tests/checkbox/test-07-navigate-to-unchecked-checkbox-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "navigate to unchecked checkbox",
+  "specific_user_instruction": "Navigate to the first checkbox (which is now unchecked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-08-navigate-to-unchecked-checkbox-reading.html
+++ b/tests/checkbox/test-08-navigate-to-unchecked-checkbox-reading.html
@@ -6,21 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to unchecked checkbox",
-    specific_user_instruction: "Navigate to the first checkbox (which is now unchecked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-08-navigate-to-unchecked-checkbox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-08-navigate-to-unchecked-checkbox-reading.json
+++ b/tests/checkbox/test-08-navigate-to-unchecked-checkbox-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to unchecked checkbox",
+  "specific_user_instruction": "Navigate to the first checkbox (which is now unchecked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-09-operate-checkbox-interaction.html
+++ b/tests/checkbox/test-09-operate-checkbox-interaction.html
@@ -5,19 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "operate checkbox",
-    specific_user_instruction: "Check and uncheck the first checkbox",
-    output_assertions: [
-      [1, "Change in state is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-09-operate-checkbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-09-operate-checkbox-interaction.json
+++ b/tests/checkbox/test-09-operate-checkbox-interaction.json
@@ -1,0 +1,18 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "operate checkbox",
+  "specific_user_instruction": "Check and uncheck the first checkbox",
+  "output_assertions": [
+    [
+      "1",
+      "Change in state is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-10-operate-checkbox-reading.html
+++ b/tests/checkbox/test-10-operate-checkbox-reading.html
@@ -5,19 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "operate checkbox",
-    specific_user_instruction: "Check and uncheck the first checkbox",
-    output_assertions: [
-      [1, "Change in state is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-10-operate-checkbox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-10-operate-checkbox-reading.json
+++ b/tests/checkbox/test-10-operate-checkbox-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "operate checkbox",
+  "specific_user_instruction": "Check and uncheck the first checkbox",
+  "output_assertions": [
+    [
+      "1",
+      "Change in state is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-11-read-the-checkbox-group-interaction.html
+++ b/tests/checkbox/test-11-read-the-checkbox-group-interaction.html
@@ -5,20 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#group">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "read the checkbox group",
-    specific_user_instruction: "When focus or cursor is on a checkbox, read its grouping information",
-    output_assertions: [
-      [1, "Role 'group' is conveyed"],
-      [1, "Group name 'Sandwich Condiments' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-11-read-the-checkbox-group-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-11-read-the-checkbox-group-interaction.json
+++ b/tests/checkbox/test-11-read-the-checkbox-group-interaction.json
@@ -1,0 +1,22 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "read the checkbox group",
+  "specific_user_instruction": "When focus or cursor is on a checkbox, read its grouping information",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "1",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-12-read-the-checkbox-group-reading.html
+++ b/tests/checkbox/test-12-read-the-checkbox-group-reading.html
@@ -5,20 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#group">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read the checkbox group",
-    specific_user_instruction: "When focus or cursor is on a checkbox, read its grouping information",
-    output_assertions: [
-      [1, "Role 'group' is conveyed"],
-      [1, "Group name 'Sandwich Condiments' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-12-read-the-checkbox-group-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-12-read-the-checkbox-group-reading.json
+++ b/tests/checkbox/test-12-read-the-checkbox-group-reading.json
@@ -1,0 +1,21 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read the checkbox group",
+  "specific_user_instruction": "When focus or cursor is on a checkbox, read its grouping information",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'group' is conveyed"
+    ],
+    [
+      "1",
+      "Group name 'Sandwich Condiments' is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-13-read-unchecked-checkbox-interaction.html
+++ b/tests/checkbox/test-13-read-unchecked-checkbox-interaction.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Put DOM focus on the first checkbox",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to first checkbox
-      testPageDocument.querySelector('[role="checkbox"]').focus();
-    },
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "read unchecked checkbox",
-    specific_user_instruction: "When the focus or reading cursor is on the first checkbox, read the first checkbox",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-13-read-unchecked-checkbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-13-read-unchecked-checkbox-interaction.json
+++ b/tests/checkbox/test-13-read-unchecked-checkbox-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "Put DOM focus on the first checkbox",
+  "setupTestPage": "moveFocusToFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "read unchecked checkbox",
+  "specific_user_instruction": "When the focus or reading cursor is on the first checkbox, read the first checkbox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-14-read-unchecked-checkbox-reading.html
+++ b/tests/checkbox/test-14-read-unchecked-checkbox-reading.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Put DOM focus on the first checkbox",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to first checkbox
-      testPageDocument.querySelector('[role="checkbox"]').focus();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read unchecked checkbox",
-    specific_user_instruction: "When the focus or reading cursor is on the first checkbox, read the first checkbox",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-14-read-unchecked-checkbox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-14-read-unchecked-checkbox-reading.json
+++ b/tests/checkbox/test-14-read-unchecked-checkbox-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "Put DOM focus on the first checkbox",
+  "setupTestPage": "moveFocusToFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read unchecked checkbox",
+  "specific_user_instruction": "When the focus or reading cursor is on the first checkbox, read the first checkbox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-15-read-checked-checkbox-interaction.html
+++ b/tests/checkbox/test-15-read-checked-checkbox-interaction.html
@@ -6,28 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Mark first checkbox as checked",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus and set aria-checked on first checkbox
-      const checkbox = testPageDocument.querySelector('[role="checkbox"]');
-      checkbox.focus();
-      checkbox.setAttribute('aria-checked', 'true');
-    },
-    applies_to: ["JAWS","NVDA","VoiceOver"],
-    mode: "interaction",
-    task: "read checked checkbox",
-    specific_user_instruction: "When the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-15-read-checked-checkbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-15-read-checked-checkbox-interaction.json
+++ b/tests/checkbox/test-15-read-checked-checkbox-interaction.json
@@ -1,0 +1,26 @@
+{
+  "setup_script_description": "Mark first checkbox as checked",
+  "setupTestPage": "moveFocusAndCheckFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA",
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "read checked checkbox",
+  "specific_user_instruction": "When the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/checkbox/test-16-read-checked-checkbox-reading.html
+++ b/tests/checkbox/test-16-read-checked-checkbox-reading.html
@@ -6,28 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#checkbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Mark first checkbox as checked",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus and set aria-checked on first checkbox
-      const checkbox = testPageDocument.querySelector('[role="checkbox"]');
-      checkbox.focus();
-      checkbox.setAttribute('aria-checked', 'true');
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read checked checkbox",
-    specific_user_instruction: "When the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
-    output_assertions: [
-      [1, "Role 'checkbox' is conveyed"],
-      [1, "Name 'Lettuce' is conveyed"],
-      [1, "State of the checkbox (not checked) is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/two-state-checkbox.html");
+  fetch("test-16-read-checked-checkbox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/two-state-checkbox.html");
+    });
 
 </script>

--- a/tests/checkbox/test-16-read-checked-checkbox-reading.json
+++ b/tests/checkbox/test-16-read-checked-checkbox-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "Mark first checkbox as checked",
+  "setupTestPage": "moveFocusAndCheckFirstCheckbox",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read checked checkbox",
+  "specific_user_instruction": "When the focus or reading cursor is on the first checkbox, read the first checkbox (which is now checked)",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'Lettuce' is conveyed"
+    ],
+    [
+      "1",
+      "State of the checkbox (not checked) is conveyed"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/index.html
+++ b/tests/combobox-autocomplete-both/index.html
@@ -47,7 +47,7 @@
 <body>
   <h1>Index of Test Files</h1>
   <p>This is useful for viewing the local files on a local web server and provides links that will work when the local version of the
-  test runner is being executed, using <code>npm run start</code> from the root director: <code>C:\inetpub\wwwroot\aria-at\</code>.</p>
+  test runner is being executed, using <code>npm run start</code> from the root director: <code>/Users/zcorpan/git/w3c/aria-at/</code>.</p>
   <table>
     <thead>
       <tr>

--- a/tests/combobox-autocomplete-both/scripts.js
+++ b/tests/combobox-autocomplete-both/scripts.js
@@ -1,0 +1,207 @@
+var scripts = {
+	comboboxValueSetCollapsedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'Alabama'
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'Alabama';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+},
+	comboboxValueSetCollapsedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'Alabama'
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'Alabama';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+},
+	comboboxValueSetCollapsedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'Alabama'
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'Alabama';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+},
+	comboboxValueSetCollapsedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'Alabama'
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'Alabama';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+},
+	comboboxValueSetExpandedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'a'
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'a';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	comboboxValueSetExpandedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'a'
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'a';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	comboboxValueSetExpandedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'a'
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'a';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	comboboxValueSetExpandedState: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'a'
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = 'a';
+	cb.comboboxNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyExpanded: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' to 'Alabama'
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	buttonFocusEmptyCollpased: function(testPageDocument){
+	// Set focus on button
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.buttonNode.focus();
+},
+	buttonFocusEmptyCollpased: function(testPageDocument){
+	// Set focus on button
+	// Ensure in collapsed state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.buttonNode.focus();
+},
+	buttonFocusEmptyExpanded: function(testPageDocument){
+	// Set focus on button
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.buttonNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	buttonFocusEmptyExpanded: function(testPageDocument){
+	// Set focus on button
+	// Ensure in expanded state.
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.buttonNode.focus();
+	cb.filter = cb.comboboxNode.value;
+	cb.filterOptions();
+	cb.open();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+},
+	comboboxFocusEmptyCollapsed: function(testPageDocument){
+	// Set focus on combobox
+	// Set value of 'combobox' is empty
+	// Ensure in collapsed state
+	var cb = testPageDocument.comboboxAutocomplete;
+	cb.comboboxNode.value = '';
+	cb.combobox.focus();
+}
+};

--- a/tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.html
@@ -4,22 +4,15 @@
 <title>Navigating to empty; editable combobox conveys role; name; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["Screen Readers"],
-    mode: "reading",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-01-navigate-to-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "reading",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.html
@@ -4,21 +4,15 @@
 <title>Navigating by line to empty; editable combobox conveys role; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate by line to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-02-navigate-by-line-to-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate by line to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.html
@@ -4,22 +4,15 @@
 <title>Navigating to empty; editable combobox conveys role; name; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["Screen Readers"],
-    mode: "interaction",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-03-navigate-to-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-04-read-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-04-read-combobox-reading.html
@@ -4,22 +4,15 @@
 <title>Reading empty; editable combobox conveys role; name; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read combobox",
-    specific_user_instruction: "With the reading cursor on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-04-read-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-04-read-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-04-read-combobox-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read combobox",
+  "specific_user_instruction": "With the reading cursor on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-05-read-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-05-read-combobox-interaction.html
@@ -4,22 +4,15 @@
 <title>Reading empty; editable combobox conveys role; name; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "read combobox",
-    specific_user_instruction: "With focus on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-05-read-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-05-read-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-05-read-combobox-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "read combobox",
+  "specific_user_instruction": "With focus on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.html
@@ -4,34 +4,15 @@
 <title>Navigating to filled; editable; collapsed  combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'Alabama'
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'Alabama';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-    },
-    applies_to: ["Screen Readers"],
-    mode: "reading",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'Alabama' is conveyed."],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-06-navigate-to-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
+  "setupTestPage": "comboboxValueSetCollapsedState",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "reading",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'Alabama' is conveyed."
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.html
@@ -4,34 +4,15 @@
 <title>Navigating to filled; editable; collapsed  combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'Alabama'
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'Alabama';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-    },
-    applies_to: ["Screen Readers"],
-    mode: "interaction",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'Alabama' is conveyed."],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-07-navigate-to-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
+  "setupTestPage": "comboboxValueSetCollapsedState",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'Alabama' is conveyed."
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-08-read-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-08-read-combobox-reading.html
@@ -4,34 +4,15 @@
 <title>Reading filled; editable; collapsed combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'Alabama'
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'Alabama';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read combobox",
-    specific_user_instruction: "With the reading cursor on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'Alabama' is conveyed."],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-08-read-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-08-read-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-08-read-combobox-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
+  "setupTestPage": "comboboxValueSetCollapsedState",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read combobox",
+  "specific_user_instruction": "With the reading cursor on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'Alabama' is conveyed."
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-09-read-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-09-read-combobox-interaction.html
@@ -4,34 +4,15 @@
 <title>Reading filled; editable; collapsed combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'Alabama'
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'Alabama';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "read combobox",
-    specific_user_instruction: "With focus on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'Alabama' is conveyed."],
-      [2, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-09-read-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-09-read-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-09-read-combobox-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'Alabama'; ensure in collapsed state.",
+  "setupTestPage": "comboboxValueSetCollapsedState",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "read combobox",
+  "specific_user_instruction": "With focus on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'Alabama' is conveyed."
+    ],
+    [
+      "2",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.html
@@ -4,35 +4,15 @@
 <title>Navigating to filled; editable; expanded combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'a'
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'a';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["Screen Readers"],
-    mode: "reading",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [2, "Expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-10-navigate-to-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
+  "setupTestPage": "comboboxValueSetExpandedState",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "reading",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "2",
+      "Expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.html
@@ -4,22 +4,15 @@
 <title>Navigating by line to filled; editable; expanded combobox conveys role; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate by line to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [2, "Expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-11-navigate-by-line-to-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate by line to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "2",
+      "Expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.html
@@ -4,35 +4,15 @@
 <title>Navigating to filled; editable; expanded combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'a'
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'a';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["Screen Readers"],
-    mode: "interaction",
-    task: "navigate to combobox",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [2, "Expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-12-navigate-to-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
+  "setupTestPage": "comboboxValueSetExpandedState",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "navigate to combobox",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "2",
+      "Expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-13-read-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-13-read-combobox-reading.html
@@ -4,35 +4,15 @@
 <title>Reading filled; editable; expanded combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'a'
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'a';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read combobox",
-    specific_user_instruction: "With the reading cursor on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [2, "Expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-13-read-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-13-read-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-13-read-combobox-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
+  "setupTestPage": "comboboxValueSetExpandedState",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read combobox",
+  "specific_user_instruction": "With the reading cursor on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "2",
+      "Expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-14-read-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-14-read-combobox-interaction.html
@@ -4,35 +4,15 @@
 <title>Reading filled; editable; expanded combobox conveys role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'a'
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = 'a';
-      cb.comboboxNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "read combobox",
-    specific_user_instruction: "With focus on the combobox; read the combobox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [2, "Expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-14-read-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-14-read-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-14-read-combobox-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; set value of 'combobox' to 'A'; ensure in expanded state.",
+  "setupTestPage": "comboboxValueSetExpandedState",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "read combobox",
+  "specific_user_instruction": "With focus on the combobox; read the combobox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "2",
+      "Expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.html
+++ b/tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.html
@@ -4,19 +4,15 @@
 <title>Navigating to editable combobox switches mode from reading to interaction</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to combobox with keys that switch modes",
-    specific_user_instruction: "Navigate to the 'State' combobox",
-    output_assertions: [
-      [1, "The screen reader switches to mode that allows text input"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.json
+++ b/tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to combobox with keys that switch modes",
+  "specific_user_instruction": "Navigate to the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "The screen reader switches to mode that allows text input"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-16-activate-combobox-reading.html
+++ b/tests/combobox-autocomplete-both/test-16-activate-combobox-reading.html
@@ -4,28 +4,15 @@
 <title>Activating editable combobox switches mode from reading to interaction</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "activate combobox",
-    specific_user_instruction: "Activate the 'State' combobox",
-    output_assertions: [
-      [1, "The screen reader switches to mode that allows text input"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-16-activate-combobox-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-16-activate-combobox-reading.json
+++ b/tests/combobox-autocomplete-both/test-16-activate-combobox-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "Set focus on combobox",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "activate combobox",
+  "specific_user_instruction": "Activate the 'State' combobox",
+  "output_assertions": [
+    [
+      "1",
+      "The screen reader switches to mode that allows text input"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-17-open-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-17-open-combobox-interaction.html
@@ -4,30 +4,15 @@
 <title>Opening combobox conveys combobox state and optionally describes suggestion availability</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; ensure it is empty and collapsed.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "open combobox",
-    specific_user_instruction: "Display the popup from empty combobox",
-    output_assertions: [
-      [1, "Expanded state of combobox is conveyed"],
-      [2, "Name 'States' is conveyed for the popup."],
-      [2, "Number of options available is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-17-open-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-17-open-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-17-open-combobox-interaction.json
@@ -1,0 +1,24 @@
+{
+  "setup_script_description": "Set focus on combobox; ensure it is empty and collapsed.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "open combobox",
+  "specific_user_instruction": "Display the popup from empty combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Expanded state of combobox is conveyed"
+    ],
+    [
+      "2",
+      "Name 'States' is conveyed for the popup."
+    ],
+    [
+      "2",
+      "Number of options available is conveyed"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-18-close-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-18-close-combobox-interaction.html
@@ -4,31 +4,15 @@
 <title>Closing combobox conveys combobox state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; ensure it is empty and expanded.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' to 'Alabama'
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "close combobox",
-    specific_user_instruction: "Collapse the combobox popup",
-    output_assertions: [
-      [1, "Collapsed state of combobox is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-18-close-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-18-close-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-18-close-combobox-interaction.json
@@ -1,0 +1,16 @@
+{
+  "setup_script_description": "Set focus on combobox; ensure it is empty and expanded.",
+  "setupTestPage": "comboboxFocusEmptyExpanded",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "close combobox",
+  "specific_user_instruction": "Collapse the combobox popup",
+  "output_assertions": [
+    [
+      "1",
+      "Collapsed state of combobox is conveyed"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-19-activate-states-button-reading.html
+++ b/tests/combobox-autocomplete-both/test-19-activate-states-button-reading.html
@@ -4,29 +4,15 @@
 <title>Activating 'States' button opens combobox and conveys name; role; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on 'States' button; Ensure combobox is empty and collapsed.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on button
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.buttonNode.focus();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "activate states button",
-    specific_user_instruction: "Activate the button that displays the list of states.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-19-activate-states-button-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-19-activate-states-button-reading.json
+++ b/tests/combobox-autocomplete-both/test-19-activate-states-button-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "Set focus on 'States' button; Ensure combobox is empty and collapsed.",
+  "setupTestPage": "buttonFocusEmptyCollpased",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "activate states button",
+  "specific_user_instruction": "Activate the button that displays the list of states.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.html
+++ b/tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.html
@@ -4,29 +4,15 @@
 <title>Activating 'States' button opens combobox and conveys name; role; editability; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on 'States' button; Ensure combobox is empty and collapsed.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on button
-      // Ensure in collapsed state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.buttonNode.focus();
-    },
-    applies_to: ["VoiceOver"],
-    mode: "interaction",
-    task: "activate states button",
-    specific_user_instruction: "Activate the button that displays the list of states.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "expanded state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-20-activate-states-button-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.json
+++ b/tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "Set focus on 'States' button; Ensure combobox is empty and collapsed.",
+  "setupTestPage": "buttonFocusEmptyCollpased",
+  "applies_to": [
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "activate states button",
+  "specific_user_instruction": "Activate the button that displays the list of states.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "expanded state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-21-activate-states-button-reading.html
+++ b/tests/combobox-autocomplete-both/test-21-activate-states-button-reading.html
@@ -4,29 +4,15 @@
 <title>Activating 'States' button closes combobox and conveys collapsed state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on 'States' button; Ensure combobox is expanded.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on button
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.buttonNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "activate states button",
-    specific_user_instruction: "Activate the button that hides the list of states.",
-    output_assertions: [
-      [1, "Collapsed state is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-21-activate-states-button-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-21-activate-states-button-reading.json
+++ b/tests/combobox-autocomplete-both/test-21-activate-states-button-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "Set focus on 'States' button; Ensure combobox is expanded.",
+  "setupTestPage": "buttonFocusEmptyExpanded",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "activate states button",
+  "specific_user_instruction": "Activate the button that hides the list of states.",
+  "output_assertions": [
+    [
+      "1",
+      "Collapsed state is conveyed"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.html
+++ b/tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.html
@@ -4,29 +4,15 @@
 <title>Activating 'States' button closes combobox and conveys collapsed state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on 'States' button; Ensure combobox is expanded.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on button
-      // Ensure in expanded state.
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.buttonNode.focus();
-      cb.filter = cb.comboboxNode.value;
-      cb.filterOptions();
-      cb.open();
-    },
-    applies_to: ["VoiceOver"],
-    mode: "interaction",
-    task: "activate states button",
-    specific_user_instruction: "Activate the button that hides the list of states.",
-    output_assertions: [
-      [1, "Collapsed state is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-22-activate-states-button-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.json
+++ b/tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.json
@@ -1,0 +1,16 @@
+{
+  "setup_script_description": "Set focus on 'States' button; Ensure combobox is expanded.",
+  "setupTestPage": "buttonFocusEmptyExpanded",
+  "applies_to": [
+    "VoiceOver"
+  ],
+  "mode": "interaction",
+  "task": "activate states button",
+  "specific_user_instruction": "Activate the button that hides the list of states.",
+  "output_assertions": [
+    [
+      "1",
+      "Collapsed state is conveyed"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.html
@@ -4,31 +4,15 @@
 <title>Navigating into popup from empty combobox conveys role; name; properties; and states of the popup and selected option</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; ensure it is empty.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "navigate into popup from combobox",
-    specific_user_instruction: "Navigate into the popup from the empty combobox",
-    output_assertions: [
-      [1, "Role 'listbox' is conveyed for the popup."],
-      [2, "Name 'States' is conveyed for the popup."],
-      [1, "Name of focused option is conveyed; e.g.; 'Alabama' if first option; 'Wyoming' if last option."],
-      [1, "Position in set of the focused option is conveyed; e.g.; 1 of 56 if first option; 56 of 56 if last option."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-23-navigate-into-popup-from-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "Set focus on combobox; ensure it is empty.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "navigate into popup from combobox",
+  "specific_user_instruction": "Navigate into the popup from the empty combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'listbox' is conveyed for the popup."
+    ],
+    [
+      "2",
+      "Name 'States' is conveyed for the popup."
+    ],
+    [
+      "1",
+      "Name of focused option is conveyed; e.g.; 'Alabama' if first option; 'Wyoming' if last option."
+    ],
+    [
+      "1",
+      "Position in set of the focused option is conveyed; e.g.; 1 of 56 if first option; 56 of 56 if last option."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.html
@@ -4,31 +4,15 @@
 <title>Typing portion of valid value to open popup conveys changes in combobox state and value selection</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; ensure it is empty.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Screen Readers"],
-    mode: "interaction",
-    task: "type in empty combobox",
-    specific_user_instruction: "Type 'a' in the empty combobox",
-    output_assertions: [
-      [1, "Either 1) The selected text 'labama' is conveyed or 2) The entire value 'Alabama' is conveyed."],
-      [1, "The selected state of of the value option 'Alabama' is conveyed."],
-      [1, "The combobox state change from collapsed to expanded is conveyed"],
-      [2, "The position in set of the selected option is conveyed; e.g.; 1 of 4 suggestions."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-24-type-in-empty-combobox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "Set focus on combobox; ensure it is empty.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "type in empty combobox",
+  "specific_user_instruction": "Type 'a' in the empty combobox",
+  "output_assertions": [
+    [
+      "1",
+      "Either 1) The selected text 'labama' is conveyed or 2) The entire value 'Alabama' is conveyed."
+    ],
+    [
+      "1",
+      "The selected state of of the value option 'Alabama' is conveyed."
+    ],
+    [
+      "1",
+      "The combobox state change from collapsed to expanded is conveyed"
+    ],
+    [
+      "2",
+      "The position in set of the selected option is conveyed; e.g.; 1 of 4 suggestions."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.html
+++ b/tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.html
@@ -4,30 +4,15 @@
 <title>Navigating popup conveys name and properties of the selected option</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; press down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "navigate listbox popup",
-    specific_user_instruction: "Navigate through options in the popup listbox",
-    output_assertions: [
-      [1, "The name of the focused option is conveyed; e.g.; 'American Samoa'"],
-      [2, "Role listbox or role option is conveyed"],
-      [2, "The position in set of the focused option is conveyed; e.g.; 3 of 56"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-25-navigate-listbox-popup-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.json
+++ b/tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.json
@@ -1,0 +1,24 @@
+{
+  "setup_script_description": "Set focus on combobox; press down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "navigate listbox popup",
+  "specific_user_instruction": "Navigate through options in the popup listbox",
+  "output_assertions": [
+    [
+      "1",
+      "The name of the focused option is conveyed; e.g.; 'American Samoa'"
+    ],
+    [
+      "2",
+      "Role listbox or role option is conveyed"
+    ],
+    [
+      "2",
+      "The position in set of the focused option is conveyed; e.g.; 3 of 56"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.html
+++ b/tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.html
@@ -4,30 +4,15 @@
 <title>Reading popup item conveys name and properties of the selected option</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; press down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "reading",
-    task: "read option in listbox popup",
-    specific_user_instruction: "With focus on an item in the popup listbox; read the item.",
-    output_assertions: [
-      [1, "Name of focused option is conveyed; e.g.; 'Alaska'"],
-      [2, "Role listbox or role option is conveyed"],
-      [2, "The position in set of the focused option is conveyed; e.g.; 2 of 56"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-26-read-option-in-listbox-popup-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.json
+++ b/tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.json
@@ -1,0 +1,24 @@
+{
+  "setup_script_description": "Set focus on combobox; press down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "reading",
+  "task": "read option in listbox popup",
+  "specific_user_instruction": "With focus on an item in the popup listbox; read the item.",
+  "output_assertions": [
+    [
+      "1",
+      "Name of focused option is conveyed; e.g.; 'Alaska'"
+    ],
+    [
+      "2",
+      "Role listbox or role option is conveyed"
+    ],
+    [
+      "2",
+      "The position in set of the focused option is conveyed; e.g.; 2 of 56"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.html
+++ b/tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.html
@@ -4,30 +4,15 @@
 <title>Reading popup item conveys name and properties of the selected option</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; press down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "read option in listbox popup",
-    specific_user_instruction: "With focus on an item in the popup listbox; read the item.",
-    output_assertions: [
-      [1, "Name of focused option is conveyed; e.g.; 'Alaska'"],
-      [2, "Role listbox or role option is conveyed"],
-      [2, "The position in set of the focused option is conveyed; e.g.; 2 of 56"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-27-read-option-in-listbox-popup-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.json
+++ b/tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.json
@@ -1,0 +1,24 @@
+{
+  "setup_script_description": "Set focus on combobox; press down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "read option in listbox popup",
+  "specific_user_instruction": "With focus on an item in the popup listbox; read the item.",
+  "output_assertions": [
+    [
+      "1",
+      "Name of focused option is conveyed; e.g.; 'Alaska'"
+    ],
+    [
+      "2",
+      "Role listbox or role option is conveyed"
+    ],
+    [
+      "2",
+      "The position in set of the focused option is conveyed; e.g.; 2 of 56"
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.html
+++ b/tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.html
@@ -4,32 +4,15 @@
 <title>Activating option in popup conveys combobox role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; press down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "choose combobox option",
-    specific_user_instruction: "Choose 'Alaska' from the listbox.",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'Alaska' is conveyed."],
-      [1, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-28-choose-combobox-option-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.json
+++ b/tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; press down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "choose combobox option",
+  "specific_user_instruction": "Choose 'Alaska' from the listbox.",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'Alaska' is conveyed."
+    ],
+    [
+      "1",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.html
+++ b/tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.html
@@ -4,32 +4,15 @@
 <title>Canceling option selection conveys combobox role; name; editability; value; and state</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; type 'A'; down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "cancel selection",
-    specific_user_instruction: "Collapse the combobox popup",
-    output_assertions: [
-      [1, "Role 'combobox' is conveyed"],
-      [1, "Name 'State' is conveyed"],
-      [1, "Ability to enter text is conveyed"],
-      [1, "Value 'A' is conveyed."],
-      [1, "Collapsed state is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-29-cancel-selection-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.json
+++ b/tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.json
@@ -1,0 +1,32 @@
+{
+  "setup_script_description": "Set focus on combobox; type 'A'; down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "cancel selection",
+  "specific_user_instruction": "Collapse the combobox popup",
+  "output_assertions": [
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "1",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "1",
+      "Ability to enter text is conveyed"
+    ],
+    [
+      "1",
+      "Value 'A' is conveyed."
+    ],
+    [
+      "1",
+      "Collapsed state is conveyed."
+    ]
+  ]
+}

--- a/tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.html
+++ b/tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.html
@@ -4,31 +4,15 @@
 <title>Initiating caret movement from listbox conveys combobox value</title>
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Set focus on combobox; press down arrow 2 times.",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Set focus on combobox
-      // Set value of 'combobox' is empty
-      // Ensure in collapsed state
-      var cb = testPageDocument.comboboxAutocomplete;
-      cb.comboboxNode.value = '';
-      cb.combobox.focus();
-    },
-    applies_to: ["Desktop Screen Readers"],
-    mode: "interaction",
-    task: "initiate caret movement from listbox",
-    specific_user_instruction: "Start caret movement in the textbox while focus is in the listbox",
-    output_assertions: [
-      [1, "Caret position is conveyed"],
-      [1, "Role 'combobox' is conveyed"],
-      [2, "Name 'State' is conveyed"],
-      [2, "Value 'Alaska' is conveyed."]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+  fetch("test-30-initiate-caret-movement-from-listbox-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/combobox-autocomplete-both.html");
+    });
 
 </script>

--- a/tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.json
+++ b/tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.json
@@ -1,0 +1,28 @@
+{
+  "setup_script_description": "Set focus on combobox; press down arrow 2 times.",
+  "setupTestPage": "comboboxFocusEmptyCollapsed",
+  "applies_to": [
+    "Desktop Screen Readers"
+  ],
+  "mode": "interaction",
+  "task": "initiate caret movement from listbox",
+  "specific_user_instruction": "Start caret movement in the textbox while focus is in the listbox",
+  "output_assertions": [
+    [
+      "1",
+      "Caret position is conveyed"
+    ],
+    [
+      "1",
+      "Role 'combobox' is conveyed"
+    ],
+    [
+      "2",
+      "Name 'State' is conveyed"
+    ],
+    [
+      "2",
+      "Value 'Alaska' is conveyed."
+    ]
+  ]
+}

--- a/tests/menubar-editor/index.html
+++ b/tests/menubar-editor/index.html
@@ -47,7 +47,7 @@
 <body>
   <h1>Index of Test Files</h1>
   <p>This is useful for viewing the local files on a local web server and provides links that will work when the local version of the
-  test runner is being executed, using <code>npm run start</code> from the root director: <code>C:\inetpub\wwwroot\aria-at\</code>.</p>
+  test runner is being executed, using <code>npm run start</code> from the root director: <code>/Users/zcorpan/git/w3c/aria-at/</code>.</p>
   <table>
     <thead>
       <tr>

--- a/tests/menubar-editor/scripts.js
+++ b/tests/menubar-editor/scripts.js
@@ -1,0 +1,174 @@
+var scripts = {
+	focusonfirstlink: function(testPageDocument){
+	// Move focus to the link just before the meunbar
+	console.log('[focusOnFirstLink][menubarEditor]: ' + testPageDocument.menubarEditor);
+	testPageDocument.querySelector('a').focus();
+},
+	focusonfirstlink: function(testPageDocument){
+	// Move focus to the link just before the meunbar
+	console.log('[focusOnFirstLink][menubarEditor]: ' + testPageDocument.menubarEditor);
+	testPageDocument.querySelector('a').focus();
+},
+	focusonfont: function(testPageDocument){
+	// Move focus to the "Font" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonfont: function(testPageDocument){
+	// Move focus to the "Font" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	openfontsubmenu: function(testPageDocument){
+	// Open "Font" menu item and move focus to the "Font" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+	testPageDocument.menubarEditor.openPopup(node);
+},
+	focusonfont: function(testPageDocument){
+	// Move focus to the "Font" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	opentextalignsubmenu: function(testPageDocument){
+	// open "Text Align" menuitem and give the "Text Align" menu item focus
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+	testPageDocument.menubarEditor.openPopup(node);
+},
+	focusonstylecolor: function(testPageDocument){
+	// Move focus to the "Style/Color" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[1];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorblue: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Blue' menu item radio option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[5];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorblue: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Blue' menu item radio option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[5];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecoloritalic: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecoloritalic: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecoloritalicchecked: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.toggleCheckbox(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecoloritalicchecked: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.toggleCheckbox(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusontextalign: function(testPageDocument){
+	// Move focus to the "Text Align" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusontextalign: function(testPageDocument){
+	// Move focus to the "Text Align" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusontextalignleft: function(testPageDocument){
+	// open "Text Align" menu item and move focus to the 'Left' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[12];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusontextalignleft: function(testPageDocument){
+	// open "Text Align" menu item and move focus to the 'Left' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[12];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonsize: function(testPageDocument){
+	// Move focus to the "Size" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[3];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonsize: function(testPageDocument){
+	// Move focus to the "Size" menu item
+	var node = testPageDocument.querySelectorAll('[role=menuitem]')[3];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorblack: function(testPageDocument){
+	// open "Style/Color" menu item and move focue to the 'Black' menu item radio option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[4];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorblack: function(testPageDocument){
+	// open "Style/Color" menu item and move focue to the 'Black' menu item radio option
+	var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[4];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorbold: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Bold' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonstylecolorbold: function(testPageDocument){
+	// open "Style/Color" menu item and move focus to the 'Bold' menu item checkbox option
+	var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[0];
+	var menuId = testPageDocument.menubarEditor.getMenuId(node)
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonsizelargerdisabled: function(testPageDocument){
+	// open "Size" menu item, disable the "Larger" option and move focus to the "Larger" menu item checkbox option
+	var nodes = testPageDocument.querySelectorAll('[role=menuitemradio]');
+	var node = nodes[nodes.length-1];  // get last radio button, x-large
+	console.log(node.textContent);
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	var option = testPageDocument.menubarEditor.getDataOption(node);
+	var value = testPageDocument.menubarEditor.setRadioButton(node);
+	testPageDocument.menubarEditor.actionManager.setOption(option, value);
+	testPageDocument.menubarEditor.updateFontSizeMenu('menu-size');
+	node = testPageDocument.querySelectorAll('[role=menuitem]')[5];
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+},
+	focusonsizelargerdisabled: function(testPageDocument){
+	// open "Size" menu item, disable the "Larger" option and move focus to the "Larger" menu item checkbox option
+	var nodes = testPageDocument.querySelectorAll('[role=menuitemradio]');
+	var node = nodes[nodes.length-1];  // get last radio button, x-large
+	console.log(node.textContent);
+	var menuId = testPageDocument.menubarEditor.getMenuId(node);
+	var option = testPageDocument.menubarEditor.getDataOption(node);
+	var value = testPageDocument.menubarEditor.setRadioButton(node);
+	testPageDocument.menubarEditor.actionManager.setOption(option, value);
+	testPageDocument.menubarEditor.updateFontSizeMenu('menu-size');
+	node = testPageDocument.querySelectorAll('[role=menuitem]')[5];
+	testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
+}
+};

--- a/tests/menubar-editor/test-01-activate-menubar-reading.html
+++ b/tests/menubar-editor/test-01-activate-menubar-reading.html
@@ -5,19 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menubar">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "activate menubar",
-    specific_user_instruction: "activate the 'Text Formatting' menubar",
-    output_assertions: [
-      [1, "Screen reader switching to interaction mode is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-01-activate-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-01-activate-menubar-reading.json
+++ b/tests/menubar-editor/test-01-activate-menubar-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "",
+  "setupTestPage": "",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "activate menubar",
+  "specific_user_instruction": "activate the 'Text Formatting' menubar",
+  "output_assertions": [
+    [
+      "1",
+      "Screen reader switching to interaction mode is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-02-tab-to-menubar-reading.html
+++ b/tests/menubar-editor/test-02-tab-to-menubar-reading.html
@@ -5,25 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menubar">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the link just before the meunbar",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the link just before the meunbar
-      console.log('[focusOnFirstLink][menubarEditor]: ' + testPageDocument.menubarEditor);
-      testPageDocument.querySelector('a').focus();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "tab to menubar",
-    specific_user_instruction: "navigate to the 'Text Formatting' menubar",
-    output_assertions: [
-      [1, "Screen reader switching to interaction mode is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-02-tab-to-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-02-tab-to-menubar-reading.json
+++ b/tests/menubar-editor/test-02-tab-to-menubar-reading.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "Move focus to the link just before the meunbar",
+  "setupTestPage": "focusonfirstlink",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "tab to menubar",
+  "specific_user_instruction": "navigate to the 'Text Formatting' menubar",
+  "output_assertions": [
+    [
+      "1",
+      "Screen reader switching to interaction mode is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-03-navigate-to-menubar-reading.html
+++ b/tests/menubar-editor/test-03-navigate-to-menubar-reading.html
@@ -5,27 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menubar">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the link just before the meunbar",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the link just before the meunbar
-      console.log('[focusOnFirstLink][menubarEditor]: ' + testPageDocument.menubarEditor);
-      testPageDocument.querySelector('a').focus();
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to menubar",
-    specific_user_instruction: "navigate to the 'Text Formatting' menubar",
-    output_assertions: [
-      [1, "The role 'menubar' is conveyed"],
-      [1, "The menubar label 'Text Formatting' is conveyed"],
-      [1, "Number of items in menubar is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-03-navigate-to-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-03-navigate-to-menubar-reading.json
+++ b/tests/menubar-editor/test-03-navigate-to-menubar-reading.json
@@ -1,0 +1,25 @@
+{
+  "setup_script_description": "Move focus to the link just before the meunbar",
+  "setupTestPage": "focusonfirstlink",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to menubar",
+  "specific_user_instruction": "navigate to the 'Text Formatting' menubar",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menubar' is conveyed"
+    ],
+    [
+      "1",
+      "The menubar label 'Text Formatting' is conveyed"
+    ],
+    [
+      "1",
+      "Number of items in menubar is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-04-navigate-to-menuitem-in-menubar-reading.html
+++ b/tests/menubar-editor/test-04-navigate-to-menuitem-in-menubar-reading.html
@@ -5,30 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Font' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Font" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to menuitem in menubar",
-    specific_user_instruction: "navigate to 'Style/Color' menu",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Style/Color' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role 'menubar' is conveyed"],
-      [2, " The menubar label 'Text Formatting' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-04-navigate-to-menuitem-in-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-04-navigate-to-menuitem-in-menubar-reading.json
+++ b/tests/menubar-editor/test-04-navigate-to-menuitem-in-menubar-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Font' menu item",
+  "setupTestPage": "focusonfont",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to menuitem in menubar",
+  "specific_user_instruction": "navigate to 'Style/Color' menu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Style/Color' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role 'menubar' is conveyed"
+    ],
+    [
+      "2",
+      " The menubar label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-05-navigate-to-menuitem-in-menubar-interaction.html
+++ b/tests/menubar-editor/test-05-navigate-to-menuitem-in-menubar-interaction.html
@@ -5,30 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Font' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Font" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "navigate to menuitem in menubar",
-    specific_user_instruction: "navigate to 'Style/Color' menu",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Style/Color' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role 'menubar' is conveyed"],
-      [2, " The menubar label 'Text Formatting' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-05-navigate-to-menuitem-in-menubar-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-05-navigate-to-menuitem-in-menubar-interaction.json
+++ b/tests/menubar-editor/test-05-navigate-to-menuitem-in-menubar-interaction.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Font' menu item",
+  "setupTestPage": "focusonfont",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "navigate to menuitem in menubar",
+  "specific_user_instruction": "navigate to 'Style/Color' menu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Style/Color' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role 'menubar' is conveyed"
+    ],
+    [
+      "2",
+      " The menubar label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-06-navigate-to-menuitemradio-in-submenu-reading.html
+++ b/tests/menubar-editor/test-06-navigate-to-menuitemradio-in-submenu-reading.html
@@ -5,30 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Open 'Font' menu item and move focus to the 'Font' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Open "Font" menu item and move focus to the "Font" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-      testPageDocument.menubarEditor.openPopup(node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to menuitemradio in submenu",
-    specific_user_instruction: "navigate to 'Sans-serif' menu item in the 'Font' submenu",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Sans-serif' is conveyed"],
-      [1, "The checked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-06-navigate-to-menuitemradio-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-06-navigate-to-menuitemradio-in-submenu-reading.json
+++ b/tests/menubar-editor/test-06-navigate-to-menuitemradio-in-submenu-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "Open 'Font' menu item and move focus to the 'Font' menu item",
+  "setupTestPage": "openfontsubmenu",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to menuitemradio in submenu",
+  "specific_user_instruction": "navigate to 'Sans-serif' menu item in the 'Font' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Sans-serif' is conveyed"
+    ],
+    [
+      "1",
+      "The checked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-07-navigate-to-menuitemradio-in-submenu-interaction.html
+++ b/tests/menubar-editor/test-07-navigate-to-menuitemradio-in-submenu-interaction.html
@@ -5,29 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Font' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Font" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "navigate to menuitemradio in submenu",
-    specific_user_instruction: "navigate to 'Sans-serif' menu item in the 'Font' submenu",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Sans-serif' is conveyed"],
-      [1, "The checked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-07-navigate-to-menuitemradio-in-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-07-navigate-to-menuitemradio-in-submenu-interaction.json
+++ b/tests/menubar-editor/test-07-navigate-to-menuitemradio-in-submenu-interaction.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "Move focus to the 'Font' menu item",
+  "setupTestPage": "focusonfont",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "navigate to menuitemradio in submenu",
+  "specific_user_instruction": "navigate to 'Sans-serif' menu item in the 'Font' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Sans-serif' is conveyed"
+    ],
+    [
+      "1",
+      "The checked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-08-navigate-to-menuitemcheckbox-in-submenu-reading.html
+++ b/tests/menubar-editor/test-08-navigate-to-menuitemcheckbox-in-submenu-reading.html
@@ -5,30 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Text Align' menuitem and give the 'Text ALign' menu item focus",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Text Align" menuitem and give the "Text Align" menu item focus
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-      testPageDocument.menubarEditor.openPopup(node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "navigate to menuitemcheckbox in submenu",
-    specific_user_instruction: "navigate to 'Bold' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item checkbox' is conveyed"],
-      [1, "The label 'Sans-serif' is conveyed"],
-      [1, "The unchecked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-08-navigate-to-menuitemcheckbox-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-08-navigate-to-menuitemcheckbox-in-submenu-reading.json
+++ b/tests/menubar-editor/test-08-navigate-to-menuitemcheckbox-in-submenu-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "open 'Text Align' menuitem and give the 'Text ALign' menu item focus",
+  "setupTestPage": "opentextalignsubmenu",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "navigate to menuitemcheckbox in submenu",
+  "specific_user_instruction": "navigate to 'Bold' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Sans-serif' is conveyed"
+    ],
+    [
+      "1",
+      "The unchecked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-09-navigate-to-menuitemcheckbox-in-submenu-interaction.html
+++ b/tests/menubar-editor/test-09-navigate-to-menuitemcheckbox-in-submenu-interaction.html
@@ -5,29 +5,15 @@
 <link rel="help" href="https://w3c.github.io/aria-practices/examples/menubar/menubar-2/menubar-2.html">
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Style/Color' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Style/Color" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[1];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "navigate to menuitemcheckbox in submenu",
-    specific_user_instruction: "navigate to 'Bold' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item checkbox' is conveyed"],
-      [1, "The label 'Bold' is conveyed"],
-      [1, "The unchecked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-09-navigate-to-menuitemcheckbox-in-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-09-navigate-to-menuitemcheckbox-in-submenu-interaction.json
+++ b/tests/menubar-editor/test-09-navigate-to-menuitemcheckbox-in-submenu-interaction.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "Move focus to the 'Style/Color' menu item",
+  "setupTestPage": "focusonstylecolor",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "navigate to menuitemcheckbox in submenu",
+  "specific_user_instruction": "navigate to 'Bold' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Bold' is conveyed"
+    ],
+    [
+      "1",
+      "The unchecked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-10-change-state-of-menuitemradio-in-submenu-reading.html
+++ b/tests/menubar-editor/test-10-change-state-of-menuitemradio-in-submenu-reading.html
@@ -6,27 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Blue' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Blue' menu item radio option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[5];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "change state of menuitemradio in submenu",
-    specific_user_instruction: "check the 'Blue' menu item in the 'Style/Color'sub menu",
-    output_assertions: [
-      [1, "The checked state of the checkbox is conveyed"],
-      [1, "Screen reader switching to interaction mode is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-10-change-state-of-menuitemradio-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-10-change-state-of-menuitemradio-in-submenu-reading.json
+++ b/tests/menubar-editor/test-10-change-state-of-menuitemradio-in-submenu-reading.json
@@ -1,0 +1,21 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Blue' menu item radio option",
+  "setupTestPage": "focusonstylecolorblue",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "change state of menuitemradio in submenu",
+  "specific_user_instruction": "check the 'Blue' menu item in the 'Style/Color'sub menu",
+  "output_assertions": [
+    [
+      "1",
+      "The checked state of the checkbox is conveyed"
+    ],
+    [
+      "1",
+      "Screen reader switching to interaction mode is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-11-change-state-of-menuitemradio-in-submenu-interaction.html
+++ b/tests/menubar-editor/test-11-change-state-of-menuitemradio-in-submenu-interaction.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Blue' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Blue' menu item radio option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[5];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "change state of menuitemradio in submenu",
-    specific_user_instruction: "check the 'Blue' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The checked state of the checkbox is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-11-change-state-of-menuitemradio-in-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-11-change-state-of-menuitemradio-in-submenu-interaction.json
+++ b/tests/menubar-editor/test-11-change-state-of-menuitemradio-in-submenu-interaction.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Blue' menu item radio option",
+  "setupTestPage": "focusonstylecolorblue",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "change state of menuitemradio in submenu",
+  "specific_user_instruction": "check the 'Blue' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The checked state of the checkbox is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-12-change-state-of-menuitemcheckbox-in-submenu-reading.html
+++ b/tests/menubar-editor/test-12-change-state-of-menuitemcheckbox-in-submenu-reading.html
@@ -6,27 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "change state of menuitemcheckbox in submenu",
-    specific_user_instruction: "check the 'Italic' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The checked state of the checkbox is conveyed"],
-      [1, "Screen reader switching to interaction mode is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-12-change-state-of-menuitemcheckbox-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-12-change-state-of-menuitemcheckbox-in-submenu-reading.json
+++ b/tests/menubar-editor/test-12-change-state-of-menuitemcheckbox-in-submenu-reading.json
@@ -1,0 +1,21 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
+  "setupTestPage": "focusonstylecoloritalic",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "change state of menuitemcheckbox in submenu",
+  "specific_user_instruction": "check the 'Italic' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The checked state of the checkbox is conveyed"
+    ],
+    [
+      "1",
+      "Screen reader switching to interaction mode is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-13-change-state-of-menuitemcheckbox-in-submenu-interaction.html
+++ b/tests/menubar-editor/test-13-change-state-of-menuitemcheckbox-in-submenu-interaction.html
@@ -6,26 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "change state of menuitemcheckbox in submenu",
-    specific_user_instruction: "check the 'Italic' menu item in the 'Style/Color'sub menu",
-    output_assertions: [
-      [1, "The checked state of the checkbox is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-13-change-state-of-menuitemcheckbox-in-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-13-change-state-of-menuitemcheckbox-in-submenu-interaction.json
+++ b/tests/menubar-editor/test-13-change-state-of-menuitemcheckbox-in-submenu-interaction.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
+  "setupTestPage": "focusonstylecoloritalic",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "change state of menuitemcheckbox in submenu",
+  "specific_user_instruction": "check the 'Italic' menu item in the 'Style/Color'sub menu",
+  "output_assertions": [
+    [
+      "1",
+      "The checked state of the checkbox is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-14-change-state-of-menuitemcheckbox-in-submenu-reading.html
+++ b/tests/menubar-editor/test-14-change-state-of-menuitemcheckbox-in-submenu-reading.html
@@ -6,28 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.toggleCheckbox(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "change state of menuitemcheckbox in submenu",
-    specific_user_instruction: "uncheck the 'Italic' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The unchecked state of the checkbox is conveyed"],
-      [1, "Screen reader switching to interaction mode is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-14-change-state-of-menuitemcheckbox-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-14-change-state-of-menuitemcheckbox-in-submenu-reading.json
+++ b/tests/menubar-editor/test-14-change-state-of-menuitemcheckbox-in-submenu-reading.json
@@ -1,0 +1,21 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
+  "setupTestPage": "focusonstylecoloritalicchecked",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "change state of menuitemcheckbox in submenu",
+  "specific_user_instruction": "uncheck the 'Italic' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The unchecked state of the checkbox is conveyed"
+    ],
+    [
+      "1",
+      "Screen reader switching to interaction mode is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-15-change-state-of-menuitemcheckbox-in-submenu-interaction.html
+++ b/tests/menubar-editor/test-15-change-state-of-menuitemcheckbox-in-submenu-interaction.html
@@ -6,27 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Italic' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[1];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.toggleCheckbox(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "change state of menuitemcheckbox in submenu",
-    specific_user_instruction: "uncheck the 'Italic' menu item in the 'Style/Color' menu",
-    output_assertions: [
-      [1, "The unchecked state of the checkbox is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-15-change-state-of-menuitemcheckbox-in-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-15-change-state-of-menuitemcheckbox-in-submenu-interaction.json
+++ b/tests/menubar-editor/test-15-change-state-of-menuitemcheckbox-in-submenu-interaction.json
@@ -1,0 +1,17 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Italic' menu item checkbox option",
+  "setupTestPage": "focusonstylecoloritalicchecked",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "change state of menuitemcheckbox in submenu",
+  "specific_user_instruction": "uncheck the 'Italic' menu item in the 'Style/Color' menu",
+  "output_assertions": [
+    [
+      "1",
+      "The unchecked state of the checkbox is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-16-open-submenu-of-menubar-reading.html
+++ b/tests/menubar-editor/test-16-open-submenu-of-menubar-reading.html
@@ -6,30 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Text Align' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Text Align" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "open submenu of menubar",
-    specific_user_instruction: "opens 'Text Align' submenu and move focus to 'Left' menu item",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Left' is conveyed"],
-      [2, " The role 'menu' is conveyed"],
-      [2, " The label 'Text Align' is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-16-open-submenu-of-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-16-open-submenu-of-menubar-reading.json
+++ b/tests/menubar-editor/test-16-open-submenu-of-menubar-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Text Align' menu item",
+  "setupTestPage": "focusontextalign",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "open submenu of menubar",
+  "specific_user_instruction": "opens 'Text Align' submenu and move focus to 'Left' menu item",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Left' is conveyed"
+    ],
+    [
+      "2",
+      " The role 'menu' is conveyed"
+    ],
+    [
+      "2",
+      " The label 'Text Align' is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-17-open-submenu-of-menubar-interaction.html
+++ b/tests/menubar-editor/test-17-open-submenu-of-menubar-interaction.html
@@ -6,30 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Text Align' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Text Align" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[2];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "open submenu of menubar",
-    specific_user_instruction: "opens 'Text Align' submenu and focus moves to 'Left' menu item",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Left' is conveyed"],
-      [2, " The role menu is conveyed"],
-      [2, " The label 'Text Align' is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-17-open-submenu-of-menubar-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-17-open-submenu-of-menubar-interaction.json
+++ b/tests/menubar-editor/test-17-open-submenu-of-menubar-interaction.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Text Align' menu item",
+  "setupTestPage": "focusontextalign",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "open submenu of menubar",
+  "specific_user_instruction": "opens 'Text Align' submenu and focus moves to 'Left' menu item",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Left' is conveyed"
+    ],
+    [
+      "2",
+      " The role menu is conveyed"
+    ],
+    [
+      "2",
+      " The label 'Text Align' is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-18-close-submenu-of-menubar-reading.html
+++ b/tests/menubar-editor/test-18-close-submenu-of-menubar-reading.html
@@ -6,31 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Text Align' menu item and move focus to the 'Left' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Text Align" menu item and move focus to the 'Left' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[12];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "close submenu of menubar",
-    specific_user_instruction: "Closes 'Text Align' submenu and moves focus to 'Text Align' menu item",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Text Align' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role menubar is conveyed"],
-      [2, " The label 'Text Formatting' is conveyed"],
-      [2, " The position and size of the menubar  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-18-close-submenu-of-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-18-close-submenu-of-menubar-reading.json
+++ b/tests/menubar-editor/test-18-close-submenu-of-menubar-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "open 'Text Align' menu item and move focus to the 'Left' menu item checkbox option",
+  "setupTestPage": "focusontextalignleft",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "close submenu of menubar",
+  "specific_user_instruction": "Closes 'Text Align' submenu and moves focus to 'Text Align' menu item",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Text Align' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role menubar is conveyed"
+    ],
+    [
+      "2",
+      " The label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-19-close-submenu-of-menubar-interaction.html
+++ b/tests/menubar-editor/test-19-close-submenu-of-menubar-interaction.html
@@ -6,31 +6,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Text Align' menu item and move focus to the 'Left' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Text Align" menu item and move focus to the 'Left' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[12];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "close submenu of menubar",
-    specific_user_instruction: "Closes 'Text Align' submenu and moves focus to 'Text Align' menu item",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Text Align' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role menubar is conveyed"],
-      [2, " The label 'Text Formatting' is conveyed"],
-      [2, " The position and size of the menubar  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-19-close-submenu-of-menubar-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-19-close-submenu-of-menubar-interaction.json
+++ b/tests/menubar-editor/test-19-close-submenu-of-menubar-interaction.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "open 'Text Align' menu item and move focus to the 'Left' menu item checkbox option",
+  "setupTestPage": "focusontextalignleft",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "close submenu of menubar",
+  "specific_user_instruction": "Closes 'Text Align' submenu and moves focus to 'Text Align' menu item",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Text Align' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role menubar is conveyed"
+    ],
+    [
+      "2",
+      " The label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-20-read-menuitem-in-menubar-reading.html
+++ b/tests/menubar-editor/test-20-read-menuitem-in-menubar-reading.html
@@ -8,30 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#aria-haspopup">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Size' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Size" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[3];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read menuitem in menubar",
-    specific_user_instruction: "Review the  'Size' menu item in the menubar",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Size' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role 'menubar' is conveyed"],
-      [2, " The menubar label 'Text Formatting' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-20-read-menuitem-in-menubar-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-20-read-menuitem-in-menubar-reading.json
+++ b/tests/menubar-editor/test-20-read-menuitem-in-menubar-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Size' menu item",
+  "setupTestPage": "focusonsize",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read menuitem in menubar",
+  "specific_user_instruction": "Review the  'Size' menu item in the menubar",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Size' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role 'menubar' is conveyed"
+    ],
+    [
+      "2",
+      " The menubar label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-21-read-menuitem-in-menubar-interaction.html
+++ b/tests/menubar-editor/test-21-read-menuitem-in-menubar-interaction.html
@@ -8,30 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#aria-haspopup">
 <link rel="help" href="https://w3c.github.io/aria/#aria-expanded">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "Move focus to the 'Size' menu item",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // Move focus to the "Size" menu item
-      var node = testPageDocument.querySelectorAll('[role=menuitem]')[3];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "read menuitem in menubar",
-    specific_user_instruction: "Review the  'Size' menu item in the menubar",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Size' is conveyed"],
-      [1, "Opens submenu is conveyed"],
-      [2, " The role 'menubar' is conveyed"],
-      [2, " The menubar label 'Text Formatting' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-21-read-menuitem-in-menubar-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-21-read-menuitem-in-menubar-interaction.json
+++ b/tests/menubar-editor/test-21-read-menuitem-in-menubar-interaction.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "Move focus to the 'Size' menu item",
+  "setupTestPage": "focusonsize",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "read menuitem in menubar",
+  "specific_user_instruction": "Review the  'Size' menu item in the menubar",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Size' is conveyed"
+    ],
+    [
+      "1",
+      "Opens submenu is conveyed"
+    ],
+    [
+      "2",
+      " The role 'menubar' is conveyed"
+    ],
+    [
+      "2",
+      " The menubar label 'Text Formatting' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-22-read-menuitemradio-in-a-group-in-submenu-reading.html
+++ b/tests/menubar-editor/test-22-read-menuitemradio-in-a-group-in-submenu-reading.html
@@ -8,30 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focue to the 'Black' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focue to the 'Black' menu item radio option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[4];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read menuitemradio in a group in submenu",
-    specific_user_instruction: "Review the  'Black' menu item radio in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Black' is conveyed"],
-      [1, "The checked state is conveyed"],
-      [2, " The role group is conveyed"],
-      [2, " The group label 'Text Color' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-22-read-menuitemradio-in-a-group-in-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-22-read-menuitemradio-in-a-group-in-submenu-reading.json
+++ b/tests/menubar-editor/test-22-read-menuitemradio-in-a-group-in-submenu-reading.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focue to the 'Black' menu item radio option",
+  "setupTestPage": "focusonstylecolorblack",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read menuitemradio in a group in submenu",
+  "specific_user_instruction": "Review the  'Black' menu item radio in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Black' is conveyed"
+    ],
+    [
+      "1",
+      "The checked state is conveyed"
+    ],
+    [
+      "2",
+      " The role group is conveyed"
+    ],
+    [
+      "2",
+      " The group label 'Text Color' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-23-read-menuitemradio-in-a-group-in-a-submenu-interaction.html
+++ b/tests/menubar-editor/test-23-read-menuitemradio-in-a-group-in-a-submenu-interaction.html
@@ -8,30 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemradio">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focue to the 'Black' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focue to the 'Black' menu item radio option
-      var node = testPageDocument.querySelectorAll('[role=menuitemradio]')[4];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "read menuitemradio in a group in a submenu",
-    specific_user_instruction: "Review the  'Blue' menu item radio in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item radio' is conveyed"],
-      [1, "The label 'Black' is conveyed"],
-      [1, "The checked state is conveyed"],
-      [2, " The role group is conveyed"],
-      [2, " The group label 'Text Color' is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-23-read-menuitemradio-in-a-group-in-a-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-23-read-menuitemradio-in-a-group-in-a-submenu-interaction.json
+++ b/tests/menubar-editor/test-23-read-menuitemradio-in-a-group-in-a-submenu-interaction.json
@@ -1,0 +1,33 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focue to the 'Black' menu item radio option",
+  "setupTestPage": "focusonstylecolorblack",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "read menuitemradio in a group in a submenu",
+  "specific_user_instruction": "Review the  'Blue' menu item radio in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item radio' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Black' is conveyed"
+    ],
+    [
+      "1",
+      "The checked state is conveyed"
+    ],
+    [
+      "2",
+      " The role group is conveyed"
+    ],
+    [
+      "2",
+      " The group label 'Text Color' is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-24-read-menuitemcheckbox-in-a-submenu-reading.html
+++ b/tests/menubar-editor/test-24-read-menuitemcheckbox-in-a-submenu-reading.html
@@ -8,29 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Bold' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Bold' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read menuitemcheckbox in a submenu",
-    specific_user_instruction: "Review the 'Bold' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item checkbox' is conveyed"],
-      [1, "The label 'Bold' is conveyed"],
-      [1, "The unchecked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-24-read-menuitemcheckbox-in-a-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-24-read-menuitemcheckbox-in-a-submenu-reading.json
+++ b/tests/menubar-editor/test-24-read-menuitemcheckbox-in-a-submenu-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Bold' menu item radio option",
+  "setupTestPage": "focusonstylecolorbold",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read menuitemcheckbox in a submenu",
+  "specific_user_instruction": "Review the 'Bold' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Bold' is conveyed"
+    ],
+    [
+      "1",
+      "The unchecked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-25-read-menuitemcheckbox-in-a-submenu-interaction.html
+++ b/tests/menubar-editor/test-25-read-menuitemcheckbox-in-a-submenu-interaction.html
@@ -8,29 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitemcheckbox">
 <link rel="help" href="https://w3c.github.io/aria/#aria-checked">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Style/Color' menu item and move focus to the 'Bold' menu item radio option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Style/Color" menu item and move focus to the 'Bold' menu item checkbox option
-      var node = testPageDocument.querySelectorAll('[role=menuitemcheckbox]')[0];
-      var menuId = testPageDocument.menubarEditor.getMenuId(node)
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "read menuitemcheckbox in a submenu",
-    specific_user_instruction: "Review the 'Bold' menu item in the 'Style/Color' submenu",
-    output_assertions: [
-      [1, "The role 'menu item checkbox' is conveyed"],
-      [1, "The label 'Bold' is conveyed"],
-      [1, "The unchecked state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-25-read-menuitemcheckbox-in-a-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-25-read-menuitemcheckbox-in-a-submenu-interaction.json
+++ b/tests/menubar-editor/test-25-read-menuitemcheckbox-in-a-submenu-interaction.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "open 'Style/Color' menu item and move focus to the 'Bold' menu item radio option",
+  "setupTestPage": "focusonstylecolorbold",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "read menuitemcheckbox in a submenu",
+  "specific_user_instruction": "Review the 'Bold' menu item in the 'Style/Color' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item checkbox' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Bold' is conveyed"
+    ],
+    [
+      "1",
+      "The unchecked state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-26-read-disabled-menuitem-in-a-submenu-reading.html
+++ b/tests/menubar-editor/test-26-read-disabled-menuitem-in-a-submenu-reading.html
@@ -8,36 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-disabled">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Size' menu item and disable the 'Larger' option and move focus to the 'Larger' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Size" menu item, disable the "Larger" option and move focus to the "Larger" menu item checkbox option
-      var nodes = testPageDocument.querySelectorAll('[role=menuitemradio]');
-      var node = nodes[nodes.length-1];  // get last radio button, x-large
-      console.log(node.textContent);
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      var option = testPageDocument.menubarEditor.getDataOption(node);
-      var value = testPageDocument.menubarEditor.setRadioButton(node);
-      testPageDocument.menubarEditor.actionManager.setOption(option, value);
-      testPageDocument.menubarEditor.updateFontSizeMenu('menu-size');
-      node = testPageDocument.querySelectorAll('[role=menuitem]')[5];
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "reading",
-    task: "read disabled menuitem in a submenu",
-    specific_user_instruction: "Review the 'Larger' menu item in the 'Size' submenu",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Smaller' is conveyed"],
-      [1, "The disabled state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-26-read-disabled-menuitem-in-a-submenu-reading.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-26-read-disabled-menuitem-in-a-submenu-reading.json
+++ b/tests/menubar-editor/test-26-read-disabled-menuitem-in-a-submenu-reading.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "open 'Size' menu item and disable the 'Larger' option and move focus to the 'Larger' menu item checkbox option",
+  "setupTestPage": "focusonsizelargerdisabled",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "reading",
+  "task": "read disabled menuitem in a submenu",
+  "specific_user_instruction": "Review the 'Larger' menu item in the 'Size' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Smaller' is conveyed"
+    ],
+    [
+      "1",
+      "The disabled state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/menubar-editor/test-27-read-disabled-menuitem-in-a-submenu-interaction.html
+++ b/tests/menubar-editor/test-27-read-disabled-menuitem-in-a-submenu-interaction.html
@@ -8,36 +8,15 @@
 <link rel="help" href="https://w3c.github.io/aria/#menuitem">
 <link rel="help" href="https://w3c.github.io/aria/#aria-disabled">
 
+<script src="scripts.js"></script>
 <script type="module">
   import { verifyATBehavior, displayTestPageAndInstructions } from "../resources/aria-at-harness.mjs";
 
-  verifyATBehavior({
-    setup_script_description: "open 'Size' menu item and disable the 'Larger' option and move focus to the 'Larger' menu item checkbox option",
-    setupTestPage: function setupTestPage(testPageDocument) {
-      // open "Size" menu item, disable the "Larger" option and move focus to the "Larger" menu item checkbox option
-      var nodes = testPageDocument.querySelectorAll('[role=menuitemradio]');
-      var node = nodes[nodes.length-1];  // get last radio button, x-large
-      console.log(node.textContent);
-      var menuId = testPageDocument.menubarEditor.getMenuId(node);
-      var option = testPageDocument.menubarEditor.getDataOption(node);
-      var value = testPageDocument.menubarEditor.setRadioButton(node);
-      testPageDocument.menubarEditor.actionManager.setOption(option, value);
-      testPageDocument.menubarEditor.updateFontSizeMenu('menu-size');
-      node = testPageDocument.querySelectorAll('[role=menuitem]')[5];
-      testPageDocument.menubarEditor.setFocusToMenuitem(menuId, node);
-    },
-    applies_to: ["JAWS","NVDA"],
-    mode: "interaction",
-    task: "read disabled menuitem in a submenu",
-    specific_user_instruction: "Review the 'Larger' menu item in the 'Size' submenu",
-    output_assertions: [
-      [1, "The role 'menu item' is conveyed"],
-      [1, "The label 'Smaller' is conveyed"],
-      [1, "The disabled state is conveyed"],
-      [2, " The position and size of the submenu  is conveyed"]
-    ]
-  });
-
-  displayTestPageAndInstructions("reference/menubar-editor.html");
+  fetch("test-27-read-disabled-menuitem-in-a-submenu-interaction.json")
+    .then(response => response.json()) // parse the JSON from the server
+    .then(data => {
+      verifyATBehavior(data);
+      displayTestPageAndInstructions("reference/menubar-editor.html");
+    });
 
 </script>

--- a/tests/menubar-editor/test-27-read-disabled-menuitem-in-a-submenu-interaction.json
+++ b/tests/menubar-editor/test-27-read-disabled-menuitem-in-a-submenu-interaction.json
@@ -1,0 +1,29 @@
+{
+  "setup_script_description": "open 'Size' menu item and disable the 'Larger' option and move focus to the 'Larger' menu item checkbox option",
+  "setupTestPage": "focusonsizelargerdisabled",
+  "applies_to": [
+    "JAWS",
+    "NVDA"
+  ],
+  "mode": "interaction",
+  "task": "read disabled menuitem in a submenu",
+  "specific_user_instruction": "Review the 'Larger' menu item in the 'Size' submenu",
+  "output_assertions": [
+    [
+      "1",
+      "The role 'menu item' is conveyed"
+    ],
+    [
+      "1",
+      "The label 'Smaller' is conveyed"
+    ],
+    [
+      "1",
+      "The disabled state is conveyed"
+    ],
+    [
+      "2",
+      " The position and size of the submenu  is conveyed"
+    ]
+  ]
+}

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -142,11 +142,13 @@ function executeScriptInTestPage() {
       return;
     }
 
-    setupTestPage(testPageWindow.document);
+    scripts[behavior.setupTestPage](testPageWindow.document);
   }
 }
 
-export function verifyATBehavior(atBehavior) {
+export function verifyATBehavior() {
+  let atBehavior = JSON.parse(document.getElementById('test-data').innerHTML);
+
   // This is temporary until transition is complete from multiple modes to one mode
   let mode = typeof atBehavior.mode === 'string' ? atBehavior.mode : atBehavior.mode[0];
 

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -146,9 +146,7 @@ function executeScriptInTestPage() {
   }
 }
 
-export function verifyATBehavior() {
-  let atBehavior = JSON.parse(document.getElementById('test-data').innerHTML);
-
+export function verifyATBehavior(atBehavior) {
   // This is temporary until transition is complete from multiple modes to one mode
   let mode = typeof atBehavior.mode === 'string' ? atBehavior.mode : atBehavior.mode[0];
 


### PR DESCRIPTION
See #145 

- [x] Get feedback on this approach
- [x] Move JSON to an external file
- [ ] Use a single HTML file for all tests and load test-dependant data via the approach outlined in #145? might move this to another PR depending on complexity.
- [x] Make sure that the script to generate the review files works correctly

@spectranaut @zcorpan I'd like your feedback on this approach. I'm generating a `scripts.js` file that defines a single object with a property for each 'script', and then I tell the harness which property to use instead of encoding the JS itself in the JSON data.

