### PR TITLE
Support command sequences in at-commands.mjs

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -48,7 +48,7 @@
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -56,7 +56,7 @@
             <td><a href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -64,7 +64,7 @@
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -72,7 +72,7 @@
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -80,7 +80,7 @@
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -88,7 +88,7 @@
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
           <tr>
@@ -96,7 +96,7 @@
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+            <td><a href="https://github.com/w3c/aria-at/commit/5311dde" target="_blank">5311dde Use &#39;then&#39; instead of &#39;followed by&#39;
 </a></td>
           </tr>
     </table>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -48,14 +48,15 @@
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
+</a></td>
           </tr>
           <tr>
             <td>combobox-autocomplete-both</td>
             <td><a href="./tests/combobox-autocomplete-both/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both.html">Review</a></td>
             <td>30</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -63,7 +64,7 @@
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -71,7 +72,7 @@
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -79,7 +80,7 @@
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -87,7 +88,7 @@
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
           <tr>
@@ -95,7 +96,7 @@
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/b40864a" target="_blank">b40864a Regenerate test files
+            <td><a href="https://github.com/w3c/aria-at/commit/264861e" target="_blank">264861e Support command sequences in at-commands.mjs
 </a></td>
           </tr>
     </table>

--- a/review/checkbox-tri-state.html
+++ b/review/checkbox-tri-state.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -383,7 +383,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -465,7 +465,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -541,7 +541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -617,7 +617,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -668,7 +668,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -790,7 +790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -861,7 +861,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -908,7 +908,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -980,7 +980,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1052,7 +1052,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1100,7 +1100,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1178,7 +1178,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1256,7 +1256,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1306,7 +1306,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1378,7 +1378,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1450,7 +1450,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1497,7 +1497,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1575,7 +1575,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1649,7 +1649,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1723,7 +1723,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1797,7 +1797,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1844,7 +1844,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/checkbox-tri-state.html
+++ b/review/checkbox-tri-state.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -383,7 +383,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -465,7 +465,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -541,7 +541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -617,7 +617,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -668,7 +668,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -790,7 +790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -861,7 +861,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -908,7 +908,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -980,7 +980,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1052,7 +1052,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1100,7 +1100,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1178,7 +1178,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1256,7 +1256,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1306,7 +1306,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1378,7 +1378,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1450,7 +1450,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1497,7 +1497,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1575,7 +1575,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1649,7 +1649,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1723,7 +1723,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1797,7 +1797,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1844,7 +1844,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/checkbox.html
+++ b/review/checkbox.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -374,7 +374,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -440,7 +440,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -486,7 +486,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -569,7 +569,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -645,7 +645,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -696,7 +696,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -759,7 +759,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -820,7 +820,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -862,7 +862,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -940,7 +940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1018,7 +1018,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1068,7 +1068,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1224,7 +1224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1274,7 +1274,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1338,7 +1338,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1446,7 +1446,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1515,7 +1515,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1561,7 +1561,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1638,7 +1638,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1707,7 +1707,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1757,7 +1757,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1826,7 +1826,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1895,7 +1895,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/checkbox.html
+++ b/review/checkbox.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -374,7 +374,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -440,7 +440,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -486,7 +486,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -569,7 +569,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -645,7 +645,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -696,7 +696,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -759,7 +759,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -820,7 +820,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -862,7 +862,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -940,7 +940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1018,7 +1018,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1068,7 +1068,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1224,7 +1224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1274,7 +1274,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1338,7 +1338,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1446,7 +1446,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1515,7 +1515,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1561,7 +1561,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1638,7 +1638,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1707,7 +1707,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1757,7 +1757,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1826,7 +1826,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1895,7 +1895,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/combobox-autocomplete-both.html
+++ b/review/combobox-autocomplete-both.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -371,7 +371,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -437,7 +437,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -503,7 +503,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-04-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -569,7 +569,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-05-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -635,7 +635,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -717,7 +717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -795,7 +795,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-08-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -873,7 +873,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-09-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -951,7 +951,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1033,7 +1033,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1179,7 +1179,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-13-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1257,7 +1257,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-14-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1335,7 +1335,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.html?at=jaws">jaws</a></li>
@@ -1395,7 +1395,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-16-activate-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1465,7 +1465,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-17-open-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1539,7 +1539,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-18-close-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1609,7 +1609,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-19-activate-states-button-reading.html?at=jaws">jaws</a></li>
@@ -1677,7 +1677,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1720,7 +1720,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-21-activate-states-button-reading.html?at=jaws">jaws</a></li>
@@ -1792,7 +1792,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.html?at=jaws">jaws</a></li>
@@ -1862,7 +1862,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1940,7 +1940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2016,7 +2016,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2092,7 +2092,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.html?at=jaws">jaws</a></li>
@@ -2167,7 +2167,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2242,7 +2242,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.html?at=jaws">jaws</a></li>
@@ -2320,7 +2320,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.html?at=jaws">jaws</a></li>
@@ -2398,7 +2398,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.html?at=jaws">jaws</a></li>

