### PR TITLE
add Setup Test Page button into test window

### DIFF
--- a/scripts/review-template.mustache
+++ b/scripts/review-template.mustache
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,45 +56,30 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
+      var scripts = {
+        {{{setupScripts}}}
+      };
 
-        if (setupScriptName) {
-          var scripts = {
-            {{{setupScripts}}}
-          };
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
-
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>

--- a/tests/resources/aria-at-test-window.mjs
+++ b/tests/resources/aria-at-test-window.mjs
@@ -28,46 +28,50 @@ export class TestWindow {
     this.scripts = scripts;
   }
 
-  /** If the window is closed, re-enable open popup button. */
   windowOnBeforeUnload() {
     window.setTimeout(() => {
       if (this.window.closed) {
         this.window = undefined;
-
-        this.hooks.windowClosed();
-      } else {
-        // If the window is open (after a location.reload()) rerun the setupTestPage script.
-        this.prepare();
       }
+
+      /** Re-enable open popup button. If the window was reloaded it may be 100ms  */
+      this.hooks.windowClosed();
     }, 100);
   }
 
+  windowOnDOMContentLoaded() {
+    if (this.window) {
+      this.prepare();
+    }
+  }
+
+  /**
+   * @param {Window} testPageWindow
+   */
   injectSetupResetButton(testPageWindow) {
+    const {scripts, setupScriptName} = this;
+    const setupScriptPresent = Boolean(setupScriptName && scripts[setupScriptName]);
+
+    /** @type {'setup' | 'post-setup'} */
+    let runSetupOrRelad = setupScriptPresent ? 'setup' : 'post-setup';
+
     const buttonDiv = testPageWindow.document.createElement('div');
     buttonDiv.innerHTML = `
       <div style="position: relative; left: 0; right: 0; height: 2rem;">
-        <button style="height: 100%; width: 100%;">Run Test Setup</button>
+        <button autofocus style="height: 100%; width: 100%;"${setupScriptPresent ? '' : ' disabled'}>Run Test Setup</button>
       </div>
     `;
     const buttonButton = buttonDiv.querySelector('button');
 
-    /** @type {'setup' | 'reload'} */
-    let runSetupOrRelad = 'setup';
-
-    const setupScriptName = this.setupScriptName;
-
     buttonButton.onclick = function() {
       try {
         if (runSetupOrRelad === 'setup') {
-          runSetupOrRelad = 'reload';
-          buttonButton.innerText = 'Reload Test';
+          runSetupOrRelad = 'post-setup';
+          buttonButton.disabled = true;
 
           if (setupScriptName) {
-            scripts[behavior.setupScriptName](testPageWindow.document);
+            scripts[setupScriptName](testPageWindow.document);
           }
-        } else {
-          testPageWindow.location.reload();
-          buttonButton.disabled = true;
         }
       } catch (error) {
         window.console.error(error);
@@ -75,32 +79,39 @@ export class TestWindow {
       }
     };
 
-    testPageWindow.document.body.insertBefore(buttonDiv.children[0], testPageWindow.document.body.children[0]);
+    const bodyElement = testPageWindow.document.body;
+    const mainElement = bodyElement.getElementsByTagName('main')[0] || bodyElement;
+
+    mainElement.appendChild(buttonDiv.children[0]);
   }
 
   open() {
+    if (this.window) {
+      this.window.close();
+    }
+
     this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
 
     this.hooks.windowOpened();
 
-    // If the window is closed, re-enable open popup button
-    this.window.onbeforeunload = this.windowOnBeforeUnload.bind(this);
+    // Prepare the window once we can modify it.
+    this.window.addEventListener('DOMContentLoaded', this.windowOnDOMContentLoaded.bind(this));
   }
 
-  prepare() {
+  async prepare() {
     if (!this.window) {
       return;
     }
 
-    // make sure the origin is the same, and prevent this from firing on an 'about' page
-    if (
+    // Re-enable open button when unloaded by closing the window or reloading it.
+    this.window.onbeforeunload = this.windowOnBeforeUnload.bind(this);
+
+    // Make sure the origin is the same, and prevent this from firing on an 'about' page.
+    while (
       this.window.location.origin !== window.location.origin ||
-      this.window.document.readyState !== "complete"
+      this.window.document.readyState !== "complete" && this.window.document.readyState !== "interactive"
     ) {
-      window.setTimeout(() => {
-        this.prepare();
-      }, 100);
-      return;
+      await new Promise(resolve => window.setTimeout(resolve, 100));
     }
 
     this.injectSetupResetButton(this.window);


### PR DESCRIPTION
[Open PR Preview](https://raw.githack.com/mzgoddard/aria-at/mzgoddard-reset-test/index.html)

This change injects a button at the bottom of the test page in the window opened by activating the `Open Test Page` button.

The button has the text `Setup Test Page` and the autofocus attribute. Clicking it will run a test setup script if this test has one and then disables itself. If there is no setup script the button will disabled at the start.

<details>
<summary>Original PR Description</summary>

This change is a first step for https://github.com/w3c/aria-at/issues/358. In a follow up PR, we can inject a button into the test page that on click will reload the test page window.

After the test page window is reloaded, or refreshed, the setupTestPage script will be executed on the reloaded page. As well the unload listener is added again so that a second reload, and third and so on, will have the same functionality. By adding the unload listener after reloading it will also be able to re-enable the open test page when it is closed.
</details>