### PR TITLE
Switch from pr-previwer to github action preview link

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -6,11 +6,11 @@ jobs:
   update_pr:
     runs-on: ubuntu-latest
     steps:
-    - uses: tzkhan/pr-update-action@v1.1.1
+    - uses: rmeritz/pr-update-action@930be7f0caa6f2e6339756fe2ef5b8b8963454cf
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
-        branch-regex: '.*'                                           # required - regex to match text from the head branch name
-        title-template: '%branch%'                                  # required - text template to update title with
+        branch-regex: '.*'                                          # required - regex to match text from the head branch name
+        title-template: ''                                          # required - text template to update title with
         replace-title: false                                        # optional - whether to prefix or replace title with title-template
         uppercase-title: false
         body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,4 +1,4 @@
-name: "Update Pull Request"
+name: "Update Pull Request with Preview Link"
 
 on: pull_request
 

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -11,5 +11,5 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         head-branch-regex: '.*'
         title-template: ''
-        body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%branch%/index.html)'
+        body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%headbranch%/index.html)'
         body-update-action: prefix

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -12,6 +12,8 @@ jobs:
         branch-regex: '.*'                                           # required - regex to match text from the head branch name
         title-template: '%branch%'                                  # required - text template to update title with
         replace-title: false                                        # optional - whether to prefix or replace title with title-template
-        body-template: '[Preview](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body
+        uppercase-title: false
+        body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body
         replace-body: false                                         # optional - whether to prefix or replace body with body-template
         body-prefix-newline-count: 2                                # optional - number of newlines to insert after body prefix
+        uppercase-body: false

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,0 +1,17 @@
+name: "Update Pull Request"
+
+on: pull_request
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tzkhan/pr-update-action@v1.1.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
+        branch-regex: '*'                                           # required - regex to match text from the head branch name
+        title-template: ''                                          # required - text template to update title with
+        replace-title: false                                        # optional - whether to prefix or replace title with title-template
+        body-template: '[Preview](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body
+        replace-body: false                                         # optional - whether to prefix or replace body with body-template
+        body-prefix-newline-count: 2                                # optional - number of newlines to insert after body prefix

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
         branch-regex: '*'                                           # required - regex to match text from the head branch name
-        title-template: ''                                          # required - text template to update title with
+        title-template: '%branch%'                                  # required - text template to update title with
         replace-title: false                                        # optional - whether to prefix or replace title with title-template
         body-template: '[Preview](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body
         replace-body: false                                         # optional - whether to prefix or replace body with body-template

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: tzkhan/pr-update-action@v1.1.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
-        branch-regex: '*'                                           # required - regex to match text from the head branch name
+        branch-regex: '.*'                                           # required - regex to match text from the head branch name
         title-template: '%branch%'                                  # required - text template to update title with
         replace-title: false                                        # optional - whether to prefix or replace title with title-template
         body-template: '[Preview](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -6,14 +6,10 @@ jobs:
   update_pr:
     runs-on: ubuntu-latest
     steps:
-    - uses: rmeritz/pr-update-action@930be7f0caa6f2e6339756fe2ef5b8b8963454cf
+    - uses: tzkhan/pr-update-action@v2
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
-        branch-regex: '.*'                                          # required - regex to match text from the head branch name
-        title-template: ''                                          # required - text template to update title with
-        replace-title: false                                        # optional - whether to prefix or replace title with title-template
-        uppercase-title: false
-        body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%branch%/index.html)' # required - text template to prefix body
-        replace-body: false                                         # optional - whether to prefix or replace body with body-template
-        body-prefix-newline-count: 2                                # optional - number of newlines to insert after body prefix
-        uppercase-body: false
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: '.*'
+        title-template: ''
+        body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%branch%/index.html)'
+        body-update-action: prefix

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -13,3 +13,4 @@ jobs:
         title-template: ''
         body-template: '[Preview Tests](https://raw.githack.com/w3c/aria-at/%headbranch%/index.html)'
         body-update-action: prefix
+        body-uppercase-head-match: false

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,7 @@
 {
   "src_file": "index.html",
-  "type": "html"
+  "type": "html",
+  "params": {
+    "branch": "{{ branch }}"
+  }
 }

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,7 +1,0 @@
-{
-  "src_file": "index.html",
-  "type": "html",
-  "params": {
-    "branch": "{{ branch }}"
-  }
-}

