### PR TITLE
Cleanup harness text and labels

### DIFF
--- a/tests/checkbox/index.html
+++ b/tests/checkbox/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <head>
-  <title>Index of Assistive Technology Test Files</title>
+  <title>Index of Test Files for local Server</title>
   <style>
     table {
       display: table;
@@ -37,14 +37,6 @@
       display: table-cell;
     }
 
-    td.test {
-      text-align: center;
-    }
-
-    td.none {
-      color: #333;
-    }
-
     th {
       padding: 3px;
       font-weight: bold;
@@ -53,51 +45,45 @@
   </style>
 </head>
 <body>
- <main>
-  <h1>Index of Assistive Technology Test Files</h1>
+  <h1>Index of Test Files</h1>
   <p>This is useful for viewing the local files on a local web server and provides links that will work when the local version of the
-  test runner is being executed, using <code>npm run start</code> from the root directory: <code>C:\Users\mck\git\w3c\aria-at\main\</code>.</p>
+  test runner is being executed, using <code>npm run start</code> from the root director: <code>/Users/michaelfairchild/WebstormProjects/aria-at/</code>.</p>
   <table>
     <thead>
       <tr>
         <th>Task ID</th>
         <th>Testing Task</th>
-        <th>JAWS</th>
-<th>NVDA</th>
-<th>VoiceOver for macOS</th>
-
         <th>Setup Script Reference</th>
       </tr>
     </thead>
     <tbody>
-<tr><td>1</td><td scope="row">Navigate to an unchecked checkbox in reading mode</td><td class="test"><a href="test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 1">JAWS</a></td><td class="test"><a href="test-01-navigate-to-unchecked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 1">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>2</td><td scope="row">Navigate to an unchecked checkbox in interaction mode</td><td class="test"><a href="test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 2">JAWS</a></td><td class="test"><a href="test-02-navigate-to-unchecked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 2">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>3</td><td scope="row">Navigate to an unchecked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 3">VoiceOver for macOS</a></td><td></td></tr>
-<tr><td>4</td><td scope="row">Navigate to a checked checkbox in reading mode</td><td class="test"><a href="test-04-navigate-to-checked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 4">JAWS</a></td><td class="test"><a href="test-04-navigate-to-checked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 4">NVDA</a></td><td class="test none">not included</td><td>checkFirstCheckbox</td></tr>
-<tr><td>5</td><td scope="row">Navigate to a checked checkbox in interaction mode</td><td class="test"><a href="test-05-navigate-to-checked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 5">JAWS</a></td><td class="test"><a href="test-05-navigate-to-checked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 5">NVDA</a></td><td class="test none">not included</td><td>checkFirstCheckbox</td></tr>
-<tr><td>6</td><td scope="row">Navigate to a checked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 6">VoiceOver for macOS</a></td><td>checkFirstCheckbox</td></tr>
-<tr><td>7</td><td scope="row">Operate a checkbox in reading mode</td><td class="test"><a href="test-07-operate-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 7">JAWS</a></td><td class="test"><a href="test-07-operate-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 7">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>8</td><td scope="row">Operate a checkbox in interaction mode</td><td class="test"><a href="test-08-operate-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 8">JAWS</a></td><td class="test"><a href="test-08-operate-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 8">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>9</td><td scope="row">Operate a checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-09-operate-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 9">VoiceOver for macOS</a></td><td></td></tr>
-<tr><td>10</td><td scope="row">Read an unchecked checkbox in reading mode.</td><td class="test"><a href="test-10-read-unchecked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 10">JAWS</a></td><td class="test"><a href="test-10-read-unchecked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 10">NVDA</a></td><td class="test none">not included</td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>11</td><td scope="row">Read an unchecked checkbox in interaction mode.</td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 11">JAWS</a></td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 11">NVDA</a></td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 11">VoiceOver for macOS</a></td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>12</td><td scope="row">Read an unchecked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 12">VoiceOver for macOS</a></td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>13</td><td scope="row">Read a checked checkbox in reading mode.</td><td class="test"><a href="test-13-read-checked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 13">JAWS</a></td><td class="test"><a href="test-13-read-checked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 13">NVDA</a></td><td class="test none">not included</td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>14</td><td scope="row">Read a checked checkbox in interaction mode.</td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 14">JAWS</a></td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 14">NVDA</a></td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 14">VoiceOver for macOS</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>15</td><td scope="row">Read a checked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-15-read-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 15">VoiceOver for macOS</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>16</td><td scope="row">Read grouping information of a grouped checkbox in reading mode</td><td class="test"><a href="test-16-read-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 16">JAWS</a></td><td class="test"><a href="test-16-read-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 16">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>17</td><td scope="row">Read grouping information of a grouped checkbox in interaction mode</td><td class="test"><a href="test-17-read-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 17">JAWS</a></td><td class="test"><a href="test-17-read-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 17">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>18</td><td scope="row">Read grouping information of a grouped checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-18-read-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 18">VoiceOver for macOS</a></td><td></td></tr>
-<tr><td>19</td><td scope="row">Navigate sequentially through a checkbox group in reading mode</td><td class="test"><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 19">JAWS</a></td><td class="test"><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 19">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>20</td><td scope="row">Navigate sequentially through a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 20">VoiceOver for macOS</a></td><td></td></tr>
-<tr><td>21</td><td scope="row">Navigate into a checkbox group in reading mode</td><td class="test"><a href="test-21-navigate-into-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 21">JAWS</a></td><td class="test"><a href="test-21-navigate-into-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 21">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>22</td><td scope="row">Navigate into a checkbox group in interaction mode</td><td class="test"><a href="test-22-navigate-into-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 22">JAWS</a></td><td class="test"><a href="test-22-navigate-into-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 22">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>23</td><td scope="row">Navigate into a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 23">VoiceOver for macOS</a></td><td></td></tr>
-<tr><td>24</td><td scope="row">Navigate out of a checkbox group  in reading mode</td><td class="test"><a href="test-24-navigate-out-of-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 24">JAWS</a></td><td class="test"><a href="test-24-navigate-out-of-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 24">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>25</td><td scope="row">Navigate out of a checkbox group in interaction mode</td><td class="test"><a href="test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 25">JAWS</a></td><td class="test"><a href="test-25-navigate-out-of-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 25">NVDA</a></td><td class="test none">not included</td><td></td></tr>
-<tr><td>26</td><td scope="row">Navigate out of a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 26">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>1</td><td><a href="test-01-navigate-to-unchecked-checkbox-reading.html">Navigate to an unchecked checkbox in reading mode</a></td><td></td></tr>
+<tr><td>2</td><td><a href="test-02-navigate-to-unchecked-checkbox-interaction.html">Navigate to an unchecked checkbox in interaction mode</a></td><td></td></tr>
+<tr><td>3</td><td><a href="test-03-navigate-to-unchecked-checkbox-interaction.html">Navigate to an unchecked checkbox</a></td><td></td></tr>
+<tr><td>4</td><td><a href="test-04-navigate-to-checked-checkbox-reading.html">Navigate to a checked checkbox in reading mode</a></td><td>checkFirstCheckbox</td></tr>
+<tr><td>5</td><td><a href="test-05-navigate-to-checked-checkbox-interaction.html">Navigate to a checked checkbox in interaction mode</a></td><td>checkFirstCheckbox</td></tr>
+<tr><td>6</td><td><a href="test-06-navigate-to-checked-checkbox-interaction.html">Navigate to a checked checkbox</a></td><td>checkFirstCheckbox</td></tr>
+<tr><td>7</td><td><a href="test-07-operate-checkbox-reading.html">Operate a checkbox in reading mode</a></td><td></td></tr>
+<tr><td>8</td><td><a href="test-08-operate-checkbox-interaction.html">Operate a checkbox in interaction mode</a></td><td></td></tr>
+<tr><td>9</td><td><a href="test-09-operate-checkbox-interaction.html">Operate a checkbox</a></td><td></td></tr>
+<tr><td>10</td><td><a href="test-10-read-unchecked-checkbox-reading.html">Read an unchecked checkbox in reading mode.</a></td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>11</td><td><a href="test-11-read-unchecked-checkbox-interaction.html">Read an unchecked checkbox in interaction mode.</a></td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>12</td><td><a href="test-12-read-unchecked-checkbox-interaction.html">Read an unchecked checkbox</a></td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>13</td><td><a href="test-13-read-checked-checkbox-reading.html">Read a checked checkbox in reading mode.</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>14</td><td><a href="test-14-read-checked-checkbox-interaction.html">Read a checked checkbox in interaction mode.</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>15</td><td><a href="test-15-read-checked-checkbox-interaction.html">Read a checked checkbox</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>16</td><td><a href="test-16-read-checkbox-group-reading.html">Read grouping information of a grouped checkbox in reading mode</a></td><td></td></tr>
+<tr><td>17</td><td><a href="test-17-read-checkbox-group-interaction.html">Read grouping information of a grouped checkbox in interaction mode</a></td><td></td></tr>
+<tr><td>18</td><td><a href="test-18-read-checkbox-group-interaction.html">Read grouping information of a grouped checkbox</a></td><td></td></tr>
+<tr><td>19</td><td><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html">Navigate sequentially through a checkbox group in reading mode</a></td><td></td></tr>
+<tr><td>20</td><td><a href="test-20-navigate-sequentially-through-checkbox-group-interaction.html">Navigate sequentially through a checkbox group</a></td><td></td></tr>
+<tr><td>21</td><td><a href="test-21-navigate-into-checkbox-group-reading.html">Navigate into a checkbox group in reading mode</a></td><td></td></tr>
+<tr><td>22</td><td><a href="test-22-navigate-into-checkbox-group-interaction.html">Navigate into a checkbox group in interaction mode</a></td><td></td></tr>
+<tr><td>23</td><td><a href="test-23-navigate-into-checkbox-group-interaction.html">Navigate into a checkbox group</a></td><td></td></tr>
+<tr><td>24</td><td><a href="test-24-navigate-out-of-checkbox-group-reading.html">Navigate out of a checkbox group  in reading mode</a></td><td></td></tr>
+<tr><td>25</td><td><a href="test-25-navigate-out-of-checkbox-group-interaction.html">Navigate out of a checkbox group in interaction mode</a></td><td></td></tr>
+<tr><td>26</td><td><a href="test-26-navigate-out-of-checkbox-group-interaction.html">Navigate out of a checkbox group</a></td><td></td></tr>
 
     </tbody>
   </table>
-  </main>
 </body>

--- a/tests/checkbox/index.html
+++ b/tests/checkbox/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <head>
-  <title>Index of Test Files for local Server</title>
+  <title>Index of Assistive Technology Test Files</title>
   <style>
     table {
       display: table;
@@ -37,6 +37,14 @@
       display: table-cell;
     }
 
+    td.test {
+      text-align: center;
+    }
+
+    td.none {
+      color: #333;
+    }
+
     th {
       padding: 3px;
       font-weight: bold;
@@ -45,45 +53,51 @@
   </style>
 </head>
 <body>
-  <h1>Index of Test Files</h1>
+ <main>
+  <h1>Index of Assistive Technology Test Files</h1>
   <p>This is useful for viewing the local files on a local web server and provides links that will work when the local version of the
-  test runner is being executed, using <code>npm run start</code> from the root director: <code>/Users/michaelfairchild/WebstormProjects/aria-at/</code>.</p>
+  test runner is being executed, using <code>npm run start</code> from the root directory: <code>C:\Users\mck\git\w3c\aria-at\main\</code>.</p>
   <table>
     <thead>
       <tr>
         <th>Task ID</th>
         <th>Testing Task</th>
+        <th>JAWS</th>
+<th>NVDA</th>
+<th>VoiceOver for macOS</th>
+
         <th>Setup Script Reference</th>
       </tr>
     </thead>
     <tbody>
-<tr><td>1</td><td><a href="test-01-navigate-to-unchecked-checkbox-reading.html">Navigate to an unchecked checkbox in reading mode</a></td><td></td></tr>
-<tr><td>2</td><td><a href="test-02-navigate-to-unchecked-checkbox-interaction.html">Navigate to an unchecked checkbox in interaction mode</a></td><td></td></tr>
-<tr><td>3</td><td><a href="test-03-navigate-to-unchecked-checkbox-interaction.html">Navigate to an unchecked checkbox</a></td><td></td></tr>
-<tr><td>4</td><td><a href="test-04-navigate-to-checked-checkbox-reading.html">Navigate to a checked checkbox in reading mode</a></td><td>checkFirstCheckbox</td></tr>
-<tr><td>5</td><td><a href="test-05-navigate-to-checked-checkbox-interaction.html">Navigate to a checked checkbox in interaction mode</a></td><td>checkFirstCheckbox</td></tr>
-<tr><td>6</td><td><a href="test-06-navigate-to-checked-checkbox-interaction.html">Navigate to a checked checkbox</a></td><td>checkFirstCheckbox</td></tr>
-<tr><td>7</td><td><a href="test-07-operate-checkbox-reading.html">Operate a checkbox in reading mode</a></td><td></td></tr>
-<tr><td>8</td><td><a href="test-08-operate-checkbox-interaction.html">Operate a checkbox in interaction mode</a></td><td></td></tr>
-<tr><td>9</td><td><a href="test-09-operate-checkbox-interaction.html">Operate a checkbox</a></td><td></td></tr>
-<tr><td>10</td><td><a href="test-10-read-unchecked-checkbox-reading.html">Read an unchecked checkbox in reading mode.</a></td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>11</td><td><a href="test-11-read-unchecked-checkbox-interaction.html">Read an unchecked checkbox in interaction mode.</a></td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>12</td><td><a href="test-12-read-unchecked-checkbox-interaction.html">Read an unchecked checkbox</a></td><td>moveFocusToFirstCheckbox</td></tr>
-<tr><td>13</td><td><a href="test-13-read-checked-checkbox-reading.html">Read a checked checkbox in reading mode.</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>14</td><td><a href="test-14-read-checked-checkbox-interaction.html">Read a checked checkbox in interaction mode.</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>15</td><td><a href="test-15-read-checked-checkbox-interaction.html">Read a checked checkbox</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
-<tr><td>16</td><td><a href="test-16-read-checkbox-group-reading.html">Read grouping information of a grouped checkbox in reading mode</a></td><td></td></tr>
-<tr><td>17</td><td><a href="test-17-read-checkbox-group-interaction.html">Read grouping information of a grouped checkbox in interaction mode</a></td><td></td></tr>
-<tr><td>18</td><td><a href="test-18-read-checkbox-group-interaction.html">Read grouping information of a grouped checkbox</a></td><td></td></tr>
-<tr><td>19</td><td><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html">Navigate sequentially through a checkbox group in reading mode</a></td><td></td></tr>
-<tr><td>20</td><td><a href="test-20-navigate-sequentially-through-checkbox-group-interaction.html">Navigate sequentially through a checkbox group</a></td><td></td></tr>
-<tr><td>21</td><td><a href="test-21-navigate-into-checkbox-group-reading.html">Navigate into a checkbox group in reading mode</a></td><td></td></tr>
-<tr><td>22</td><td><a href="test-22-navigate-into-checkbox-group-interaction.html">Navigate into a checkbox group in interaction mode</a></td><td></td></tr>
-<tr><td>23</td><td><a href="test-23-navigate-into-checkbox-group-interaction.html">Navigate into a checkbox group</a></td><td></td></tr>
-<tr><td>24</td><td><a href="test-24-navigate-out-of-checkbox-group-reading.html">Navigate out of a checkbox group  in reading mode</a></td><td></td></tr>
-<tr><td>25</td><td><a href="test-25-navigate-out-of-checkbox-group-interaction.html">Navigate out of a checkbox group in interaction mode</a></td><td></td></tr>
-<tr><td>26</td><td><a href="test-26-navigate-out-of-checkbox-group-interaction.html">Navigate out of a checkbox group</a></td><td></td></tr>
+<tr><td>1</td><td scope="row">Navigate to an unchecked checkbox in reading mode</td><td class="test"><a href="test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 1">JAWS</a></td><td class="test"><a href="test-01-navigate-to-unchecked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 1">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>2</td><td scope="row">Navigate to an unchecked checkbox in interaction mode</td><td class="test"><a href="test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 2">JAWS</a></td><td class="test"><a href="test-02-navigate-to-unchecked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 2">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>3</td><td scope="row">Navigate to an unchecked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 3">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>4</td><td scope="row">Navigate to a checked checkbox in reading mode</td><td class="test"><a href="test-04-navigate-to-checked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 4">JAWS</a></td><td class="test"><a href="test-04-navigate-to-checked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 4">NVDA</a></td><td class="test none">not included</td><td>checkFirstCheckbox</td></tr>
+<tr><td>5</td><td scope="row">Navigate to a checked checkbox in interaction mode</td><td class="test"><a href="test-05-navigate-to-checked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 5">JAWS</a></td><td class="test"><a href="test-05-navigate-to-checked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 5">NVDA</a></td><td class="test none">not included</td><td>checkFirstCheckbox</td></tr>
+<tr><td>6</td><td scope="row">Navigate to a checked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 6">VoiceOver for macOS</a></td><td>checkFirstCheckbox</td></tr>
+<tr><td>7</td><td scope="row">Operate a checkbox in reading mode</td><td class="test"><a href="test-07-operate-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 7">JAWS</a></td><td class="test"><a href="test-07-operate-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 7">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>8</td><td scope="row">Operate a checkbox in interaction mode</td><td class="test"><a href="test-08-operate-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 8">JAWS</a></td><td class="test"><a href="test-08-operate-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 8">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>9</td><td scope="row">Operate a checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-09-operate-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 9">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>10</td><td scope="row">Read an unchecked checkbox in reading mode.</td><td class="test"><a href="test-10-read-unchecked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 10">JAWS</a></td><td class="test"><a href="test-10-read-unchecked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 10">NVDA</a></td><td class="test none">not included</td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>11</td><td scope="row">Read an unchecked checkbox in interaction mode.</td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 11">JAWS</a></td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 11">NVDA</a></td><td class="test"><a href="test-11-read-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 11">VoiceOver for macOS</a></td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>12</td><td scope="row">Read an unchecked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 12">VoiceOver for macOS</a></td><td>moveFocusToFirstCheckbox</td></tr>
+<tr><td>13</td><td scope="row">Read a checked checkbox in reading mode.</td><td class="test"><a href="test-13-read-checked-checkbox-reading.html?at=jaws" aria-label="JAWS test for task 13">JAWS</a></td><td class="test"><a href="test-13-read-checked-checkbox-reading.html?at=nvda" aria-label="NVDA test for task 13">NVDA</a></td><td class="test none">not included</td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>14</td><td scope="row">Read a checked checkbox in interaction mode.</td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=jaws" aria-label="JAWS test for task 14">JAWS</a></td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=nvda" aria-label="NVDA test for task 14">NVDA</a></td><td class="test"><a href="test-14-read-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 14">VoiceOver for macOS</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>15</td><td scope="row">Read a checked checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-15-read-checked-checkbox-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 15">VoiceOver for macOS</a></td><td>moveFocusAndCheckFirstCheckbox</td></tr>
+<tr><td>16</td><td scope="row">Read grouping information of a grouped checkbox in reading mode</td><td class="test"><a href="test-16-read-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 16">JAWS</a></td><td class="test"><a href="test-16-read-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 16">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>17</td><td scope="row">Read grouping information of a grouped checkbox in interaction mode</td><td class="test"><a href="test-17-read-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 17">JAWS</a></td><td class="test"><a href="test-17-read-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 17">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>18</td><td scope="row">Read grouping information of a grouped checkbox</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-18-read-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 18">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>19</td><td scope="row">Navigate sequentially through a checkbox group in reading mode</td><td class="test"><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 19">JAWS</a></td><td class="test"><a href="test-19-navigate-sequentially-through-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 19">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>20</td><td scope="row">Navigate sequentially through a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 20">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>21</td><td scope="row">Navigate into a checkbox group in reading mode</td><td class="test"><a href="test-21-navigate-into-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 21">JAWS</a></td><td class="test"><a href="test-21-navigate-into-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 21">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>22</td><td scope="row">Navigate into a checkbox group in interaction mode</td><td class="test"><a href="test-22-navigate-into-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 22">JAWS</a></td><td class="test"><a href="test-22-navigate-into-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 22">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>23</td><td scope="row">Navigate into a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 23">VoiceOver for macOS</a></td><td></td></tr>
+<tr><td>24</td><td scope="row">Navigate out of a checkbox group  in reading mode</td><td class="test"><a href="test-24-navigate-out-of-checkbox-group-reading.html?at=jaws" aria-label="JAWS test for task 24">JAWS</a></td><td class="test"><a href="test-24-navigate-out-of-checkbox-group-reading.html?at=nvda" aria-label="NVDA test for task 24">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>25</td><td scope="row">Navigate out of a checkbox group in interaction mode</td><td class="test"><a href="test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws" aria-label="JAWS test for task 25">JAWS</a></td><td class="test"><a href="test-25-navigate-out-of-checkbox-group-interaction.html?at=nvda" aria-label="NVDA test for task 25">NVDA</a></td><td class="test none">not included</td><td></td></tr>
+<tr><td>26</td><td scope="row">Navigate out of a checkbox group</td><td class="test none">not included</td><td class="test none">not included</td><td class="test"><a href="test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos" aria-label="VoiceOver for macOS test for task 26">VoiceOver for macOS</a></td><td></td></tr>
 
     </tbody>
   </table>
+  </main>
 </body>

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -92,7 +92,7 @@ export function initialize(newSupport, newCommandsData) {
         at = commapi.isKnownAT(requestedAT);
       }
       else {
-        errors.push(`Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assitive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`);
+        errors.push(`Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`);
       }
     }
     if (key === 'showResults') {

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -206,7 +206,7 @@ function displayInstructionsForBehaviorTest() {
   const commands = behavior.commands;
   const assertions = behavior.output_assertions.map((a) => a[1]);
   const additionalBehaviorAssertions = behavior.additional_assertions;
-  const setupScriptDescription = behavior.setup_script_description;
+  const setupScriptDescription = behavior.setup_script_description ? ` and runs a script that will ${behavior.setup_script_description}` : behavior.setup_script_description;
   // As a hack, special case mode instructions for VoiceOver for macOS until we support modeless tests.
   let modePhrase = at.name === "VoiceOver for macOS" ? "Describe " : `With ${at.name} in ${mode} mode, describe `;
 
@@ -216,10 +216,7 @@ function displayInstructionsForBehaviorTest() {
 <p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}"</p>
 <h2>Test instructions</h2>
 <ol>
-  <li>Click the "Open test page" button below to open the example widget in a popup window
-    <ul id='setup_script_description'>
-    </ul>
-  </li>
+  <li>Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}</li>
   <li><em>${modeInstructions}</em></li>
   ${getSetupInstructions()}
   <li><em>${lastInstruction}</em> using the following commands:
@@ -232,12 +229,6 @@ function displayInstructionsForBehaviorTest() {
 <ul id='assertions'>
 </ul>
 `;
-
-  if (setupScriptDescription) {
-    let setupDescEl = document.createElement('li');
-    setupDescEl.innerHTML = `Setup test page script description: ${setupScriptDescription}`;
-    document.getElementById('setup_script_description').append(setupDescEl);
-  }
 
   for (let command of commands) {
     let commandEl = document.createElement('li');

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -216,7 +216,7 @@ function displayInstructionsForBehaviorTest() {
 <h1 id="behavior-header" tabindex="0">Testing task: ${document.title}</h1>
 <p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}"</p>
 <h2>Test instructions</h2>
-<ol>
+<ol aria-label="Instructions">
   <li>Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}</li>
   <li id="mode-instructions-li"><em>${modeInstructions}</em></li>
   ${getSetupInstructions()}
@@ -226,8 +226,8 @@ function displayInstructionsForBehaviorTest() {
   </li>
 </ol>
 <h3>Success Criteria</h3>
-<p>For this test to pass, the following assertions must be met for every possible command:</p>
-<ul id='assertions'>
+<p>To pass this test, ${at.name} needs to meet all the following assertions when each  specified command is executed:</p>
+<ul id='assertions' aria-label="Assertions">
 </ul>
 `;
 

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -206,9 +206,10 @@ function displayInstructionsForBehaviorTest() {
   const commands = behavior.commands;
   const assertions = behavior.output_assertions.map((a) => a[1]);
   const additionalBehaviorAssertions = behavior.additional_assertions;
-  const setupScriptDescription = behavior.setup_script_description ? ` and runs a script that will ${behavior.setup_script_description}` : behavior.setup_script_description;
+  const setupScriptDescription = behavior.setup_script_description ? ` and runs a script that will ${behavior.setup_script_description}.` : behavior.setup_script_description;
   // As a hack, special case mode instructions for VoiceOver for macOS until we support modeless tests.
-  let modePhrase = at.name === "VoiceOver for macOS" ? "Describe " : `With ${at.name} in ${mode} mode, describe `;
+  // ToDo: remove this when resolving issue #194
+  const modePhrase = at.name === "VoiceOver for macOS" ? "Describe " : `With ${at.name} in ${mode} mode, describe `;
 
   let instructionsEl = document.getElementById('instructions');
   instructionsEl.innerHTML = `
@@ -217,7 +218,7 @@ function displayInstructionsForBehaviorTest() {
 <h2>Test instructions</h2>
 <ol>
   <li>Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}</li>
-  <li><em>${modeInstructions}</em></li>
+  <li id="mode-instructions-li"><em>${modeInstructions}</em></li>
   ${getSetupInstructions()}
   <li><em>${lastInstruction}</em> using the following commands:
     <ul id='at_controls' aria-label='AT controls'>
@@ -229,6 +230,13 @@ function displayInstructionsForBehaviorTest() {
 <ul id='assertions'>
 </ul>
 `;
+
+  // Hack to remove mode instructions for VoiceOver for macOS to get us by until we support modeless screen readers.
+  // ToDo: remove this when resolving issue #194
+  if (at.name === "VoiceOver for macOS") {
+    let modeInstructionsEl= document.getElementById('mode-instructions-li');
+    modeInstructionsEl.parentNode.removeChild(modeInstructionsEl);
+  }
 
   for (let command of commands) {
     let commandEl = document.createElement('li');

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -276,11 +276,11 @@ function displayInstructionsForBehaviorTest() {
     <input type="text" id="speechoutput-${c}">
     <div>
       <input type="radio" id="allpass-${c}" class="allpass" name="allresults-${c}">
-      <label for="allpass-${c}">All assertions have been meet after ${commands[c]} and there was no additional unexpected or undesirable behaviors.</label>
+      <label for="allpass-${c}">All assertions were met after ${commands[c]} and there were no additional unexpected or undesirable behaviors.</label>
     </div>
     <div>
       <input type="radio" id="somefailure-${c}" class="somefailure" name="allresults-${c}">
-      <label for="somefailure-${c}">Some assertions have not been met after ${commands[c]} or there as an additional unexpected or undesirable behavior.</label>
+      <label for="somefailure-${c}">Some assertions were not met after ${commands[c]} or there was additional unexpected or undesirable behavior.</label>
     </div>
   </fieldset>
 </p>

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -340,11 +340,11 @@ function displayInstructionsForBehaviorTest() {
 Were there additional undesirable behaviors? <span class="required">(required)</span>
 <div>
   <input type="radio" id="problem-${c}-false" class="pass" name="problem-${c}">
-  <label for="problem-${c}-false">No, there are no additional undesirable behaviors.</label>
+  <label for="problem-${c}-false">No, there were no additional undesirable behaviors.</label>
 </div>
 <div>
   <input type="radio" id="problem-${c}-true" class="fail" name="problem-${c}">
-  <label for="problem-${c}-true">Yes, there are additional undesirable behaviors</label>
+  <label for="problem-${c}-true">Yes, there were additional undesirable behaviors</label>
 </div>
 <br>
 <div>

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -207,11 +207,13 @@ function displayInstructionsForBehaviorTest() {
   const assertions = behavior.output_assertions.map((a) => a[1]);
   const additionalBehaviorAssertions = behavior.additional_assertions;
   const setupScriptDescription = behavior.setup_script_description;
+  // As a hack, special case mode instructions for VoiceOver for macOS until we support modeless tests.
+  let modePhrase = at.name === "VoiceOver for macOS" ? "Describe " : `With ${at.name} in ${mode} mode, describe `;
 
   let instructionsEl = document.getElementById('instructions');
   instructionsEl.innerHTML = `
 <h1 id="behavior-header" tabindex="0">Testing task: ${document.title}</h1>
-<p>How does ${at.name} respond after task "${lastInstruction}" is performed in ${mode} mode?</p>
+<p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}."</p>
 <h2>Test instructions</h2>
 <ol>
   <li>Click the "Open test page" button below to open the example widget in a popup window

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -213,7 +213,7 @@ function displayInstructionsForBehaviorTest() {
   let instructionsEl = document.getElementById('instructions');
   instructionsEl.innerHTML = `
 <h1 id="behavior-header" tabindex="0">Testing task: ${document.title}</h1>
-<p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}."</p>
+<p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}"</p>
 <h2>Test instructions</h2>
 <ol>
   <li>Click the "Open test page" button below to open the example widget in a popup window

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -272,7 +272,7 @@ function displayInstructionsForBehaviorTest() {
     recordResults += `
 <p>
   <fieldset id="cmd-${c}-summary">
-    <label for="speechoutput-${c}">Relevant speech output after command <span class="required">(required)</span>:</label>
+    <label for="speechoutput-${c}">${at.name} output after ${commands[c]} <span class="required">(required)</span>:</label>
     <input type="text" id="speechoutput-${c}">
     <div>
       <input type="radio" id="allpass-${c}" class="allpass" name="allresults-${c}">

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -220,7 +220,7 @@ function displayInstructionsForBehaviorTest() {
   <li>Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}</li>
   <li id="mode-instructions-li"><em>${modeInstructions}</em></li>
   ${getSetupInstructions()}
-  <li><em>${lastInstruction}</em> using the following commands:
+  <li>Using the following commands, ${lastInstruction}
     <ul id='at_controls' aria-label='AT controls'>
     </ul>
   </li>

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -268,7 +268,7 @@ function displayInstructionsForBehaviorTest() {
   let recordResults = `<h2>Record Results</h2><p>${document.title}</p>`;
 
   for (let c = 0; c < commands.length; c++) {
-    recordResults += `<section id="cmd-${c}-section"><h3 id="header-cmd-${c}">After: '${commands[c]}'</h3>`;
+    recordResults += `<section id="cmd-${c}-section"><h3 id="header-cmd-${c}">After '${commands[c]}'</h3>`;
     recordResults += `
 <p>
   <fieldset id="cmd-${c}-summary">

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -221,7 +221,7 @@ function displayInstructionsForBehaviorTest() {
   <li id="mode-instructions-li"><em>${modeInstructions}</em></li>
   ${getSetupInstructions()}
   <li>Using the following commands, ${lastInstruction}
-    <ul id='at_controls' aria-label='AT controls'>
+    <ul id='at_controls' aria-label='Commands'>
     </ul>
   </li>
 </ol>


### PR DESCRIPTION
This PR makes some important clarifications of language on test pages created by the harness. It also hacks elimination of mentions of mode for VoiceOver on macOS, which should get us by until we tackle issue #194.

Here's a summary of important changes:
1. Changes the intro paragraph to simplify wording and eliminate mention of mode for VoiceOver for Mac. Mode is now mentioned first in a prepositional phrase when applicable:
   * Old format: How does VoiceOver for macOS respond after task "Navigate to the first checkbox. Note: it should be in the unchecked state." is performed in interaction mode?
   * New format: Describe how VoiceOver for macOS behaves when performing task "Navigate to the first checkbox. Note: it should be in the unchecked state."
   * New format: With JAWS in interaction mode, describe how JAWS behaves when performing task "Navigate to the first checkbox. Note: it should be in the unchecked state."
2. Changes the first instruction to remove use of word "click" and integrate description of the setup script:
   * Old format: 'Click the "Open test page" button below to open the example widget in a popup window' followed by a single item nested list with 'Setup test page script description: Mark the first checkbox as checked'
   * New format without setup script: Activate the "Open test page" button below, which opens the example to test in a new window 
   * New format with setup script: Activate the "Open test page" button below, which opens the example to test in a new window and runs a script that will Mark the first checkbox as checked
   * Note: We should not capitalize the first word of the setup script description if we go with this format.
3. Removes the mode instructions step if the screen reader is VoiceOver for macOS.
4. Revise wording of last instruction step so it is easier to understand if the step includes some kind of note:
   * Old format: Navigate to the first checkbox. Note: it should be in the unchecked state.  using the following commands: 
   * New format: Use the following commands to Navigate to the first checkbox. Note: it should be in the unchecked state.
5. Change aria-label on commands list from 'AT Controls' to 'Commands'.
6. Clarify wording of paragraph that introduces the assertions:
   * Old wording: For this test to pass, the following assertions must be met for every possible command
   * New wording: To pass this test, JAWS needs to meet all the following assertions when each specified command is executed
7. Revise the output textbox label to be more concise and so each input label is unique:
   * Old label: Relevant speech output after command 
   * New label: JAWS output after F / Shift+F 
8. Fix grammar in all pass radio label:
   * Old label: All assertions have been meet after Tab / Shift+Tab and there was no additional unexpected or undesirable behaviors.
   * New label:  All assertions were met after Tab / Shift+Tab and there were no additional unexpected or undesirable behaviors.
9. Fix grammar in the some failures radio label:
   * Old label:  Some assertions have not been met after Tab / Shift+Tab or there as an additional unexpected or undesirable behavior.
   *  Some assertions were not met after Tab / Shift+Tab or there was additional unexpected or undesirable behavior.
10. Change radio labels for additional behaviors to past tense from present tense.
   * Old label: Yes, there are additional undesirable behaviors
   * New label: Yes, there were additional undesirable behaviors