### PR TITLE
update scripts to only check first file and save last edited date fro…

### DIFF
--- a/scripts/review-template.mustache
+++ b/scripts/review-template.mustache
@@ -113,7 +113,7 @@
       <ul>
         <li>Mode: {{mode}}</li>
         <li>Applies to: {{allReleventATsFormatted}}</li>
-        <li>Lasted edited: {{lastEdited}}</li>
+        <li>Last edited: ~ {{lastEdited}}</li>
         <li>Tests:
           <ul>
             {{#allReleventATs}}

--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -164,7 +164,6 @@ fse.readdirSync(testDir).forEach(function (subDir) {
 
 	// only check the file path for the first test
   if (test.includes('test-01')) {
-	console.log(subDir +' -- last edited:');
 	const checkDataFilePath = path.join('.', 'tests', subDir, 'data');
 	const outputData = spawnSync('git', ['log', '-1', '--format="%ad"', checkDataFilePath]);
 	const lastDataEdited = new Date(outputData.stdout.toString().replace(/"/gi, '').replace('\n', ''));
@@ -175,10 +174,8 @@ fse.readdirSync(testDir).forEach(function (subDir) {
 
 	  if (dateCompare(lastReferenceEdited, lastDataEdited) === 1 ){
 		lastEdited = lastReferenceEdited;
-		console.log(lastReferenceEdited);
 	  } else {
 		lastEdited = lastDataEdited;
-		console.log(lastDataEdited);
 	  }
   }
 

--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -15,6 +15,8 @@ const reviewDir = path.resolve('.', 'review');
 const allTestsForPattern = {};
 const support = JSON.parse(fse.readFileSync(path.join(testDir, 'support.json')));
 let allATKeys = [];
+let testDate = [];
+let lastEdited;
 support.ats.forEach(at => {
 	allATKeys.push(at.key);
 });
@@ -66,6 +68,7 @@ fse.readdirSync(testDir).forEach(function (subDir) {
     });
 
     fse.readdirSync(subDirFullPath).forEach(function (test) {
+    	// DW - I think this is where we check the tests originally of all html files aother than index
       if (path.extname(test) === '.html' && path.basename(test) !== 'index.html') {
 
 	const testFile = path.join(testDir, subDir, test);
@@ -142,10 +145,42 @@ fse.readdirSync(testDir).forEach(function (subDir) {
 	  });
 	}
 
+	debugger;
+
 	// Create the test review pages
-	const testFilePath = path.join('.', 'tests', subDir, test);
-	const output = spawnSync('git', ['log', '-1', '--format="%ad"', testFilePath]);
-	const lastEdited = output.stdout.toString().replace(/"/gi, '').replace('\n', '');
+
+	//const testFilePath = path.join('.', 'tests', subDir, test);
+
+
+  	let dateCompare = function(a,b) {
+  		return(
+  			isFinite(a=a.valueOf()) &&
+            isFinite(b=b.valueOf()) ?
+            (a>b)-(a<b) :
+            NaN
+		)
+  	}
+
+
+	// only check the file path for the first test
+  if (test.includes('test-01')) {
+	console.log(subDir +' -- last edited:');
+	const checkDataFilePath = path.join('.', 'tests', subDir, 'data');
+	const outputData = spawnSync('git', ['log', '-1', '--format="%ad"', checkDataFilePath]);
+	const lastDataEdited = new Date(outputData.stdout.toString().replace(/"/gi, '').replace('\n', ''));
+
+	const checkReferenceFilePath = path.join('.', 'tests', subDir, 'reference');
+	const outputReference = spawnSync('git', ['log', '-1', '--format="%ad"', checkReferenceFilePath]);
+	const lastReferenceEdited = new Date(outputReference.stdout.toString().replace(/"/gi, '').replace('\n', ''));
+
+	  if (dateCompare(lastReferenceEdited, lastDataEdited) === 1 ){
+		lastEdited = lastReferenceEdited;
+		console.log(lastReferenceEdited);
+	  } else {
+		lastEdited = lastDataEdited;
+		console.log(lastDataEdited);
+	  }
+  }
 
 	tests.push({
 	  testNumber: tests.length+1,


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/last-edited-test-reviewer/index.html)

…m important files == git log from data and reference dirs

The code could be a little cleaner but I was able to get the optimal case complete instead of the the `test.csv`
https://app.asana.com/0/1193055321453706/1199152269152973/f

**More notes on the ticket requirements:**
- only the data and reference folders but - git log 
- last file was changed ==> Any file in relevant directory related files
- once for every test 
- can you check all of the underlying file, then just check test.csv and add a "~"
- alternative: instead of checking if the test file is changed, the most relevant stuff is in test.csv 