### PR TITLE
Test Harness: add showResults query string and postMessage communication

### DIFF
--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -654,8 +654,6 @@ function submitResult(event) {
     status: overallStatus
   };
 
-  appendJSONResults(data);
-
   // send message to parent if test is loaded in iFrame
   if (window.parent && window.parent.postMessage) {
     window.parent.postMessage({
@@ -669,6 +667,8 @@ function submitResult(event) {
   if (showResults) {
     showResultsTable();
   }
+
+  appendJSONResults(data);
 }
 
 

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -374,6 +374,7 @@ Were there additional undesirable behaviors? <span class="required">(required)</
 
   // Submit button
   let el = document.createElement('button');
+  el.id = 'review-results';
   el.innerText = "Review Results";
   el.addEventListener('click', submitResult);
   recordEl.append(el);

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -136,7 +136,7 @@ function executeScriptInTestPage() {
         || testPageWindow.document.readyState !== 'complete'
     ) {
       window.setTimeout(() => {
-	executeScriptInTestPage();
+        executeScriptInTestPage();
       }, 100);
       return;
     }
@@ -424,7 +424,7 @@ function handleRadioClick(event) {
     }
     else {
       for (let option of document.querySelectorAll(`#cmd-${cmdId}-problem option`)) {
-	option.selected = false;
+        option.selected = false;
       }
       select.disabled = true;
       other.disabled = true;
@@ -437,7 +437,7 @@ function handleRadioClick(event) {
       let radios = document.querySelectorAll(`#cmd-${cmdId}-section .${resultType}`);
       let checked = resultType === 'pass' ? true : false;
       for (let radio of radios) {
-	radio.checked = checked;
+        radio.checked = checked;
       }
     }
   }
@@ -451,8 +451,8 @@ function handleRadioClick(event) {
       let numAssertions = document.getElementById(`cmd-${cmdId}`).rows.length;
       let markedPass = document.querySelectorAll(`#cmd-${cmdId}-section .pass:checked`);
       if (markedPass.length === numAssertions) {
-	let allradio = document.querySelector(`#cmd-${cmdId}-summary #allpass-${cmdId}`);
-	allradio.checked = true;
+        let allradio = document.querySelector(`#cmd-${cmdId}-summary #allpass-${cmdId}`);
+        allradio.checked = true;
       }
     }
     else {
@@ -495,7 +495,7 @@ function validateResults() {
 
     if ( summaryFieldset.querySelector('.allpass').checked || !allSelected ) {
       for (let a = 0; a < numAssertions; a++) {
-	document.querySelector(`#assertion-${c}-${a} .required`).classList.remove('highlight-required');
+        document.querySelector(`#assertion-${c}-${a} .required`).classList.remove('highlight-required');
       }
 
       undesirableFieldset.classList.remove('highlight-required');
@@ -505,11 +505,11 @@ function validateResults() {
     for (let a = 0; a < numAssertions; a++) {
       let selectedRadio = document.querySelector(`input[name="result-${c}-${a}"]:checked`);
       if (!selectedRadio) {
-	document.querySelector(`#assertion-${c}-${a} .required`).classList.add('highlight-required');
-	focusEl = focusEl || document.getElementById(`pass-${c}-${a}`);
+        document.querySelector(`#assertion-${c}-${a} .required`).classList.add('highlight-required');
+        focusEl = focusEl || document.getElementById(`pass-${c}-${a}`);
       }
       else {
-	document.querySelector(`#assertion-${c}-${a} .required`).classList.remove('highlight-required');
+        document.querySelector(`#assertion-${c}-${a} .required`).classList.remove('highlight-required');
       }
     }
 
@@ -519,7 +519,7 @@ function validateResults() {
     let otherSelected = document.querySelector(`#problem-${c}-select option.other:checked`);
     let otherText = document.querySelector(`#problem-${c}-other`).value;
     if (!problemRadio || (problemRadio.classList.contains('fail') && !problemSelected) || (otherSelected && !otherText)) {
-	undesirableFieldset.classList.add('highlight-required');
+        undesirableFieldset.classList.add('highlight-required');
     }
     if (!problemRadio || (problemRadio.classList.contains('fail') && !problemSelected)) {
       document.querySelector(`#cmd-${c}-problem .required`).classList.add('highlight-required');
@@ -532,13 +532,13 @@ function validateResults() {
 
     if (otherSelected) {
       if (!otherText) {
-	document.querySelector(`#cmd-${c}-problem .required-other`).classList.add('highlight-required');
-	undesirableFieldset.classList.add('highlight-required');
-	focusEl = focusEl || document.querySelector(`#cmd-${c}-problem select`);
+        document.querySelector(`#cmd-${c}-problem .required-other`).classList.add('highlight-required');
+        undesirableFieldset.classList.add('highlight-required');
+        focusEl = focusEl || document.querySelector(`#cmd-${c}-problem select`);
       }
       else {
-	document.querySelector(`#cmd-${c}-problem .required-other`).classList.remove('highlight-required');
-	undesirableFieldset.classList.remove('highlight-required');
+        document.querySelector(`#cmd-${c}-problem .required-other`).classList.remove('highlight-required');
+        undesirableFieldset.classList.remove('highlight-required');
       }
     }
   }
@@ -592,27 +592,27 @@ function submitResult(event) {
       const priority = assertionPriority[assertion];
 
       let assertionResult = {
-	assertion,
-	priority
+        assertion,
+        priority
       };
 
       if (pass) {
-	assertionResult.pass = result;
-	summary[priority].pass++;
+        assertionResult.pass = result;
+        summary[priority].pass++;
       }
       else {
-	assertionResult.fail = result;
-	summary[priority].fail++;
+        assertionResult.fail = result;
+        summary[priority].fail++;
 
-	// If any priority 1 assertion fails, the test fails for this command
-	if (priority === 1) {
-	  support = 'FAILING';
-    overallStatus = 'FAIL';
-	}
-	// If any only a priority >1 assertion fails, then this test meets the all required pass case
-	else if (support !== 'FAILING') {
-	  support = 'ALL REQUIRED';
-	}
+        // If any priority 1 assertion fails, the test fails for this command
+        if (priority === 1) {
+          support = 'FAILING';
+          overallStatus = 'FAIL';
+        }
+        // If any only a priority >1 assertion fails, then this test meets the all required pass case
+        else if (support !== 'FAILING') {
+          support = 'ALL REQUIRED';
+        }
       }
 
       assertions.push(assertionResult);
@@ -624,10 +624,10 @@ function submitResult(event) {
       overallStatus = 'FAIL';
       summary.unexpectedCount++;
       if (problemEl.classList.contains('other')) {
-	unexpected.push(document.querySelector(`#problem-${c}-other`).value);
+        unexpected.push(document.querySelector(`#problem-${c}-other`).value);
       }
       else {
-	unexpected.push(problemEl.value);
+        unexpected.push(problemEl.value);
       }
     }
 
@@ -688,16 +688,16 @@ function showResultsTable() {
       let passingAssertions = '';
       let failingAssertions = '';
       for (let assertion of command.assertions) {
-	if (assertion.pass) {
-	  passingAssertions += `<li>${assertion.assertion}</li>`;
-	}
-	if (assertion.fail) {
-	  failingAssertions += `<li>${assertion.assertion}</li>`;
-	}
+        if (assertion.pass) {
+          passingAssertions += `<li>${assertion.assertion}</li>`;
+        }
+        if (assertion.fail) {
+          failingAssertions += `<li>${assertion.assertion}</li>`;
+        }
       }
       let unexpectedBehaviors = '';
       for (let unexpected of command.unexpected_behaviors) {
-	unexpectedBehaviors += `<li>${unexpected}</li>`;
+        unexpectedBehaviors += `<li>${unexpected}</li>`;
       }
       passingAssertions = passingAssertions === '' ? '<li>No passing assertions.</li>' : passingAssertions;
       failingAssertions = failingAssertions === '' ? '<li>No failing assertions.</li>' : failingAssertions;


### PR DESCRIPTION
This PR adds two features necessary to support bocoup/aria-at-app#103 (Editing test results and saving partial form values):
- ability to prevent the test harness from replacing the test contents html with the results table html, with a new `showResults` query string parameter (default value is `true` to maintain current behavior)
- `postMessage` communication to send two messages to any parent window of the test: a `loaded` message and a `results` message (this allows the parent app which embeds the test as an iFrame to cleanly know when async test loading has finished and when results have been submitted)

Note: the `postMessage` communication is sent to parent windows of any origin in order to support any app that may embed aria-at tests. This is safe as long as the test results do not contain user or privacy sensitive data.