--- a/review/combobox-autocomplete-both.html
+++ b/review/combobox-autocomplete-both.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-01-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -371,7 +371,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-02-navigate-by-line-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -437,7 +437,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-03-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -503,7 +503,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-04-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -569,7 +569,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-05-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -635,7 +635,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-06-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -717,7 +717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-07-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -795,7 +795,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-08-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -873,7 +873,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-09-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -951,7 +951,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-10-navigate-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1033,7 +1033,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-11-navigate-by-line-to-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-12-navigate-to-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1179,7 +1179,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-13-read-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1257,7 +1257,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-14-read-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1335,7 +1335,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-15-navigate-to-combobox-with-keys-that-switch-modes-reading.html?at=jaws">jaws</a></li>
@@ -1395,7 +1395,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-16-activate-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1465,7 +1465,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-17-open-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1539,7 +1539,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-18-close-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1609,7 +1609,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-19-activate-states-button-reading.html?at=jaws">jaws</a></li>
@@ -1677,7 +1677,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-20-activate-states-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1720,7 +1720,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-21-activate-states-button-reading.html?at=jaws">jaws</a></li>
@@ -1792,7 +1792,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-22-activate-states-button-interaction.html?at=jaws">jaws</a></li>
@@ -1862,7 +1862,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-23-navigate-into-popup-from-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1940,7 +1940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-24-type-in-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2016,7 +2016,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-25-navigate-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2092,7 +2092,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-26-read-option-in-listbox-popup-reading.html?at=jaws">jaws</a></li>
@@ -2167,7 +2167,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-27-read-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2242,7 +2242,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-28-choose-combobox-option-interaction.html?at=jaws">jaws</a></li>
@@ -2320,7 +2320,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-29-cancel-selection-interaction.html?at=jaws">jaws</a></li>
@@ -2398,7 +2398,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both/test-30-initiate-caret-movement-from-listbox-interaction.html?at=jaws">jaws</a></li>

