### PR TITLE
chore: Don't generate for Dependabot

### DIFF
--- a/.github/workflows/generate-and-commit-files.yml
+++ b/.github/workflows/generate-and-commit-files.yml
@@ -1,6 +1,9 @@
 name: Generate and Commit Files
 
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+      - dependabot/**
 
 jobs:
   generate-and-commit-files:


### PR DESCRIPTION
Prevents Dependabot from keeping PR updated for newer dependency release