### PR TITLE
Bump the limit of test assertions to 30

### DIFF
--- a/scripts/create-tests.js
+++ b/scripts/create-tests.js
@@ -364,7 +364,10 @@ function createTestFile (test, refs, commands) {
   let references  = getReferences(refs.example, test.refs);
   addSetupScript(test.setupScript, setupFileName);
 
-  for (let i=1; i<6; i++) {
+  for (let i=1; i<31; i++) {
+    if (!test["assertion"+i]) {
+      continue;
+    }
     addAssertion(test["assertion"+i]);
   }
 


### PR DESCRIPTION
fixes #193

Notes

* Bumps limit from 5 to 30
* Looks for columns in the csv named `assertion{x}`
* If an assertion is not found in the csv, it is not processed (for example, `assertion15` was not found)
* The assertions are already the last columns in the csv, so this shouldn't be an issue.