--- a/index.html
+++ b/index.html
@@ -34,25 +34,32 @@
         <th>Pattern</th>
         <th>Index Page</th>
         <th>Review Page</th>
-        <th>Number of Tests</th>
+        <th># of Tests</th>
+        <th>Commit of Last Change</th>
       </tr>
           <tr>
             <td>checkbox</td>
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
+            <td><a href="https://github.com/w3c/aria-at/commit/4d24c9b" target="_blank">4d24c9b checkbox: don&#39;t present interaction mode tests to macOS VoiceOver users (#283)
+</a></td>
           </tr>
           <tr>
             <td>combobox-autocomplete-both</td>
             <td><a href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
+            <td><a href="https://github.com/w3c/aria-at/commit/2a3c46f" target="_blank">2a3c46f Combobox Tests: Mark not ready for testing and partially update to recent format (pull #203)
+</a></td>
           </tr>
           <tr>
             <td>menubar-editor</td>
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
+            <td><a href="https://github.com/w3c/aria-at/commit/826d2c2" target="_blank">826d2c2 Fix issue where menubar test 15 for jaws was not rendering (#267)
+</a></td>
           </tr>
     </table>
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,12 @@
 
     </style>
     <script>
+      document.addEventListener("DOMContentLoaded", function(){
+        const branch = new URL(window.location.href.toLowerCase()).searchParams.get("branch");
+        Array.from(document.getElementsByClassName('githack-link')).forEach(function (item) {
+          item.href = item.href.replace(/BRANCH/, branch);
+        });
+      });
     </script>
   </head>
   <body>
@@ -39,24 +45,24 @@
       </tr>
           <tr>
             <td>checkbox</td>
-            <td><a href="./tests/checkbox/index.html">Index</a></td>
-            <td><a href="./review/checkbox.html">Review</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/checkbox/index.html">Index</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/checkbox.html">Review</a></td>
             <td>26</td>
             <td><a href="https://github.com/w3c/aria-at/commit/4d24c9b" target="_blank">4d24c9b checkbox: don&#39;t present interaction mode tests to macOS VoiceOver users (#283)
 </a></td>
           </tr>
           <tr>
             <td>combobox-autocomplete-both</td>
-            <td><a href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
-            <td><a href="./review/combobox-autocomplete-both.html">Review</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/combobox-autocomplete-both/index.html">Index</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
             <td><a href="https://github.com/w3c/aria-at/commit/2a3c46f" target="_blank">2a3c46f Combobox Tests: Mark not ready for testing and partially update to recent format (pull #203)
 </a></td>
           </tr>
           <tr>
             <td>menubar-editor</td>
-            <td><a href="./tests/menubar-editor/index.html">Index</a></td>
-            <td><a href="./review/menubar-editor.html">Review</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/menubar-editor/index.html">Index</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/menubar-editor.html">Review</a></td>
             <td>40</td>
             <td><a href="https://github.com/w3c/aria-at/commit/826d2c2" target="_blank">826d2c2 Fix issue where menubar test 15 for jaws was not rendering (#267)
 </a></td>

--- a/index.html
+++ b/index.html
@@ -22,14 +22,6 @@
       }
 
     </style>
-    <script>
-      document.addEventListener("DOMContentLoaded", function(){
-        const branch = new URL(window.location.href.toLowerCase()).searchParams.get("branch");
-        Array.from(document.getElementsByClassName('githack-link')).forEach(function (item) {
-          item.href = item.href.replace(/BRANCH/, branch);
-        });
-      });
-    </script>
   </head>
   <body>
 
@@ -45,24 +37,24 @@
       </tr>
           <tr>
             <td>checkbox</td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/checkbox/index.html">Index</a></td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/checkbox.html">Review</a></td>
+            <td><a class="githack-link" href="./tests/checkbox/index.html">Index</a></td>
+            <td><a class="githack-link" href="./review/checkbox.html">Review</a></td>
             <td>26</td>
             <td><a href="https://github.com/w3c/aria-at/commit/4d24c9b" target="_blank">4d24c9b checkbox: don&#39;t present interaction mode tests to macOS VoiceOver users (#283)
 </a></td>
           </tr>
           <tr>
             <td>combobox-autocomplete-both</td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/combobox-autocomplete-both/index.html">Index</a></td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/combobox-autocomplete-both.html">Review</a></td>
+            <td><a class="githack-link" href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
+            <td><a class="githack-link" href="./review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
             <td><a href="https://github.com/w3c/aria-at/commit/2a3c46f" target="_blank">2a3c46f Combobox Tests: Mark not ready for testing and partially update to recent format (pull #203)
 </a></td>
           </tr>
           <tr>
             <td>menubar-editor</td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/menubar-editor/index.html">Index</a></td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/menubar-editor.html">Review</a></td>
+            <td><a class="githack-link" href="./tests/menubar-editor/index.html">Index</a></td>
+            <td><a class="githack-link" href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
             <td><a href="https://github.com/w3c/aria-at/commit/826d2c2" target="_blank">826d2c2 Fix issue where menubar test 15 for jaws was not rendering (#267)
 </a></td>

--- a/index.html
+++ b/index.html
@@ -37,24 +37,24 @@
       </tr>
           <tr>
             <td>checkbox</td>
-            <td><a class="githack-link" href="./tests/checkbox/index.html">Index</a></td>
-            <td><a class="githack-link" href="./review/checkbox.html">Review</a></td>
+            <td><a href="./tests/checkbox/index.html">Index</a></td>
+            <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
             <td><a href="https://github.com/w3c/aria-at/commit/4d24c9b" target="_blank">4d24c9b checkbox: don&#39;t present interaction mode tests to macOS VoiceOver users (#283)
 </a></td>
           </tr>
           <tr>
             <td>combobox-autocomplete-both</td>
-            <td><a class="githack-link" href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
-            <td><a class="githack-link" href="./review/combobox-autocomplete-both.html">Review</a></td>
+            <td><a href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
+            <td><a href="./review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
             <td><a href="https://github.com/w3c/aria-at/commit/2a3c46f" target="_blank">2a3c46f Combobox Tests: Mark not ready for testing and partially update to recent format (pull #203)
 </a></td>
           </tr>
           <tr>
             <td>menubar-editor</td>
-            <td><a class="githack-link" href="./tests/menubar-editor/index.html">Index</a></td>
-            <td><a class="githack-link" href="./review/menubar-editor.html">Review</a></td>
+            <td><a href="./tests/menubar-editor/index.html">Index</a></td>
+            <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
             <td><a href="https://github.com/w3c/aria-at/commit/826d2c2" target="_blank">826d2c2 Fix issue where menubar test 15 for jaws was not rendering (#267)
 </a></td>

--- a/scripts/review-index-template.mustache
+++ b/scripts/review-index-template.mustache
@@ -23,6 +23,12 @@
 
     </style>
     <script>
+      document.addEventListener("DOMContentLoaded", function(){
+        const branch = new URL(window.location.href.toLowerCase()).searchParams.get("branch");
+        Array.from(document.getElementsByClassName('githack-link')).forEach(function (item) {
+          item.href = item.href.replace(/BRANCH/, branch);
+        });
+      });
     </script>
   </head>
   <body>
@@ -40,8 +46,8 @@
       {{#patterns}}
           <tr>
             <td>{{name}}</td>
-            <td><a href="tests/{{name}}/index.html">Index</a></td>
-            <td><a href="review/{{name}}.html">Review</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/{{name}}/index.html">Index</a></td>
+            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/{{name}}.html">Review</a></td>
             <td>{{numberOfTests}}</td>
             <td><a href="https://github.com/w3c/aria-at/commit/{{commit}}" target="_blank">{{commitDescription}}</a></td>
           </tr>

--- a/scripts/review-index-template.mustache
+++ b/scripts/review-index-template.mustache
@@ -38,8 +38,8 @@
       {{#patterns}}
           <tr>
             <td>{{name}}</td>
-            <td><a class="githack-link" href="./tests/{{name}}/index.html">Index</a></td>
-            <td><a class="githack-link" href="./review/{{name}}.html">Review</a></td>
+            <td><a href="./tests/{{name}}/index.html">Index</a></td>
+            <td><a href="./review/{{name}}.html">Review</a></td>
             <td>{{numberOfTests}}</td>
             <td><a href="https://github.com/w3c/aria-at/commit/{{commit}}" target="_blank">{{commitDescription}}</a></td>
           </tr>

--- a/scripts/review-index-template.mustache
+++ b/scripts/review-index-template.mustache
@@ -34,7 +34,8 @@
         <th>Pattern</th>
         <th>Index Page</th>
         <th>Review Page</th>
-        <th>Number of Tests</th>
+        <th># of Tests</th>
+        <th>Commit of Last Change</th>
       </tr>
       {{#patterns}}
           <tr>
@@ -42,6 +43,7 @@
             <td><a href="./tests/{{name}}/index.html">Index</a></td>
             <td><a href="./review/{{name}}.html">Review</a></td>
             <td>{{numberOfTests}}</td>
+            <td><a href="https://github.com/w3c/aria-at/commit/{{commit}}" target="_blank">{{commitDescription}}</a></td>
           </tr>
       {{/patterns}}
     </table>

--- a/scripts/review-index-template.mustache
+++ b/scripts/review-index-template.mustache
@@ -40,8 +40,8 @@
       {{#patterns}}
           <tr>
             <td>{{name}}</td>
-            <td><a href="./tests/{{name}}/index.html">Index</a></td>
-            <td><a href="./review/{{name}}.html">Review</a></td>
+            <td><a href="tests/{{name}}/index.html">Index</a></td>
+            <td><a href="review/{{name}}.html">Review</a></td>
             <td>{{numberOfTests}}</td>
             <td><a href="https://github.com/w3c/aria-at/commit/{{commit}}" target="_blank">{{commitDescription}}</a></td>
           </tr>

--- a/scripts/review-index-template.mustache
+++ b/scripts/review-index-template.mustache
@@ -22,14 +22,6 @@
       }
 
     </style>
-    <script>
-      document.addEventListener("DOMContentLoaded", function(){
-        const branch = new URL(window.location.href.toLowerCase()).searchParams.get("branch");
-        Array.from(document.getElementsByClassName('githack-link')).forEach(function (item) {
-          item.href = item.href.replace(/BRANCH/, branch);
-        });
-      });
-    </script>
   </head>
   <body>
 
@@ -46,8 +38,8 @@
       {{#patterns}}
           <tr>
             <td>{{name}}</td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/tests/{{name}}/index.html">Index</a></td>
-            <td><a class="githack-link" href="https://raw.githack.com/w3c/aria-at/BRANCH/review/{{name}}.html">Review</a></td>
+            <td><a class="githack-link" href="./tests/{{name}}/index.html">Index</a></td>
+            <td><a class="githack-link" href="./review/{{name}}.html">Review</a></td>
             <td>{{numberOfTests}}</td>
             <td><a href="https://github.com/w3c/aria-at/commit/{{commit}}" target="_blank">{{commitDescription}}</a></td>
           </tr>

--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -170,7 +170,15 @@ for (let pattern in allTestsForPattern) {
 }
 
 const renderedIndex = mustache.render(indexTemplate, {
-  patterns: Object.keys(allTestsForPattern).map(pattern => ({ name: pattern, numberOfTests: allTestsForPattern[pattern].length }))
+  patterns: Object.keys(allTestsForPattern).map(pattern => {
+    const lastCommit = spawnSync('git', ['log', '-n1', '--oneline', path.join('.', 'tests', pattern)]).stdout.toString();
+    return {
+      name: pattern,
+      numberOfTests: allTestsForPattern[pattern].length,
+      commit: lastCommit.split(' ')[0],
+      commitDescription: lastCommit
+    }
+  })
 });
 const indexFile = path.resolve('.', 'index.html');
 fse.writeFileSync(indexFile, renderedIndex);


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/pr-previewer-fixes/index.html)

The installed pr-previewer had two bugs:
1. The preview wasn't automatically attached to diffs unless they changed the number of tests.
2. Links to other pages from the review index got an access denied error.

I tried a couple of approaches to fixing including [reaching out to pr-previwer](https://github.com/tobie/pr-preview/issues/83) to find a solution before ultimately deciding to use a different solution and uninstall pr-previewer.

I switched to using a GitHub action called [pr-updater](https://github.com/tzkhan/pr-update-action) that adds templated branch name information to the title and body of all prs. 

The "Preview Tests" link above was automatically added in via the action. It uses the service rawgit, which pr-previewer provided a wrapper around, to preview link to the test index on the branch.

I created [a fork](https://github.com/rmeritz/pr-update-action) of the original action so that I didn't automatically need to include the branch name in the title. I've opened a [PR](https://github.com/tzkhan/pr-update-action/pull/16) to merge my changes into the original action.

I also updated the index file to show and link to the latest commit where the test example was changed. 
<!--
    no preview
-->