--- a/review/combobox-select-only.html
+++ b/review/combobox-select-only.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -386,7 +386,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -471,7 +471,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -550,7 +550,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -629,7 +629,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -682,7 +682,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -735,7 +735,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -816,7 +816,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -895,7 +895,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -947,7 +947,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1034,7 +1034,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1190,7 +1190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1277,7 +1277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1333,7 +1333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1420,7 +1420,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1476,7 +1476,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -1563,7 +1563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1619,7 +1619,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1703,7 +1703,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1758,7 +1758,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1836,7 +1836,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1914,7 +1914,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1966,7 +1966,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2018,7 +2018,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2096,7 +2096,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2146,7 +2146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2224,7 +2224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2302,7 +2302,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2352,7 +2352,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2402,7 +2402,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2480,7 +2480,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2558,7 +2558,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2608,7 +2608,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2658,7 +2658,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2741,7 +2741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2795,7 +2795,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2874,7 +2874,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/combobox-select-only.html
+++ b/review/combobox-select-only.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -386,7 +386,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -471,7 +471,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -550,7 +550,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -629,7 +629,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -682,7 +682,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -735,7 +735,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -816,7 +816,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -895,7 +895,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -947,7 +947,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1034,7 +1034,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1190,7 +1190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1277,7 +1277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1333,7 +1333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1420,7 +1420,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1476,7 +1476,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -1563,7 +1563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1619,7 +1619,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1703,7 +1703,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1758,7 +1758,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1836,7 +1836,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -1914,7 +1914,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1966,7 +1966,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2018,7 +2018,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2096,7 +2096,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2146,7 +2146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2224,7 +2224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2302,7 +2302,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2352,7 +2352,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2402,7 +2402,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2480,7 +2480,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2558,7 +2558,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2608,7 +2608,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2658,7 +2658,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2741,7 +2741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2795,7 +2795,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2874,7 +2874,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/menu-button-actions-active-descendant.html
+++ b/review/menu-button-actions-active-descendant.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -380,7 +380,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -459,7 +459,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -532,7 +532,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -605,7 +605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -654,7 +654,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -703,7 +703,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -778,7 +778,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -853,7 +853,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -901,7 +901,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -987,7 +987,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1075,7 +1075,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1131,7 +1131,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1215,7 +1215,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1269,7 +1269,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1349,7 +1349,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1400,7 +1400,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1480,7 +1480,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1531,7 +1531,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1611,7 +1611,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1662,7 +1662,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -1740,7 +1740,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1790,7 +1790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1911,7 +1911,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1984,7 +1984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/menu-button-actions-active-descendant.html
+++ b/review/menu-button-actions-active-descendant.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -380,7 +380,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -459,7 +459,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -532,7 +532,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -605,7 +605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -654,7 +654,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -703,7 +703,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -778,7 +778,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -853,7 +853,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -901,7 +901,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -987,7 +987,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1075,7 +1075,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1131,7 +1131,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1215,7 +1215,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1269,7 +1269,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1349,7 +1349,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1400,7 +1400,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1480,7 +1480,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1531,7 +1531,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1611,7 +1611,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1662,7 +1662,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -1740,7 +1740,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1790,7 +1790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1911,7 +1911,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1984,7 +1984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/menubar-editor.html
+++ b/review/menubar-editor.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -382,7 +382,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -445,7 +445,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -526,7 +526,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -605,7 +605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -656,7 +656,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +725,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -855,7 +855,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -934,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -984,7 +984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1064,7 +1064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1116,7 +1116,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1322,7 +1322,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1373,7 +1373,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1502,7 +1502,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1582,7 +1582,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1634,7 +1634,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1720,7 +1720,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1775,7 +1775,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1849,7 +1849,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1933,7 +1933,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1987,7 +1987,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2071,7 +2071,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2155,7 +2155,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2209,7 +2209,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2293,7 +2293,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2377,7 +2377,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2431,7 +2431,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2515,7 +2515,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2599,7 +2599,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2653,7 +2653,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2737,7 +2737,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2821,7 +2821,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2875,7 +2875,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2957,7 +2957,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3039,7 +3039,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/menubar-editor.html
+++ b/review/menubar-editor.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -382,7 +382,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -445,7 +445,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -526,7 +526,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -605,7 +605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -656,7 +656,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +725,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -855,7 +855,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -934,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -984,7 +984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1064,7 +1064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1116,7 +1116,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1322,7 +1322,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1373,7 +1373,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1502,7 +1502,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1582,7 +1582,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1634,7 +1634,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1720,7 +1720,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1775,7 +1775,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1849,7 +1849,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1933,7 +1933,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1987,7 +1987,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2071,7 +2071,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2155,7 +2155,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2209,7 +2209,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2293,7 +2293,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2377,7 +2377,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2431,7 +2431,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2515,7 +2515,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2599,7 +2599,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2653,7 +2653,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2737,7 +2737,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2821,7 +2821,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2875,7 +2875,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2957,7 +2957,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3039,7 +3039,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/modal-dialog.html
+++ b/review/modal-dialog.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -381,7 +381,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -461,7 +461,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -513,7 +513,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -585,7 +585,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -657,7 +657,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -703,7 +703,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -777,7 +777,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -851,7 +851,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -899,7 +899,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -971,7 +971,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1017,7 +1017,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1089,7 +1089,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1135,7 +1135,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1209,7 +1209,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1328,7 +1328,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1374,7 +1374,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1457,7 +1457,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1540,7 +1540,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1594,7 +1594,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1672,7 +1672,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1750,7 +1750,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1800,7 +1800,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1880,7 +1880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1960,7 +1960,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2012,7 +2012,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2093,7 +2093,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2174,7 +2174,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/modal-dialog.html
+++ b/review/modal-dialog.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -381,7 +381,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -461,7 +461,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -513,7 +513,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -585,7 +585,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -657,7 +657,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -703,7 +703,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -777,7 +777,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -851,7 +851,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -899,7 +899,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -971,7 +971,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1017,7 +1017,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1089,7 +1089,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1135,7 +1135,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1209,7 +1209,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1328,7 +1328,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1374,7 +1374,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1457,7 +1457,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1540,7 +1540,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1594,7 +1594,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1672,7 +1672,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1750,7 +1750,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1800,7 +1800,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1880,7 +1880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1960,7 +1960,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2012,7 +2012,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2093,7 +2093,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2174,7 +2174,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/tabs-manual-activation.html
+++ b/review/tabs-manual-activation.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -390,7 +390,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -479,7 +479,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -566,7 +566,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -653,7 +653,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -711,7 +711,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -769,7 +769,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -852,7 +852,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -935,7 +935,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -988,7 +988,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1066,7 +1066,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1144,7 +1144,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1275,7 +1275,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1356,7 +1356,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1408,7 +1408,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1489,7 +1489,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1541,7 +1541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1619,7 +1619,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1669,7 +1669,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -1745,7 +1745,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -1821,7 +1821,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1871,7 +1871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1921,7 +1921,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1994,7 +1994,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2067,7 +2067,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2115,7 +2115,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2196,7 +2196,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2277,7 +2277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Wed Mar 24 23:33:00 2021 -0700</li>
+        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/review/tabs-manual-activation.html
+++ b/review/tabs-manual-activation.html
@@ -301,7 +301,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -390,7 +390,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -479,7 +479,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -566,7 +566,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -653,7 +653,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -711,7 +711,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -769,7 +769,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -852,7 +852,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -935,7 +935,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -988,7 +988,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1066,7 +1066,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1144,7 +1144,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1275,7 +1275,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1356,7 +1356,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1408,7 +1408,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1489,7 +1489,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1541,7 +1541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1619,7 +1619,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1669,7 +1669,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -1745,7 +1745,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -1821,7 +1821,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1871,7 +1871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1921,7 +1921,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1994,7 +1994,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2067,7 +2067,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2115,7 +2115,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2196,7 +2196,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2277,7 +2277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Lasted edited: Tue Jun 1 15:27:07 2021 +0200</li>
+        <li>Lasted edited: Thu Jun 3 22:57:25 2021 +0200</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -63,14 +63,19 @@ constructor(commands, support) {
     let commands = [];
 
     for (let c of commandsData) {
-      let command = keys[c[0]];
-      if (typeof command === 'undefined') {
-        throw new Error(`Key instruction identifier "${c}" for AT "${assistiveTech.name}", mode "${mode}", task "${task}" is not an available identified. Update you commands.json file to the correct identifier or add your identifier to resources/keys.mjs.`);
-      }
+      let innerCommands = [];
+      let commandSequence = c[0].split(',');
+      for (let command of commandSequence) {
+        command = keys[command];
+        if (typeof command === 'undefined') {
+          throw new Error(`Key instruction identifier "${c}" for AT "${assistiveTech.name}", mode "${mode}", task "${task}" is not an available identified. Update you commands.json file to the correct identifier or add your identifier to resources/keys.mjs.`);
+        }
 
-      let furtherInstruction = c[1];
-      command = furtherInstruction ? `${command} ${furtherInstruction}` : command;
-      commands.push(command);
+        let furtherInstruction = c[1];
+        command = furtherInstruction ? `${command} ${furtherInstruction}` : command;
+        innerCommands.push(command);
+      }
+      commands.push(innerCommands.join(' followed by '));
     }
 
     return commands;

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -75,7 +75,7 @@ constructor(commands, support) {
         command = furtherInstruction ? `${command} ${furtherInstruction}` : command;
         innerCommands.push(command);
       }
-      commands.push(innerCommands.join(' followed by '));
+      commands.push(innerCommands.join(", then "));
     }
 
     return commands;


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/command-sequences/index.html)

Fixes #363

---

This change supports the syntax proposed in https://github.com/w3c/aria-at/issues/363#issuecomment-789842774 

```
1,navigate forwards to grid,reading,JAWS,"T,DOWN","DOWN,DOWN",,,,
```

without changing the structure of `commands.json` (the strings can contain commas), and without changing the `CommandsAPI` used by `aria-at-harness.mjs`. This is to not shake the foundation for e.g. #434, while still giving test authors the option to use command sequences.

For example, given this in `test-01-navigate-to-unchecked-checkbox-reading.html`:
```
      "nvda": [
        [ "X_AND_SHIFT_X,X_AND_SHIFT_X" ],
        [ "F_AND_SHIFT_F" ],
        [ "TAB_AND_SHIFT_TAB" ],
        [ "UP_AND_DOWN" ]
      ]
```
the rendered test instructions are:

> 4. Using the following commands, Navigate to the first checkbox. Note: it should be in the unchecked state.
>    - **X / Shift+X followed by X / Shift+X**
>    - F / Shift+F
>    - Tab / Shift+Tab
>    - Up Arrow / Down Arrow