### PR TITLE
chore: Skip double build on Dependabot linting

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -7,6 +7,8 @@ on:
       - "package*.json"
       - ".eslintrc.json"
       - ".github/workflows/js-lint.yml"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths:
       - "**/*.js"


### PR DESCRIPTION
Only submitted through PRs, so it doesn't need the push build