### PR TITLE
[WIP] Link to the test page from review test plan

### DIFF
--- a/scripts/review-template.mustache
+++ b/scripts/review-template.mustache
@@ -75,8 +75,8 @@
       <ul>
         <li>Mode: {{mode}}</i>
         <li>Applies to: {{allReleventATs}}</li>
-        <li>Lasted edited: {{lastEdited}}
-        <li>File: <a href="https://github.com/w3c/aria-at/tree/master/tests{{{location}}}">{{{location}}}<a></li>
+        <li>Lasted edited: {{lastEdited}}</li>
+        <li>Test page: <a href="????">????</a></li>
         <li>Relevant Specifications:
           <ul>
             {{#helpLinks}}


### PR DESCRIPTION
@spectranaut I don't know how to fix this. Can you help?

I suppose it could link to the reference page (e.g. "Checkbox Example (Two State)"), rather than running the test with `at=jaws` etc. Is the reference page's path accessible from here?