### PR TITLE
Replace harness instruction page rendering

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -40,7 +40,7 @@
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -48,7 +48,7 @@
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -56,7 +56,7 @@
             <td><a href="./tests/combobox-autocomplete-both-updated/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both-updated.html">Review</a></td>
             <td>76</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -64,7 +64,7 @@
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -72,7 +72,7 @@
             <td><a href="./tests/command-button/index.html">Index</a></td>
             <td><a href="./review/command-button.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -80,7 +80,7 @@
             <td><a href="./tests/disclosure-faq/index.html">Index</a></td>
             <td><a href="./review/disclosure-faq.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -88,7 +88,7 @@
             <td><a href="./tests/disclosure-navigation/index.html">Index</a></td>
             <td><a href="./review/disclosure-navigation.html">Review</a></td>
             <td>46</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -96,7 +96,7 @@
             <td><a href="./tests/menu-button-actions/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -104,7 +104,7 @@
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -112,7 +112,7 @@
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -120,7 +120,7 @@
             <td><a href="./tests/minimal-data-grid/index.html">Index</a></td>
             <td><a href="./review/minimal-data-grid.html">Review</a></td>
             <td>55</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -128,7 +128,7 @@
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -136,7 +136,7 @@
             <td><a href="./tests/radiogroup-aria-activedescendant/index.html">Index</a></td>
             <td><a href="./review/radiogroup-aria-activedescendant.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -144,7 +144,7 @@
             <td><a href="./tests/radiogroup-roving-tabindex/index.html">Index</a></td>
             <td><a href="./review/radiogroup-roving-tabindex.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -152,7 +152,7 @@
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
           <tr>
@@ -160,7 +160,7 @@
             <td><a href="./tests/toggle-button/index.html">Index</a></td>
             <td><a href="./review/toggle-button.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/9dcb5bc" target="_blank">9dcb5bc Merge branch &#39;master&#39; into remove-old-combobox
+            <td><a href="https://github.com/w3c/aria-at/commit/f626b91" target="_blank">f626b91 fixup! replace harness instruction page rendering
 </a></td>
           </tr>
     </table>

--- a/build/review/checkbox-tri-state.html
+++ b/build/review/checkbox-tri-state.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +722,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -956,7 +956,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1007,7 +1007,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1200,7 +1200,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1247,7 +1247,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1391,7 +1391,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1439,7 +1439,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1517,7 +1517,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1595,7 +1595,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1645,7 +1645,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1789,7 +1789,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1836,7 +1836,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1914,7 +1914,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1988,7 +1988,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2062,7 +2062,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2136,7 +2136,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2183,7 +2183,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox.html
+++ b/build/review/checkbox.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -713,7 +713,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -779,7 +779,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -825,7 +825,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -908,7 +908,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -984,7 +984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1035,7 +1035,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1098,7 +1098,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1159,7 +1159,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1201,7 +1201,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1279,7 +1279,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1357,7 +1357,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1407,7 +1407,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1485,7 +1485,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1563,7 +1563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1613,7 +1613,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1677,7 +1677,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1741,7 +1741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1785,7 +1785,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1854,7 +1854,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1900,7 +1900,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1977,7 +1977,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2046,7 +2046,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2096,7 +2096,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2165,7 +2165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2234,7 +2234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-autocomplete-both-updated.html
+++ b/build/review/combobox-autocomplete-both-updated.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-01-navigate-forwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -729,7 +729,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-02-navigate-backwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -818,7 +818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-03-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -899,7 +899,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-04-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -980,7 +980,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-05-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1034,7 +1034,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-06-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1088,7 +1088,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-07-read-information-about-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1171,7 +1171,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-08-read-information-about-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1252,7 +1252,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-09-read-information-about-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1305,7 +1305,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-10-navigate-forwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1398,7 +1398,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-11-navigate-backwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1491,7 +1491,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-12-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1576,7 +1576,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-13-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-14-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-15-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1773,7 +1773,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-16-read-information-about-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1860,7 +1860,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-17-read-information-about-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1945,7 +1945,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-18-read-information-about-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2000,7 +2000,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-19-open-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2073,7 +2073,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-20-open-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2146,7 +2146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-21-open-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2193,7 +2193,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-22-open-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2266,7 +2266,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-23-open-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2339,7 +2339,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-24-open-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2386,7 +2386,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-25-open-empty-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2461,7 +2461,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-26-open-an-empty-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2509,7 +2509,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-27-open-a-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2584,7 +2584,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-28-open-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2632,7 +2632,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-29-read-information-about-empty-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2715,7 +2715,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-30-read-information-about-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2796,7 +2796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-31-read-information-about-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2849,7 +2849,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-32-read-information-about-filled-in-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2936,7 +2936,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-33-read-information-about-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3021,7 +3021,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-34-read-information-about-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3076,7 +3076,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-35-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3148,7 +3148,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-36-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3194,7 +3194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-37-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3266,7 +3266,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-38-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3312,7 +3312,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-39-close-empty-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3383,7 +3383,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-40-close-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3456,7 +3456,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-41-close-empty-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3503,7 +3503,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-42-close-filled-in-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3574,7 +3574,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-43-close-filled-in-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3647,7 +3647,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-44-close-filled-in-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3694,7 +3694,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-45-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3781,7 +3781,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-46-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3837,7 +3837,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-47-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3922,7 +3922,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-48-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3977,7 +3977,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-49-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4064,7 +4064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-50-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4120,7 +4120,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-51-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4207,7 +4207,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-52-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4263,7 +4263,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-53-navigate-from-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4348,7 +4348,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-54-navigate-from-an-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4403,7 +4403,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-55-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4488,7 +4488,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-56-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4543,7 +4543,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-57-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4628,7 +4628,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-58-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4683,7 +4683,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-59-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4768,7 +4768,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-60-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4823,7 +4823,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-61-navigate-to-next-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4910,7 +4910,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-62-navigate-to-next-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4967,7 +4967,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-63-navigate-to-previous-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5054,7 +5054,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-64-navigate-to-previous-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5111,7 +5111,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-65-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5195,7 +5195,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-66-read-information-about-a-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5250,7 +5250,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-67-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=jaws">jaws</a></li>
@@ -5335,7 +5335,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-68-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=jaws">jaws</a></li>
@@ -5420,7 +5420,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-69-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5474,7 +5474,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-70-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5528,7 +5528,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-71-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5613,7 +5613,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-72-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5698,7 +5698,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-73-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5752,7 +5752,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-74-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5806,7 +5806,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-75-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5892,7 +5892,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-76-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-select-only.html
+++ b/build/review/combobox-select-only.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +725,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -810,7 +810,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -889,7 +889,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -968,7 +968,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1021,7 +1021,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1074,7 +1074,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1155,7 +1155,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1234,7 +1234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1286,7 +1286,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1373,7 +1373,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1468,7 +1468,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1529,7 +1529,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1672,7 +1672,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1759,7 +1759,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1815,7 +1815,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -1902,7 +1902,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1958,7 +1958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2042,7 +2042,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2097,7 +2097,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2175,7 +2175,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2253,7 +2253,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2305,7 +2305,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2357,7 +2357,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2435,7 +2435,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2485,7 +2485,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2563,7 +2563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2641,7 +2641,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2691,7 +2691,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2741,7 +2741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2819,7 +2819,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2897,7 +2897,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2947,7 +2947,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2997,7 +2997,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3080,7 +3080,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3134,7 +3134,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3213,7 +3213,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/command-button.html
+++ b/build/review/command-button.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-01-navigate-forwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-02-navigate-backwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-03-navigate-forwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-04-navigate-backwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-05-navigate-forwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-06-navigate-backwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-07-read-information-about-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-08-read-information-about-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-09-read-information-about-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-faq.html
+++ b/build/review/disclosure-faq.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -802,7 +802,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -877,7 +877,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -952,7 +952,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1002,7 +1002,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1052,7 +1052,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1133,7 +1133,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1214,7 +1214,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1289,7 +1289,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1364,7 +1364,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1414,7 +1414,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1464,7 +1464,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1541,7 +1541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1665,7 +1665,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1742,7 +1742,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1817,7 +1817,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1866,7 +1866,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1939,7 +1939,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2012,7 +2012,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2060,7 +2060,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2133,7 +2133,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2206,7 +2206,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2254,7 +2254,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-25-navigate-from-expanded-disclosure-button-to-text-of-question-answer-reading.html?at=jaws">jaws</a></li>
@@ -2325,7 +2325,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-26-navigate-from-expanded-disclosure-button-to-text-of-question-answer-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-navigation.html
+++ b/build/review/disclosure-navigation.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -802,7 +802,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -877,7 +877,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -958,7 +958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1008,7 +1008,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1139,7 +1139,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1220,7 +1220,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1295,7 +1295,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1376,7 +1376,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1425,7 +1425,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1475,7 +1475,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1552,7 +1552,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1627,7 +1627,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1676,7 +1676,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1828,7 +1828,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1877,7 +1877,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2023,7 +2023,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2071,7 +2071,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2144,7 +2144,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2217,7 +2217,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2265,7 +2265,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-25-navigate-from-expanded-disclosure-button-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2346,7 +2346,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-26-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -2424,7 +2424,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-27-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2475,7 +2475,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-28-navigate-from-expanded-disclosure-button-to-current-page-link-reading.html?at=jaws">jaws</a></li>
@@ -2559,7 +2559,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-29-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=jaws">jaws</a></li>
@@ -2640,7 +2640,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-30-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2693,7 +2693,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-31-navigate-from-dropdown-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2768,7 +2768,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-32-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2843,7 +2843,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-33-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2891,7 +2891,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-34-navigate-forwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2968,7 +2968,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-35-navigate-backwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3045,7 +3045,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-36-navigate-forwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3121,7 +3121,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-37-navigate-backwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3197,7 +3197,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-38-navigate-forwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3247,7 +3247,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-39-navigate-backwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3297,7 +3297,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-40-navigate-to-first-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3369,7 +3369,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-41-navigate-to-last-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3441,7 +3441,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-42-navigate-to-first-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3487,7 +3487,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-43-navigate-to-last-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3533,7 +3533,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-44-activate-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3609,7 +3609,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-45-activate-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3685,7 +3685,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-46-activate-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions-active-descendant.html
+++ b/build/review/menu-button-actions-active-descendant.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1326,7 +1326,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1414,7 +1414,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1470,7 +1470,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1554,7 +1554,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1608,7 +1608,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1688,7 +1688,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1739,7 +1739,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1819,7 +1819,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1870,7 +1870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2001,7 +2001,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2079,7 +2079,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2129,7 +2129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2202,7 +2202,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2250,7 +2250,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2323,7 +2323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions.html
+++ b/build/review/menu-button-actions.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1325,7 +1325,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1412,7 +1412,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1468,7 +1468,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1551,7 +1551,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1604,7 +1604,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1683,7 +1683,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1733,7 +1733,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1812,7 +1812,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1862,7 +1862,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1941,7 +1941,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1991,7 +1991,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2068,7 +2068,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2117,7 +2117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2190,7 +2190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2238,7 +2238,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2311,7 +2311,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menubar-editor.html
+++ b/build/review/menubar-editor.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -784,7 +784,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -865,7 +865,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -995,7 +995,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1064,7 +1064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1143,7 +1143,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1273,7 +1273,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1323,7 +1323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1403,7 +1403,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1455,7 +1455,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1533,7 +1533,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1583,7 +1583,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1712,7 +1712,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1790,7 +1790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1841,7 +1841,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1921,7 +1921,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1973,7 +1973,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2059,7 +2059,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2114,7 +2114,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -2188,7 +2188,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -2272,7 +2272,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2326,7 +2326,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2410,7 +2410,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2494,7 +2494,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2548,7 +2548,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2632,7 +2632,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2716,7 +2716,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2770,7 +2770,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2854,7 +2854,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2938,7 +2938,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2992,7 +2992,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3076,7 +3076,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3160,7 +3160,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3214,7 +3214,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3296,7 +3296,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3378,7 +3378,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/minimal-data-grid.html
+++ b/build/review/minimal-data-grid.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-01-navigate-forwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -724,7 +724,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-02-navigate-backwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -806,7 +806,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-03-navigate-forwards-to-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -859,7 +859,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-04-navigate-into-end-of-grid-reading.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-05-navigate-into-end-of-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -997,7 +997,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-06-move-focus-forwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1081,7 +1081,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-07-move-focus-backwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1165,7 +1165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-08-move-focus-forwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1249,7 +1249,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-09-move-focus-backwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1333,7 +1333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-10-move-focus-forwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1386,7 +1386,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-11-move-focus-backwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1439,7 +1439,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-12-read-information-about-grid-cell-reading.html?at=jaws">jaws</a></li>
@@ -1515,7 +1515,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-13-read-information-about-grid-cell-interaction.html?at=jaws">jaws</a></li>
@@ -1591,7 +1591,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-14-read-information-about-grid-cell-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1639,7 +1639,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-15-read-information-about-grid-cell-containing-link-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-16-read-information-about-grid-cell-containing-link-interaction.html?at=jaws">jaws</a></li>
@@ -1795,7 +1795,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-17-read-information-about-grid-cell-containing-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1844,7 +1844,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-18-navigate-to-next-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -1918,7 +1918,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-19-navigate-to-next-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1992,7 +1992,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-20-navigate-to-next-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2041,7 +2041,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-21-navigate-to-previous-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2115,7 +2115,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-22-navigate-to-previous-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2189,7 +2189,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-23-navigate-to-previous-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2238,7 +2238,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-24-navigate-to-next-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2317,7 +2317,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-25-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2394,7 +2394,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-26-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2445,7 +2445,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-27-navigate-to-previous-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2524,7 +2524,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-28-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2600,7 +2600,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-29-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2651,7 +2651,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-30-navigate-to-next-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2725,7 +2725,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-31-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2799,7 +2799,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-32-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2848,7 +2848,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-33-navigate-to-previous-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2922,7 +2922,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-34-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2996,7 +2996,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-35-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3046,7 +3046,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-36-navigate-to-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3120,7 +3120,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-37-navigate-to-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3194,7 +3194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-38-navigate-to-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3242,7 +3242,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-39-navigate-to-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3316,7 +3316,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-40-navigate-to-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3390,7 +3390,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-41-navigate-to-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3438,7 +3438,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-42-navigate-to-cell-containing-link-on-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3514,7 +3514,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-43-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3590,7 +3590,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-44-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3639,7 +3639,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-45-navigate-to-cell-containing-link-on-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3715,7 +3715,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-46-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3791,7 +3791,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-47-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3840,7 +3840,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-48-navigate-to-first-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3914,7 +3914,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-49-navigate-to-first-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3961,7 +3961,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-50-navigate-to-last-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4035,7 +4035,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-51-navigate-to-last-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4082,7 +4082,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-52-navigate-to-first-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4156,7 +4156,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-53-navigate-to-first-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4203,7 +4203,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-54-navigate-to-last-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4277,7 +4277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-55-navigate-to-last-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/modal-dialog.html
+++ b/build/review/modal-dialog.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -720,7 +720,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -800,7 +800,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -852,7 +852,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -996,7 +996,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1116,7 +1116,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1190,7 +1190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1238,7 +1238,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1310,7 +1310,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1356,7 +1356,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1428,7 +1428,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1474,7 +1474,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1548,7 +1548,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1595,7 +1595,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1667,7 +1667,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1713,7 +1713,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1796,7 +1796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1879,7 +1879,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1933,7 +1933,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -2011,7 +2011,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2089,7 +2089,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2139,7 +2139,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -2219,7 +2219,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -2299,7 +2299,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2351,7 +2351,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2432,7 +2432,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2513,7 +2513,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-aria-activedescendant.html
+++ b/build/review/radiogroup-aria-activedescendant.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -731,7 +731,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -788,7 +788,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -879,7 +879,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -936,7 +936,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1027,7 +1027,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1084,7 +1084,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1175,7 +1175,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1232,7 +1232,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1375,7 +1375,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1462,7 +1462,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1518,7 +1518,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1605,7 +1605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1748,7 +1748,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1804,7 +1804,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1886,7 +1886,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1966,7 +1966,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2018,7 +2018,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2100,7 +2100,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2180,7 +2180,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2232,7 +2232,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2315,7 +2315,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2398,7 +2398,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2451,7 +2451,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2534,7 +2534,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2617,7 +2617,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2670,7 +2670,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2753,7 +2753,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2807,7 +2807,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2890,7 +2890,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2944,7 +2944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3027,7 +3027,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3080,7 +3080,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3163,7 +3163,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3216,7 +3216,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3287,7 +3287,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3358,7 +3358,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-roving-tabindex.html
+++ b/build/review/radiogroup-roving-tabindex.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -730,7 +730,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -786,7 +786,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -876,7 +876,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -932,7 +932,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1078,7 +1078,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1168,7 +1168,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1224,7 +1224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1310,7 +1310,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1365,7 +1365,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1506,7 +1506,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1592,7 +1592,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1647,7 +1647,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1733,7 +1733,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1788,7 +1788,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1870,7 +1870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2002,7 +2002,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2084,7 +2084,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2164,7 +2164,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2216,7 +2216,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2298,7 +2298,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2380,7 +2380,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2432,7 +2432,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2514,7 +2514,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2596,7 +2596,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2648,7 +2648,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2730,7 +2730,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2783,7 +2783,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2865,7 +2865,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2918,7 +2918,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3000,7 +3000,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3052,7 +3052,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3134,7 +3134,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3186,7 +3186,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3257,7 +3257,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3328,7 +3328,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/tabs-manual-activation.html
+++ b/build/review/tabs-manual-activation.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -729,7 +729,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -818,7 +818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -905,7 +905,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -992,7 +992,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1050,7 +1050,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1108,7 +1108,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1191,7 +1191,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1274,7 +1274,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1327,7 +1327,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1405,7 +1405,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1483,7 +1483,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1533,7 +1533,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1614,7 +1614,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1695,7 +1695,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1747,7 +1747,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1828,7 +1828,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1880,7 +1880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1958,7 +1958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2008,7 +2008,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2084,7 +2084,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2210,7 +2210,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2260,7 +2260,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2333,7 +2333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2406,7 +2406,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2454,7 +2454,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2535,7 +2535,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2616,7 +2616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/toggle-button.html
+++ b/build/review/toggle-button.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-01-navigate-forwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +722,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-02-navigate-backwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-03-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-04-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -956,7 +956,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-05-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1007,7 +1007,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-06-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-07-navigate-forwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1140,7 +1140,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-08-navigate-backwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1222,7 +1222,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-09-navigate-forwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1298,7 +1298,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-10-navigate-backwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1374,7 +1374,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-11-navigate-forwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1425,7 +1425,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-12-navigate-backwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1476,7 +1476,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-13-read-information-about-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1554,7 +1554,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-14-read-information-about-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1632,7 +1632,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-15-read-information-about-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1682,7 +1682,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-16-read-information-about-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1760,7 +1760,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-17-read-information-about-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1838,7 +1838,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-18-read-information-about-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1888,7 +1888,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-19-operate-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1962,7 +1962,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-20-operate-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2036,7 +2036,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-21-operate-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2086,7 +2086,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-22-operate-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-23-operate-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2234,7 +2234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Jul 22 13:56:35 2021 -0500</li>
+        <li>Last edited: Tue Jul 27 11:31:03 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-24-operate-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/tests/resources/aria-at-harness.mjs
+++ b/build/tests/resources/aria-at-harness.mjs
@@ -1,20 +1,25 @@
-import {commandsAPI} from './at-commands.mjs';
+import {commandsAPI} from "./at-commands.mjs";
+import {element, fragment, property, attribute, className, style, focus, render} from "./vrender.mjs";
+import {
+  AssertionResultMap,
+  CommonResultMap,
+  createEnumMap,
+  HasUnexpectedBehaviorMap,
+  TestRun,
+  UserActionMap,
+  userCloseWindow,
+  userOpenWindow,
+  WhitespaceStyleMap,
+} from "./aria-at-test-run.mjs";
 
-const UNDESIRABLES = [
+const UNEXPECTED_BEHAVIORS = [
   "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
   "Reading cursor position changed in an unexpected manner",
   "Screen reader became extremely sluggish",
   "Screen reader crashed",
-  "Browser crashed"
+  "Browser crashed",
 ];
 
-const TEST_HTML_OUTLINE = `
-<div>
-  <section id='errors' style='display:none'><h2>Test cannot be performed due to error(s)!</h2><ul></ul><hr></section>
-  <section id='instructions'></section>
-  <section id='record-results'></section>
-</div>
-`;
 const PAGE_STYLES = `
   table {
     border-collapse: collapse;
@@ -72,362 +77,171 @@ const PAGE_STYLES = `
   }
 `;
 
-let behavior;
-let behaviorResults;
-let overallStatus;
+/** @type {string[]} */
 const errors = [];
-let testPageUri;
-let testPageWindow;
 let showResults = true;
 let showSubmitButton = true;
 
+/** @type {AT} */
 let at;
-let commandsData;
+/** @type {CommandsAPI} */
 let commapi;
-let support;
+/** @type {Behavior} */
+let behavior;
+/** @type {TestRunState} */
+let firstState;
 
+/**
+ * @param {Support} newSupport
+ * @param {Commands} newCommandsData
+ */
 export function initialize(newSupport, newCommandsData) {
-  support = newSupport;
-  commandsData = newCommandsData;
-  commapi = new commandsAPI(commandsData, support);
+  commapi = new commandsAPI(newCommandsData, newSupport);
 
   // Get the AT under test from the URL search params
   // set the showResults flag from the URL search params
-  let params = (new URL(document.location)).searchParams;
-  at = support.ats[0];
+  let params = new URL(document.location).searchParams;
+  at = newSupport.ats[0];
   for (const [key, value] of params) {
-    if (key === 'at') {
+    if (key === "at") {
       let requestedAT = value;
       if (commapi.isKnownAT(requestedAT)) {
         at = commapi.isKnownAT(requestedAT);
-      }
-      else {
-        errors.push(`Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`);
+      } else {
+        errors.push(
+          `Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`
+        );
       }
     }
-    if (key === 'showResults') {
-      if (value === 'true') {
+    if (key === "showResults") {
+      if (value === "true") {
         showResults = true;
-      } else if (value === 'false') {
+      } else if (value === "false") {
         showResults = false;
       }
     }
-    if (key === 'showSubmitButton') {
-      if (value === 'true') {
+    if (key === "showSubmitButton") {
+      if (value === "true") {
         showSubmitButton = true;
-      } else if (value === 'false') {
+      } else if (value === "false") {
         showSubmitButton = false;
       }
     }
   }
 }
 
-function openTestPagePopup() {
-  testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-  document.getElementById('open-test-page').disabled = true;
-
-  // If the window is closed, re-enable open popup button
-  testPageWindow.onunload = function(event) {
-    window.setTimeout(() => {
-      if (testPageWindow.closed) {
-        testPageWindow = undefined;
-        document.getElementById('open-test-page').disabled = false;
-      }
-    }, 100);
-
-  };
-
-  executeScriptInTestPage();
-}
-
-function putTestPageWindowIntoCorrectState() {
-  // testPageWindow.location.reload(); // TODO: Address the race condition this causes with script execution.
-  executeScriptInTestPage();
-}
-
-function executeScriptInTestPage() {
-  let setupTestPage = behavior.setupTestPage;
-  if (setupTestPage) {
-    if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-        || testPageWindow.document.readyState !== 'complete'
-    ) {
-      window.setTimeout(() => {
-        executeScriptInTestPage();
-      }, 100);
-      return;
-    }
-
-    scripts[behavior.setupTestPage](testPageWindow.document);
-  }
-}
-
+/**
+ * @param {BehaviorJSON} atBehavior
+ */
 export function verifyATBehavior(atBehavior) {
   // This is temporary until transition is complete from multiple modes to one mode
-  let mode = typeof atBehavior.mode === 'string' ? atBehavior.mode : atBehavior.mode[0];
+  let mode = typeof atBehavior.mode === "string" ? atBehavior.mode : atBehavior.mode[0];
 
-  let newBehavior = Object.assign({}, atBehavior, { mode: mode });
-  newBehavior.commands = commapi.getATCommands(mode, atBehavior.task, at);
+  /** @type {Behavior} */
+  behavior = {
+    description: document.title,
+    task: atBehavior.task,
+    mode,
+    modeInstructions: commapi.getModeInstructions(mode, at),
+    appliesTo: atBehavior.applies_to,
+    specificUserInstruction: atBehavior.specific_user_instruction,
+    setupScriptDescription: atBehavior.setup_script_description,
+    setupTestPage: atBehavior.setupTestPage,
+    commands: commapi.getATCommands(mode, atBehavior.task, at),
+    outputAssertions: atBehavior.output_assertions ? atBehavior.output_assertions : [],
+    additionalAssertions: atBehavior.additional_assertions ? atBehavior.additional_assertions[at.key] || [] : [],
+    unexpectedBehaviors: [
+      ...UNEXPECTED_BEHAVIORS.map(content => ({content})),
+      {content: "Other", requireExplanation: true},
+    ],
+  };
 
-  newBehavior.output_assertions = newBehavior.output_assertions ? newBehavior.output_assertions : [];
-  newBehavior.additional_assertions = newBehavior.additional_assertions
-    ? atBehavior.additional_assertions[at.key] || []
-    : [];
-  if (!behavior && newBehavior.commands.length) {
-    behavior = newBehavior;
+  if (!firstState && behavior.commands.length) {
+    firstState = initializeTestRunState({
+      errors: errors.length ? errors : null,
+      test: behavior,
+      config: {at, displaySubmitButton: showSubmitButton, renderResultsAfterSubmit: showResults},
+    });
   } else {
-    throw new Error('Test files should only contain one verifyATBehavior call.');
+    throw new Error("Test files should only contain one verifyATBehavior call.");
   }
 }
 
 export function displayTestPageAndInstructions(testPage) {
-  testPageUri = testPage;
-
-  if (document.readyState !== 'complete') {
+  if (document.readyState !== "complete") {
     window.setTimeout(() => {
       displayTestPageAndInstructions(testPage);
     }, 100);
     return;
   }
 
-  document.querySelector('html').setAttribute('lang', 'en');
-  document.body.innerHTML = (TEST_HTML_OUTLINE);
-  var style = document.createElement('style');
+  document.querySelector("html").setAttribute("lang", "en");
+  var style = document.createElement("style");
   style.innerHTML = PAGE_STYLES;
   document.head.appendChild(style);
 
-  showUserError();
-
-  displayInstructionsForBehaviorTest();
+  displayInstructionsForBehaviorTest(testPage, behavior);
 }
 
-function displayInstructionsForBehaviorTest() {
-
-  function getSetupInstructions() {
-    let html = '';
-    for (let i = 0; i < (userInstructions.length - 1); i++) {
-      html += `<li><em>${userInstructions[i]}</em></li>`;
-    }
-    return html;
-  }
+/**
+ * @param {string} testPage
+ * @param {Behavior} behavior
+ */
+function displayInstructionsForBehaviorTest(testPage, behavior) {
+  const windowManager = new TestWindow({
+    pageUri: testPage,
+    setupScriptName: behavior.setupTestPage,
+    scripts: typeof scripts === "object" ? scripts : {},
+    hooks: {
+      windowOpened() {
+        app.dispatch(userOpenWindow());
+      },
+      windowClosed() {
+        app.dispatch(userCloseWindow());
+      },
+    },
+  });
 
   // First, execute necesary set up script in test page if the test page is open from a previous behavior test
-  if (testPageWindow) {
-    putTestPageWindowIntoCorrectState();
-  }
+  windowManager.prepare();
 
-  const mode = behavior.mode;
-  const modeInstructions = commapi.getModeInstructions(mode, at);
-  const userInstructions = behavior.specific_user_instruction.split('|');
-  const lastInstruction = userInstructions[userInstructions.length-1];
-  const commands = behavior.commands;
-  const assertions = behavior.output_assertions.map((a) => a[1]);
-  const additionalBehaviorAssertions = behavior.additional_assertions;
-  const setupScriptDescription = behavior.setup_script_description ? ` and runs a script that ${behavior.setup_script_description}.` : behavior.setup_script_description;
-  // As a hack, special case mode instructions for VoiceOver for macOS until we support modeless tests.
-  // ToDo: remove this when resolving issue #194
-  const modePhrase = at.name === "VoiceOver for macOS" ? "Describe " : `With ${at.name} in ${mode} mode, describe `;
-
-  let instructionsEl = document.getElementById('instructions');
-  instructionsEl.innerHTML = `
-<h1 id="behavior-header" tabindex="0">Testing task: ${document.title}</h1>
-<p>${modePhrase} how ${at.name} behaves when performing task "${lastInstruction}"</p>
-<h2>Test instructions</h2>
-<ol aria-label="Instructions">
-  <li>Restore default settings for ${at.name}. For help, read <a href="https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing">Configuring Screen Readers for Testing</a>.</li>
-  <li>Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}</li>
-  <li id="mode-instructions-li"><em>${modeInstructions}</em></li>
-  ${getSetupInstructions()}
-  <li>Using the following commands, ${lastInstruction}
-    <ul id='at_controls' aria-label='Commands'>
-    </ul>
-  </li>
-</ol>
-<h3>Success Criteria</h3>
-<p>To pass this test, ${at.name} needs to meet all the following assertions when each  specified command is executed:</p>
-<ul id='assertions' aria-label="Assertions">
-</ul>
-`;
-
-  // Hack to remove mode instructions for VoiceOver for macOS to get us by until we support modeless screen readers.
-  // ToDo: remove this when resolving issue #194
-  if (at.name === "VoiceOver for macOS") {
-    let modeInstructionsEl= document.getElementById('mode-instructions-li');
-    modeInstructionsEl.parentNode.removeChild(modeInstructionsEl);
-  }
-
-  for (let command of commands) {
-    let commandEl = document.createElement('li');
-    commandEl.innerHTML = `${command}`;
-    document.getElementById('at_controls').append(commandEl);
-  }
-
-  for (let assertion of assertions) {
-    let el = document.createElement('li');
-    el.innerHTML = `<em>${assertion}</em>`;
-    document.getElementById('assertions').append(el);
-  }
-
-  for (let additional of additionalBehaviorAssertions) {
-    let el = document.createElement('li');
-    el.innerHTML = `<em>${additional[1]}</em>`;
-    document.getElementById('assertions').append(el);
-  }
-
-  let openButton = document.createElement('button');
-  openButton.id = 'open-test-page';
-  openButton.innerText = "Open Test Page";
-  openButton.addEventListener('click', openTestPagePopup);
-  if (testPageWindow) {
-    openButton.disabled = true;
-  }
-  document.getElementById('instructions').append(openButton);
-
-  let recordResults = `<h2>Record Results</h2><p>${document.title}</p>`;
-
-  for (let c = 0; c < commands.length; c++) {
-    recordResults += `<section id="cmd-${c}-section"><h3 id="header-cmd-${c}">After '${commands[c]}'</h3>`;
-    recordResults += `
-<p id="cmd-${c}-output">
-  <label for="speechoutput-${c}">${at.name} output after ${commands[c]} <span class="required">(required)</span>:</label>
-    <textarea id="speechoutput-${c}"></textarea>
-</p>
-`;
-
-    recordResults += `<table id="cmd-${c}" class="record-results">
-<tr>
-  <th>Assertion</th>
-  <th>
-    Success case
-  </th>
-  <th>
-    Failure cases
-  </th>
-</tr>
-`;
-
-    for (let a = 0; a < assertions.length; a++) {
-      recordResults += `
-<tr>
-  <td id="assertion-${c}-${a}"><div class="assertion">${assertions[a]}</div><div class="required">(required: mark output)</div></td>
-  <td>
-      <input type="radio" id="pass-${c}-${a}" class="pass" name="result-${c}-${a}" aria-labelledby="pass-${c}-${a}-label assertion-${c}-${a}">
-      <label id="pass-${c}-${a}-label">Good Output <span class="off-screen">for assertion</span></label>
-  </td>
-  <td>
-      <input type="radio" id="missing-${c}-${a}" class="missing" name="result-${c}-${a}" aria-labelledby="missing-${c}-${a}-label assertion-${c}-${a}">
-      <label id="missing-${c}-${a}-label">No Output <span class="off-screen">for assertion</span></label>
-      <input type="radio" id="fail-${c}-${a}" class="fail" name="result-${c}-${a}" aria-labelledby="fail-${c}-${a}-label assertion-${c}-${a}">
-      <label id="fail-${c}-${a}-label">Incorrect Output <span class="off-screen">for assertion</span></label>
-  </td>
-</tr>
-`;
-    }
-
-    for (let n = 0; n < additionalBehaviorAssertions.length; n++) {
-      let a = assertions.length + n;
-      recordResults += `
-<tr>
-  <td id="assertion-${c}-${a}"><div class="assertion">${additionalBehaviorAssertions[n][1]}</div><div class="required">(required: mark support)</div></td>
-  <td>
-      <input type="radio" id="pass-${c}-${a}" class="pass" name="result-${c}-${a}" aria-labelledby="pass-${c}-${a}-label assertion-${c}-${a}">
-      <label id="pass-${c}-${a}-label">Good Support <span class="off-screen">for assertion</span></label>
-  </td>
-  <td>
-      <input type="radio" id="fail-${c}-${a}" class="fail" name="result-${c}-${a}" aria-labelledby="fail-${c}-${a}-label assertion-${c}-${a}">
-      <label id="fail-${c}-${a}-label">No Support <span class="off-screen">for assertion</span></label>
-  </td>
-</tr>
-`;
-    }
-
-    recordResults += '</table>';
-
-    recordResults += `
-  <fieldset id="cmd-${c}-problem">
-Were there additional undesirable behaviors? <span class="required">(required)</span>
-<div>
-  <input type="radio" id="problem-${c}-false" class="pass" name="problem-${c}">
-  <label for="problem-${c}-false">No, there were no additional undesirable behaviors.</label>
-</div>
-<div>
-  <input type="radio" id="problem-${c}-true" class="fail" name="problem-${c}">
-  <label for="problem-${c}-true">Yes, there were additional undesirable behaviors</label>
-</div>
-  <fieldset class="problem-select" id="cmd-${c}-problem-checkboxes">
-  <legend>Undesirable behaviors<span class="required"> (required)<span></legend>
-`;
-
-  for (let undesirable of UNDESIRABLES) {
-    const string = `
-      <input type="checkbox" value="${undesirable}" id="${undesirable}-${c}" class="undesirable-${c}" tabindex="-1" disabled>
-      <label for="${undesirable}-${c}">${undesirable}</label>
-      <br>
-     `;
-    recordResults += string;
-  }
-
-  recordResults += `
-     <input type="checkbox" value="Other" id="undesirable-${c}-other" name="undesirable-${c}-other" class="undesirable-${c}" tabindex="-1">
-     <label for="undesirable-${c}-other">Other</label>
-     </br>
-     <div>
-       <label for="undesirable-${c}-other-input">If "other" selected, explain <span class="required-other">(required)</span>:</label>
-       <input type="text" name="undesirable-${c}-other-input" id="undesirable-${c}-other-input" class="undesirable-other-input" disabled>
-     </div>
-  </div>
-</fieldset>
-`;
-
-    recordResults += `</section>`;
-  }
-
-  let recordEl = document.getElementById('record-results');
-  recordEl.innerHTML = recordResults;
-
-  let radios = document.querySelectorAll('input[type="radio"]');
-  for (let radio of radios) {
-    radio.onclick = handleRadioClick;
-  }
-
-  let checkboxes = document.querySelectorAll('input[type=checkbox]');
-  for (let checkbox of checkboxes) {
-    checkbox.onchange = handleUndesirableSelect;
-    checkbox.addEventListener('keydown', handleUndesirableKeydown);
-  }
-
-  let otherUndesirableInput = document.querySelectorAll('.undesirable-other-input');
-  for (let otherInput of otherUndesirableInput) {
-    otherInput.addEventListener('change', handleOtherUndesirableInput);
-  }
-
-  if (showSubmitButton) {
-    // Submit button
-    let el = document.createElement('button');
-    el.id = 'submit-results';
-    el.innerText = 'Submit Results';
-    el.addEventListener('click', submitResult);
-    recordEl.append(el);
-  }
-
-  document.querySelector('#behavior-header').focus();
+  const app = new TestRunExport({
+    behavior,
+    hooks: {
+      openTestPage() {
+        windowManager.open();
+      },
+      closeTestPage() {
+        windowManager.close();
+      },
+      postResults: () => postResults(app),
+    },
+    state: firstState,
+  });
+  app.observe(() => {
+    render(document.body, renderVirtualTestPage(app.testPageAndResults()));
+  });
+  render(document.body, renderVirtualTestPage(app.testPageAndResults()));
 
   // if test is loaded in iFrame
   if (window.parent && window.parent.postMessage) {
     // results can be submitted by parent posting a message to the
     // iFrame with a data.type property of 'submit'
-    window.addEventListener('message', function(message) {
-      if (!validateMessage(message, 'submit')) return;
-      submitResult();
+    window.addEventListener("message", function (message) {
+      if (!validateMessage(message, "submit")) return;
+      app.hooks.submit();
     });
 
     // send message to parent that test has loaded
-    window.parent.postMessage({
-      type: 'loaded',
-      data: {
-        testPageUri: testPageUri
-      }
-    }, '*');
+    window.parent.postMessage(
+      {
+        type: "loaded",
+        data: {
+          testPageUri: windowManager.pageUri,
+        },
+      },
+      "*"
+    );
   }
 }
 
@@ -435,7 +249,7 @@ function validateMessage(message, type) {
   if (window.location.origin !== message.origin) {
     return false;
   }
-  if (!message.data || typeof message.data !== 'object') {
+  if (!message.data || typeof message.data !== "object") {
     return false;
   }
   if (message.data.type !== type) {
@@ -444,417 +258,882 @@ function validateMessage(message, type) {
   return true;
 }
 
-function handleUndesirableSelect(event) {
-  let radioId = event.target.id;
-  let cmdId, otherSelected;
-  if (radioId) {
-    cmdId = Number(radioId.split('-')[1]);
-    otherSelected = document.querySelector(`#undesirable-${cmdId}-other`);
-    if (otherSelected && otherSelected.checked == true) {
-      document.querySelector(`#undesirable-${cmdId}-other-input`).disabled = false;
-    } else {
-      document.querySelector(`#undesirable-${cmdId}-other-input`).disabled = true;
-      document.querySelector(`#undesirable-${cmdId}-other-input`).value = '';
-    }
-  }
-
-  // Handle any checkbox selected
-  let radioName = event.target.name;
-  if (radioName) {
-    cmdId = Number(radioName.split('-')[1]);
-    document.querySelector(`#problem-${cmdId}-true`).checked = true;
-  }
-}
-
-function handleOtherUndesirableInput(event) {
-  let inputId = event.target.id;
-  let cmd = inputId.split('-')[1];
-
-  let otherCheckbox = document.querySelector(`#undesirable-${cmd}-other`);
-  if (event.target.value) {
-    otherCheckbox.checked = true;
-  }
-  else {
-    otherCheckbox.checked = false;
-  }
-}
-
-function handleRadioClick(event) {
-  let radioId = event.target.id;
-  let cmdId = Number(radioId.split('-')[1]);
-
-  let markedAs = radioId.split('-')[2];
-  let checkboxes = document.querySelectorAll(`.undesirable-${cmdId}`);
-  let otherInput = document.querySelector(`#undesirable-${cmdId}-other-input`);
-  if (markedAs === 'true') {
-    checkboxes[0].tabIndex = 0;
-    for (let checkbox of checkboxes) {
-      checkbox.disabled = false;
-    }
-    otherInput.disabled = false;
-  } else {
-    for (let checkbox of checkboxes) {
-      checkbox.disabled = true;
-      checkbox.checked = false;
-    }
-    otherInput.disabled = true;
-    otherInput.value = '';
-  }
-}
-
-function handleUndesirableKeydown(event) {
-  var checkbox = event.currentTarget,
-    flag = false;
-
-  switch (event.key) {
-    case 'Up':
-    case 'ArrowUp':
-    case 'Left':
-    case 'ArrowLeft':
-      setFocusToPreviousItem(checkbox);
-      flag = true;
-      break;
-
-    case 'Down':
-    case 'ArrowDown':
-    case 'Right':
-    case 'ArrowRight':
-      setFocusToNextItem(checkbox);
-      flag = true;
-      break;
-
-    default:
-      break;
-  }
-
-  if (flag) {
-    event.stopPropagation();
-    event.preventDefault();
-  }
-}
-
-function setFocusToPreviousItem(checkbox) {
-  let cmd = checkbox.parentElement.id.split('-')[1];
-  let checkboxNodes = document.querySelectorAll(`#cmd-${cmd}-problem input[type=checkbox]`);
-  let checkboxes = Array.from(checkboxNodes);
-
-  let checkboxIds = checkboxes.map(c => c.id);
-  let index = checkboxIds.indexOf(checkbox.id);
-
-  checkboxNodes[index].tabIndex = -1;
-
-  if (index === 0) {
-    checkboxNodes[checkboxes.length - 1].tabIndex = 0;
-    checkboxNodes[checkboxes.length - 1].focus();
-  }
-  else {
-    checkboxNodes[index - 1].tabIndex = 0;
-    checkboxNodes[index - 1].focus();
-  }
-}
-
-function setFocusToNextItem(checkbox) {
-  let cmd = checkbox.parentElement.id.split('-')[1];
-  let checkboxNodes = document.querySelectorAll(`#cmd-${cmd}-problem input[type=checkbox]`);
-  let checkboxes = Array.from(checkboxNodes);
-
-  let checkboxIds = checkboxes.map(c => c.id);
-  let index = checkboxIds.indexOf(checkbox.id);
-
-  checkboxNodes[index].tabIndex = -1;
-  index++;
-
-  if (index === checkboxes.length) {
-    checkboxNodes[0].tabIndex = 0;
-    checkboxNodes[0].focus();
-  }
-  else {
-    checkboxNodes[index].tabIndex = 0;
-    checkboxNodes[index].focus();
-  }
-}
-
-function validateResults() {
-
-  let focusEl;
-  for (let c = 0; c < behavior.commands.length; c++) {
-
-    // If there is no output recorded, mark the screen reader output as required
-   let outputParagraph = document.getElementById(`cmd-${c}-output`);
-   let cmdInput = outputParagraph.querySelector('textarea');
-    if (!cmdInput.value) {
-      focusEl = focusEl || cmdInput;
-      outputParagraph.querySelector('.required').classList.add('highlight-required');
-    } else {
-      outputParagraph.querySelector('.required').classList.remove('highlight-required');
-    }
-
-    // If "all pass" is selected, remove "required" mark any remaining assertions (because they will
-    // all have been marked as passing, now) and move to the next command
-
-    let numAssertions = document.getElementById(`cmd-${c}`).rows.length - 1;
-    let undesirableFieldset = document.getElementById(`cmd-${c}-problem`);
-
-    // Otherwise, we must go though each assertion and add or remove the "required" mark
-    for (let a = 0; a < numAssertions; a++) {
-      let selectedRadio = document.querySelector(`input[name="result-${c}-${a}"]:checked`);
-      if (!selectedRadio) {
-        document.querySelector(`#assertion-${c}-${a} .required`).classList.add('highlight-required');
-        focusEl = focusEl || document.getElementById(`pass-${c}-${a}`);
-      }
-      else {
-        document.querySelector(`#assertion-${c}-${a} .required`).classList.remove('highlight-required');
-      }
-    }
-
-
-    // Check that the "unexpected/additional problems" fieldset is filled out
-    let problemRadio = document.querySelector(`input[name="problem-${c}"]:checked`);
-    let problemSelected = document.querySelectorAll(`.undesirable-${c}:checked`);
-    let otherSelected = document.querySelector(`#undesirable-${c}-other:checked`);
-    let otherText = document.querySelector(`#undesirable-${c}-other-input`).value;
-    if (!problemRadio || (problemRadio.classList.contains('fail') && problemSelected.length === 0 && !otherSelected)) {
-        undesirableFieldset.classList.add('highlight-required');
-    }
-    if (!problemRadio || (problemRadio.classList.contains('fail') && problemSelected.length === 0 && !otherSelected)) {
-      document.querySelector(`#cmd-${c}-problem legend .required`).classList.add('highlight-required');
-      focusEl = focusEl || document.querySelector(`#cmd-${c}-problem input[type="checkbox"]`);
-    }
-    else if (document.querySelector(`input#problem-${c}-false:checked`) || (problemRadio && problemSelected.length > 0) || (otherSelected && otherText)) {
-      document.querySelector(`#cmd-${c}-problem legend .required`).classList.remove('highlight-required');
-      undesirableFieldset.classList.remove('highlight-required');
-    }
-
-    if (otherSelected) {
-      if (!otherText) {
-        document.querySelector(`#cmd-${c}-problem .required-other`).classList.add('highlight-required');
-        undesirableFieldset.classList.add('highlight-required');
-        focusEl = focusEl || document.querySelector(`#undesirable-${c}-other-input`);
-      }
-      else {
-        document.querySelector(`#cmd-${c}-problem .required-other`).classList.remove('highlight-required');
-        undesirableFieldset.classList.remove('highlight-required');
-      }
-    }
-  }
-
-  if (focusEl) {
-    focusEl.focus();
-    return false;
-  }
-  return true;
-}
-
-
-function submitResult(event) {
-  if (!validateResults()) {
-    return;
-  }
-
-  const assertionPriority = {};
-  for (let a = 0; a < behavior.output_assertions.length; a++) {
-    const assertion = behavior.output_assertions[a];
-    assertionPriority[assertion[1]] = assertion[0];
-  }
-
-  for (let a = 0; a < behavior.additional_assertions.length; a++) {
-    const assertion = behavior.additional_assertions[a];
-    assertionPriority[assertion[1]] = assertion[0];
-  }
-
-  const summary = {
-    1: {pass: 0, fail: 0},
-    2: {pass: 0, fail: 0},
-    unexpectedCount: 0
-  };
-
-  overallStatus = 'PASS';
-
-  const commandResults = [];
-
-  for (let c = 0; c < behavior.commands.length; c++) {
-
-    let assertions = [];
-    let support = 'FULL';
-    let totalAssertions = document.querySelectorAll(`#cmd-${c} tr`).length - 1;
-
-    for (let a = 0; a < totalAssertions; a++) {
-      const assertion = document.querySelector(`#assertion-${c}-${a} .assertion`).innerHTML;
-      const resultEl = document.querySelector(`input[name="result-${c}-${a}"]:checked`);
-      const resultId = resultEl.id;
-      const pass = resultEl.classList.contains('pass');
-      const result = document.querySelector(`#${resultId}-label`).innerHTML.split('<span')[0];
-      const priority = assertionPriority[assertion];
-
-      let assertionResult = {
-        assertion,
-        priority
-      };
-
-      if (pass) {
-        assertionResult.pass = result;
-        summary[priority].pass++;
-      }
-      else {
-        assertionResult.fail = result;
-        summary[priority].fail++;
-
-        // If any priority 1 assertion fails, the test fails for this command
-        if (priority === 1) {
-          support = 'FAILING';
-          overallStatus = 'FAIL';
-        }
-        // If any only a priority >1 assertion fails, then this test meets the all required pass case
-        else if (support !== 'FAILING') {
-          support = 'ALL REQUIRED';
-        }
-      }
-
-      assertions.push(assertionResult);
-    }
-
-    const unexpected = [];
-    for (let problemEl of document.querySelectorAll(`#cmd-${c}-problem fieldset input:checked`)) {
-      support = 'FAILING';
-      overallStatus = 'FAIL';
-      summary.unexpectedCount++;
-      if (problemEl.value === 'Other') {
-        unexpected.push(document.querySelector(`#undesirable-${c}-other-input`).value);
-      }
-      else {
-        unexpected.push(problemEl.value);
-      }
-    }
-
-    commandResults.push({
-      command: behavior.commands[c],
-      output: document.querySelector(`#speechoutput-${c}`).value,
-      unexpected_behaviors: unexpected,
-      support,
-      assertions
-    });
-  }
-
-  behaviorResults = {
-    name: document.title,
-    specific_user_instruction: behavior.specific_user_instruction,
-    task: behavior.task,
-    commands: commandResults,
-    summary
-  };
-
-  let data = {
-    test: document.title,
-    details: behaviorResults,
-    status: overallStatus
-  };
-
+/**
+ * @param {TestRunExport} app
+ */
+function postResults(app) {
   // send message to parent if test is loaded in iFrame
   if (window.parent && window.parent.postMessage) {
-    window.parent.postMessage({
-      type: 'results',
-      data: data
-    }, '*');
+    window.parent.postMessage(
+      {
+        type: "results",
+        data: app.resultsJSON(),
+      },
+      "*"
+    );
   }
-
-  endTest();
-
-  if (showResults) {
-    showResultsTable();
-  }
-
-  appendJSONResults(data);
 }
 
+/** @typedef {ConstructorParameters<typeof TestRun>[0]} TestRunOptions */
+/**
+ * @typedef TestRunExportOptions
+ * @property {Behavior} behavior
+ */
 
-function showResultsTable() {
-  let resulthtml = `<h1>${document.title}</h1><h2 id=overallstatus></h2>`;
+class TestRunExport extends TestRun {
+  /**
+   * @param {TestRunOptions & TestRunExportOptions} options
+   */
+  constructor({behavior, ...parentOptions}) {
+    super(parentOptions);
 
-  resulthtml += `<table>
-    <tr>
-      <th>Command</th>
-      <th>Support</th>
-      <th>Details</th>
-    </tr>
-  `;
+    this.behavior = behavior;
+  }
 
-  for (let command of behaviorResults.commands) {
+  testPageAndResults() {
+    const testPage = this.testPage();
+    if ("results" in testPage) {
+      return {
+        ...testPage,
+        resultsJSON: this.resultsJSON(),
+      };
+    }
+    return {
+      ...testPage,
+      resultsJSON: this.state.currentUserAction === UserActionMap.CLOSE_TEST_WINDOW ? this.resultsJSON() : null,
+    };
+  }
 
-      let passingAssertions = '';
-      let failingAssertions = '';
-      for (let assertion of command.assertions) {
-        if (assertion.pass) {
-          passingAssertions += `<li>${assertion.assertion}</li>`;
+  resultsJSON() {
+    return toSubmitResultJSON(this.state, this.behavior);
+  }
+}
+
+class TestWindow {
+  /**
+   * @param {object} options
+   * @param {Window | null} [options.window]
+   * @param {string} options.pageUri
+   * @param {string} [options.setupScriptName]
+   * @param {TestWindowHooks} [options.hooks]
+   * @param {SetupScripts} [options.scripts]
+   */
+  constructor({window = null, pageUri, setupScriptName, hooks, scripts = {}}) {
+    /** @type {Window | null} */
+    this.window = window;
+
+    /** @type {string} */
+    this.pageUri = pageUri;
+
+    /** @type {string} */
+    this.setupScriptName = setupScriptName;
+
+    /** @type {TestWindowHooks} */
+    this.hooks = {
+      windowOpened: () => {},
+      windowClosed: () => {},
+      ...hooks,
+    };
+
+    /** @type {SetupScripts} */
+    this.scripts = scripts;
+  }
+
+  open() {
+    this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
+
+    this.hooks.windowOpened();
+
+    // If the window is closed, re-enable open popup button
+    this.window.onunload = () => {
+      window.setTimeout(() => {
+        if (this.window.closed) {
+          this.window = undefined;
+
+          this.hooks.windowClosed();
         }
-        if (assertion.fail) {
-          failingAssertions += `<li>${assertion.assertion}</li>`;
-        }
-      }
-      let unexpectedBehaviors = '';
-      for (let unexpected of command.unexpected_behaviors) {
-        unexpectedBehaviors += `<li>${unexpected}</li>`;
-      }
-      passingAssertions = passingAssertions === '' ? '<li>No passing assertions.</li>' : passingAssertions;
-      failingAssertions = failingAssertions === '' ? '<li>No failing assertions.</li>' : failingAssertions;
-      unexpectedBehaviors = unexpectedBehaviors === '' ? '<li>No unexpect behaviors.</li>' : unexpectedBehaviors;
+      }, 100);
+    };
 
+    this.prepare();
+  }
 
-      resulthtml+= `
-<tr>
-  <td>${command.command}</td>
-  <td>${command.support}</td>
-  <td>
-    <p>${at.name} output:<br> "${command.output.replace(/(?:\r\n|\r|\n)/g, '<br>')}"</p>
-    <div>Passing Assertions:
-      <ul>
-      ${passingAssertions}
-      </ul>
-    </div>
-    <div>Failing Assertions:
-      <ul>
-      ${failingAssertions}
-      </ul>
-    </div>
-    <div>Unexpected Behavior:
-      <ul>
-      ${unexpectedBehaviors}
-      </ul>
-    </div>
-  </td>
-</tr>
-`;
-
+  prepare() {
+    if (!this.window) {
+      return;
     }
 
-  resulthtml += `</table>`;
+    let setupScriptName = this.setupScriptName;
+    if (!setupScriptName) {
+      return;
+    }
+    if (
+      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
+      this.window.document.readyState !== "complete"
+    ) {
+      window.setTimeout(() => {
+        this.prepare();
+      }, 100);
+      return;
+    }
 
-  document.body.innerHTML = resulthtml;
-  document.querySelector('#overallstatus').innerHTML = `Test result: ${overallStatus}`;
-}
-
-function endTest() {
-  if (typeof testPageWindow !== 'undefined') {
-    testPageWindow.close();
+    this.scripts[setupScriptName](this.window.document);
   }
-}
 
-function showUserError() {
-  if (errors.length) {
-    document.getElementById('errors').style.display = "block";
-    let errorListEl = document.querySelector('#errors ul');
-    for (let error of errors) {
-      let errorMsgEl = document.createElement('li');
-      errorMsgEl.innerText = error;
-      errorListEl.append(errorMsgEl);
+  close() {
+    if (this.window) {
+      this.window.close();
     }
   }
 }
 
-function appendJSONResults(data) {
-  var results_element = document.createElement("script");
-  results_element.type = "text/json";
-  results_element.id = "__ariaatharness__results__";
-  results_element.textContent = JSON.stringify(data);
-
-  document.body.appendChild(results_element);
+function bind(fn, ...args) {
+  return (...moreArgs) => fn(...args, ...moreArgs);
 }
+
+/**
+ * @param {object} options
+ * @param {string[] | null} [options.errors]
+ * @param {Behavior} options.test
+ * @param {object} options.config
+ * @param {AT} options.config.at
+ * @param {boolean} [options.config.displaySubmitButton]
+ * @param {boolean} [options.config.renderResultsAfterSubmit]
+ * @returns {TestRunState}
+ */
+function initializeTestRunState({
+  errors = null,
+  test,
+  config: {at, displaySubmitButton = true, renderResultsAfterSubmit = true},
+}) {
+  return {
+    errors,
+    info: {
+      description: test.description,
+      task: test.task,
+      mode: test.mode,
+      modeInstructions: test.modeInstructions,
+      userInstructions: test.specificUserInstruction.split("|"),
+      setupScriptDescription: test.setupScriptDescription,
+    },
+    config: {
+      at,
+      displaySubmitButton,
+      renderResultsAfterSubmit,
+    },
+    currentUserAction: UserActionMap.LOAD_PAGE,
+    openTest: {
+      enabled: true,
+    },
+    commands: test.commands.map(
+      command =>
+        /** @type {TestRunCommand} */ ({
+          description: command,
+          atOutput: {
+            highlightRequired: false,
+            value: "",
+          },
+          assertions: test.outputAssertions.map(assertion => ({
+            description: assertion[1],
+            highlightRequired: false,
+            priority: Number(assertion[0]),
+            result: CommonResultMap.NOT_SET,
+          })),
+          additionalAssertions: test.additionalAssertions.map(assertion => ({
+            description: assertion[1],
+            highlightRequired: false,
+            priority: Number(assertion[0]),
+            result: CommonResultMap.NOT_SET,
+          })),
+          unexpected: {
+            highlightRequired: false,
+            hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
+            tabbedBehavior: 0,
+            behaviors: test.unexpectedBehaviors.map(({content: description, requireExplanation}) => ({
+              description,
+              checked: false,
+              more: requireExplanation ? {highlightRequired: false, value: ""} : null,
+            })),
+          },
+        })
+    ),
+  };
+}
+
+const a = bind(element, "a");
+const br = bind(element, "br");
+const button = bind(element, "button");
+const div = bind(element, "div");
+const em = bind(element, "em");
+const fieldset = bind(element, "fieldset");
+const h1 = bind(element, "h1");
+const h2 = bind(element, "h2");
+const h3 = bind(element, "h3");
+const hr = bind(element, "hr");
+const input = bind(element, "input");
+const label = bind(element, "label");
+const legend = bind(element, "legend");
+const li = bind(element, "li");
+const ol = bind(element, "ol");
+const p = bind(element, "p");
+const script = bind(element, "script");
+const section = bind(element, "section");
+const span = bind(element, "span");
+const table = bind(element, "table");
+const td = bind(element, "td");
+const textarea = bind(element, "textarea");
+const th = bind(element, "th");
+const tr = bind(element, "tr");
+const ul = bind(element, "ul");
+
+const forInput = bind(attribute, "for");
+const href = bind(attribute, "href");
+const id = bind(attribute, "id");
+const name = bind(attribute, "name");
+const tabIndex = bind(attribute, "tabindex");
+const textContent = bind(attribute, "textContent");
+const type = bind(attribute, "type");
+
+const value = bind(property, "value");
+const checked = bind(property, "checked");
+const disabled = bind(property, "disabled");
+
+/** @type {(cb: (ev: MouseEvent) => void) => any} */
+const onclick = bind(property, "onclick");
+/** @type {(cb: (ev: InputEvent) => void) => any} */
+const onchange = bind(property, "onchange");
+/** @type {(cb: (ev: KeyboardEvent) => void) => any} */
+const onkeydown = bind(property, "onkeydown");
+
+/**
+ * @param {Description} value
+ */
+function rich(value) {
+  if (typeof value === "string") {
+    return value;
+  } else if (Array.isArray(value)) {
+    return fragment(...value.map(rich));
+  } else {
+    if ("whitespace" in value) {
+      if (value.whitespace === WhitespaceStyleMap.LINE_BREAK) {
+        return br();
+      }
+      return null;
+    }
+    return (value.href ? a.bind(null, href(value.href)) : span)(
+      className([
+        value.offScreen ? "off-screen" : "",
+        value.required ? "required" : "",
+        value.highlightRequired ? "highlight-required" : "",
+      ]),
+      rich(value.description)
+    );
+  }
+}
+
+/**
+ * @param {TestPageAndResultsDocument} doc
+ */
+function renderVirtualTestPage(doc) {
+  return fragment(
+    "instructions" in doc
+      ? div(
+          section(
+            id("errors"),
+            style({display: doc.errors ? "block" : "none"}),
+            h2("Test cannot be performed due to error(s)!"),
+            ul(...(doc.errors ? doc.errors.map(error => li(error)) : [])),
+            hr()
+          ),
+          section(id("instructions"), renderVirtualInstructionDocument(doc.instructions)),
+          section(id("record-results"))
+        )
+      : null,
+    "results" in doc ? renderVirtualResultsTable(doc.results) : null,
+    doc.resultsJSON
+      ? script(type("text/json"), id("__ariaatharness__results__"), textContent(JSON.stringify(doc.resultsJSON)))
+      : null
+  );
+}
+
+/**
+ * @param doc {InstructionDocument}
+ */
+function renderVirtualInstructionDocument(doc) {
+  function compose(...fns) {
+    return around => fns.reduceRight((carry, fn) => fn(carry), around);
+  }
+
+  const map = (ary, el) => ary.map(item => el(item));
+
+  return div(
+    instructionHeader(doc.instructions),
+
+    instructCommands(doc.instructions.instructions),
+
+    instructAssertions(doc.instructions.assertions),
+
+    button(
+      disabled(!doc.instructions.openTestPage.enabled),
+      onclick(doc.instructions.openTestPage.click),
+      rich(doc.instructions.openTestPage.button)
+    ),
+
+    resultHeader(doc.results.header),
+
+    section(...doc.results.commands.map(commandResult)),
+
+    doc.submit ? button(onclick(doc.submit.click), rich(doc.submit.button)) : null
+  );
+
+  /**
+   * @param {InstructionDocumentResultsHeader} param0
+   */
+  function resultHeader({header, description}) {
+    return fragment(h2(rich(header)), p(rich(description)));
+  }
+
+  /**
+   * @param {InstructionDocumentResultsCommand} command
+   * @param {number} commandIndex
+   */
+  function commandResult(command, commandIndex) {
+    return fragment(
+      h3(rich(command.header)),
+      p(
+        label(rich(command.atOutput.description)),
+        textarea(
+          value(command.atOutput.value),
+          focus(command.atOutput.focus),
+          onchange(ev => command.atOutput.change(/** @type {HTMLInputElement} */ (ev.currentTarget).value))
+        )
+      ),
+      table(
+        tr(
+          th(rich(command.assertionsHeader.descriptionHeader)),
+          th(rich(command.assertionsHeader.passHeader)),
+          th(rich(command.assertionsHeader.failHeader))
+        ),
+        ...command.assertions.map(bind(commandResultAssertion, commandIndex))
+      ),
+      ...[command.unexpectedBehaviors].map(bind(commandResultUnexpectedBehavior, commandIndex))
+    );
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {InstructionDocumentResultsCommandsUnexpected} unexpected
+   */
+  function commandResultUnexpectedBehavior(commandIndex, unexpected) {
+    return fieldset(
+      id(`cmd-${commandIndex}-problem`),
+      rich(unexpected.description),
+      div(radioChoice(`problem-${commandIndex}-true`, `problem-${commandIndex}`, unexpected.passChoice)),
+      div(radioChoice(`problem-${commandIndex}-false`, `problem-${commandIndex}`, unexpected.failChoice)),
+      fieldset(
+        className(["problem-select"]),
+        id(`cmd-${commandIndex}-problem-checkboxes`),
+        legend(rich(unexpected.failChoice.options.header)),
+        ...unexpected.failChoice.options.options.map(failOption =>
+          fragment(
+            input(
+              type("checkbox"),
+              value(failOption.description),
+              id(`${failOption.description}-${commandIndex}`),
+              className([`undesirable-${commandIndex}`]),
+              tabIndex(failOption.tabbable ? "0" : "-1"),
+              disabled(!failOption.enabled),
+              checked(failOption.checked),
+              focus(failOption.focus),
+              onchange(ev => failOption.change(/** @type {HTMLInputElement} */ (ev.currentTarget).checked)),
+              onkeydown(ev => {
+                if (failOption.keydown(ev.key)) {
+                  ev.stopPropagation();
+                  ev.preventDefault();
+                }
+              })
+            ),
+            label(forInput(`${failOption.description}-${commandIndex}`), rich(failOption.description)),
+            br(),
+            failOption.more
+              ? div(
+                  label(forInput(`${failOption.description}-${commandIndex}-input`), rich(failOption.more.description)),
+                  input(
+                    type("text"),
+                    id(`${failOption.description}-${commandIndex}-input`),
+                    name(`${failOption.description}-${commandIndex}-input`),
+                    className(["undesirable-other-input"]),
+                    disabled(!failOption.more.enabled),
+                    value(failOption.more.value),
+                    onchange(ev => failOption.more.change(/** @type {HTMLInputElement} */ (ev.currentTarget).value))
+                  )
+                )
+              : fragment()
+          )
+        )
+      )
+    );
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {InstructionDocumentResultsCommandsAssertion} assertion
+   * @param {number} assertionIndex
+   */
+  function commandResultAssertion(commandIndex, assertion, assertionIndex) {
+    return tr(
+      td(rich(assertion.description)),
+      td(
+        ...[assertion.passChoice].map(choice =>
+          radioChoice(`pass-${commandIndex}-${assertionIndex}`, `result-${commandIndex}-${assertionIndex}`, choice)
+        )
+      ),
+      td(
+        ...assertion.failChoices.map((choice, failIndex) =>
+          radioChoice(
+            `${failIndex === 0 ? "missing" : "fail"}-${commandIndex}-${assertionIndex}`,
+            `result-${commandIndex}-${assertionIndex}`,
+            choice
+          )
+        )
+      )
+    );
+  }
+
+  /**
+   * @param {string} idKey
+   * @param {string} nameKey
+   * @param {InstructionDocumentAssertionChoice} choice
+   */
+  function radioChoice(idKey, nameKey, choice) {
+    return fragment(
+      input(
+        type("radio"),
+        id(idKey),
+        name(nameKey),
+        checked(choice.checked),
+        focus(choice.focus),
+        onclick(choice.click)
+      ),
+      label(id(`${idKey}-label`), forInput(`${idKey}`), rich(choice.label))
+    );
+  }
+
+  /**
+   * @param {InstructionDocumentInstructionsInstructions} param0
+   * @returns
+   */
+  function instructCommands({header, instructions, strongInstructions: boldInstructions, commands}) {
+    return fragment(
+      h2(rich(header)),
+      ol(
+        ...map(instructions, compose(li, rich)),
+        ...map(boldInstructions, compose(li, em, rich)),
+        li(rich(commands.description), ul(...map(commands.commands, compose(li, em, rich))))
+      )
+    );
+  }
+
+  /**
+   * @param {InstructionDocumentInstructions} param0
+   */
+  function instructionHeader({header, description}) {
+    return fragment(
+      h1(id("behavior-header"), tabIndex("0"), focus(header.focus), rich(header.header)),
+      p(rich(description))
+    );
+  }
+
+  /**
+   * @param {InstructionDocumentInstructionsAssertions} param0
+   */
+  function instructAssertions({header, description, assertions}) {
+    return fragment(h2(rich(header)), p(rich(description)), ol(...map(assertions, compose(li, em, rich))));
+  }
+}
+
+/**
+ * @param {ResultsTableDocument} results
+ */
+function renderVirtualResultsTable(results) {
+  return fragment(
+    h1(rich(results.header)),
+    h2(id("overallstatus"), rich(results.status.header)),
+
+    table(
+      (({description, support, details}) => tr(th(description), th(support), th(details)))(results.table.headers),
+      results.table.commands.map(
+        ({description, support, details: {output, passingAssertions, failingAssertions, unexpectedBehaviors}}) =>
+          fragment(
+            tr(
+              td(rich(description)),
+              td(rich(support)),
+              td(
+                p(rich(output)),
+                commandDetailsList(passingAssertions),
+                commandDetailsList(failingAssertions),
+                commandDetailsList(unexpectedBehaviors)
+              )
+            )
+          )
+      )
+    )
+  );
+
+  /**
+   * @param {object} list
+   * @param {Description} list.description
+   * @param {Description[]} list.items
+   */
+  function commandDetailsList({description, items}) {
+    return div(description, ul(...items.map(description => li(rich(description)))));
+  }
+}
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsPass
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionPassJSON} pass
+ */
+
+/**
+ * Passing assertion values submitted from the tester result form.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
+ */
+
+const AssertionPassJSONMap = createEnumMap({
+  GOOD_OUTPUT: "Good Output",
+});
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsFail
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionFailJSON} fail
+ */
+
+/**
+ * Failing assertion values from the tester result form as are submitted in the
+ * JSON result object.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
+ */
+
+const AssertionFailJSONMap = createEnumMap({
+  NO_OUTPUT: "No Output",
+  INCORRECT_OUTPUT: "Incorrect Output",
+  NO_SUPPORT: "No Support",
+});
+
+/** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
+
+/**
+ * Command result derived from priority 1 and 2 assertions.
+ *
+ * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
+ * if priority 2 assertions fail.
+ *
+ * In the submitted json object values may contain spaces and are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
+ */
+
+const CommandSupportJSONMap = createEnumMap({
+  FULL: "FULL",
+  FAILING: "FAILING",
+  ALL_REQUIRED: "ALL REQUIRED",
+});
+
+/**
+ * Highest level status submitted from test result.
+ *
+ * In the submitted json object values are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
+ */
+
+const StatusJSONMap = createEnumMap({
+  PASS: "PASS",
+  FAIL: "FAIL",
+});
+
+/**
+ * @param {TestRunState} state
+ * @param {Behavior} behavior
+ * @returns {SubmitResultJSON}
+ */
+function toSubmitResultJSON(state, behavior) {
+  /** @type {SubmitResultDetailsJSON} */
+  const details = {
+    name: state.info.description,
+    task: state.info.task,
+    specific_user_instruction: behavior.specificUserInstruction,
+    summary: {
+      1: {
+        pass: countAssertions(({priority, result}) => priority === 1 && result === CommonResultMap.PASS),
+        fail: countAssertions(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS),
+      },
+      2: {
+        pass: countAssertions(({priority, result}) => priority === 2 && result === CommonResultMap.PASS),
+        fail: countAssertions(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS),
+      },
+      unexpectedCount: countUnexpectedBehaviors(({checked}) => checked),
+    },
+    commands: state.commands.map(command => ({
+      command: command.description,
+      output: command.atOutput.value,
+      support: commandSupport(command),
+      assertions: [...command.assertions, ...command.additionalAssertions].map(assertionToAssertion),
+      unexpected_behaviors: command.unexpected.behaviors
+        .filter(({checked}) => checked)
+        .map(({description, more}) => (more ? more.value : description)),
+    })),
+  };
+  /** @type {SubmitResultStatusJSON} */
+  const status = state.commands.map(commandSupport).some(support => support === CommandSupportJSONMap.FAILING)
+    ? StatusJSONMap.FAIL
+    : StatusJSONMap.PASS;
+  return {
+    test: state.info.description,
+    details,
+    status,
+  };
+
+  function commandSupport(command) {
+    const allAssertions = [...command.assertions, ...command.additionalAssertions];
+    return allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
+      command.unexpected.behaviors.some(({checked}) => checked)
+      ? CommandSupportJSONMap.FAILING
+      : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
+      ? CommandSupportJSONMap.ALL_REQUIRED
+      : CommandSupportJSONMap.FULL;
+  }
+
+  /**
+   * @param {(assertion: TestRunAssertion | TestRunAdditionalAssertion) => boolean} filter
+   * @returns {number}
+   */
+  function countAssertions(filter) {
+    return state.commands.reduce(
+      (carry, command) => carry + [...command.assertions, ...command.additionalAssertions].filter(filter).length,
+      0
+    );
+  }
+
+  /**
+   * @param {(behavior: TestRunUnexpected) => boolean} filter
+   * @returns {number}
+   */
+  function countUnexpectedBehaviors(filter) {
+    return state.commands.reduce((carry, command) => carry + command.unexpected.behaviors.filter(filter).length, 0);
+  }
+
+  /**
+   * @param {TestRunAssertion | TestRunAdditionalAssertion} assertion
+   * @returns {SubmitResultAssertionsJSON}
+   */
+  function assertionToAssertion(assertion) {
+    return assertion.result === CommonResultMap.PASS
+      ? {
+          assertion: assertion.description,
+          priority: assertion.priority.toString(),
+          pass: AssertionPassJSONMap.GOOD_OUTPUT,
+        }
+      : {
+          assertion: assertion.description,
+          priority: assertion.priority.toString(),
+          fail:
+            assertion.result === AssertionResultMap.FAIL_MISSING
+              ? AssertionFailJSONMap.NO_OUTPUT
+              : assertion.result === AssertionResultMap.FAIL_INCORRECT
+              ? AssertionFailJSONMap.INCORRECT_OUTPUT
+              : AssertionFailJSONMap.NO_SUPPORT,
+        };
+  }
+}
+
+/**
+ * @typedef AT
+ * @property {string} name
+ * @property {string} key
+ */
+
+/**
+ * @typedef Support
+ * @property {AT[]} ats
+ * @property {{system: string[]}} applies_to
+ * @property {{directory: string, name: string}[]} examples
+ */
+
+/**
+ * @typedef {{[mode in ATMode]: {[atName: string]: string;};}} CommandsAPI_ModeInstructions
+ */
+
+/**
+ * @typedef {([string] | [string, string])[]} CommandAT
+ */
+
+/**
+ * @typedef {{[atMode: string]: CommandAT}} CommandMode
+ */
+
+/**
+ * @typedef Command
+ * @property {CommandMode} [reading]
+ * @property {CommandMode} [interaction]
+ */
+
+/**
+ * @typedef {{[commandDescription: string]: Command}} Commands
+ */
+
+/**
+ * @callback CommandsAPI_getATCommands
+ * @param {ATMode} mode
+ * @param {string} task
+ * @param {AT} assistiveTech
+ * @returns {string[]}
+ */
+
+/** @typedef {"reading" | "interaction"} ATMode */
+
+/**
+ * @callback CommandsAPI_getModeInstructions
+ * @param {ATMode} mode
+ * @param {AT} assistiveTech
+ * @returns {string}
+ */
+
+/**
+ * @callback CommandsAPI_isKnownAT
+ * @param {string} assistiveTech
+ * @returns {AT}
+ */
+
+/**
+ * @typedef CommandsAPI
+ * @property {Commands} AT_COMMAND_MAP
+ * @property {CommandsAPI_ModeInstructions} MODE_INSTRUCTIONS
+ * @property {Support} support
+ * @property {CommandsAPI_getATCommands} getATCommands
+ * @property {CommandsAPI_getModeInstructions} getModeInstructions
+ * @property {CommandsAPI_isKnownAT} isKnownAT
+ */
+
+/**
+ * @typedef BehaviorJSON
+ * @property {string} setup_script_description
+ * @property {string} setupTestPage
+ * @property {string[]} applies_to
+ * @property {ATMode | ATMode[]} mode
+ * @property {string} task
+ * @property {string} specific_user_instruction
+ * @property {[string, string][]} [output_assertions]
+ * @property {{[atKey: string]: [number, string][]}} [additional_assertions]
+ */
+
+/**
+ * @typedef Behavior
+ * @property {string} description
+ * @property {string} task
+ * @property {ATMode} mode
+ * @property {string} modeInstructions
+ * @property {string[]} appliesTo
+ * @property {string} specificUserInstruction
+ * @property {string} setupScriptDescription
+ * @property {string} setupTestPage
+ * @property {string[]} commands
+ * @property {[string, string][]} outputAssertions
+ * @property {[number, string][]} additionalAssertions
+ * @property {object[]} unexpectedBehaviors
+ * @property {string} unexpectedBehaviors[].content
+ * @property {boolean} [unexpectedBehaviors[].requireExplanation]
+ */
+
+/**
+ * @typedef SubmitResultJSON
+ * @property {string} test
+ * @property {SubmitResultDetailsJSON} details
+ * @property {SubmitResultStatusJSON} status
+ */
+
+/**
+ * @typedef SubmitResultSummaryPriorityJSON
+ * @property {number} pass
+ * @property {number} fail
+ */
+
+/**
+ * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
+ */
+
+/**
+ * @typedef SubmitResultSummaryPropsJSON
+ * @property {number} unexpectedCount
+ */
+
+/**
+ * @typedef {SubmitResultSummaryPriorityMapJSON & SubmitResultSummaryPropsJSON} SubmitResultSummaryJSON
+ */
+
+/**
+ * @typedef SubmitResultDetailsJSON
+ * @property {string} name
+ * @property {string} specific_user_instruction
+ * @property {string} task
+ * @property {object[]} commands
+ * @property {string} commands[].command
+ * @property {string} commands[].output
+ * @property {string[]} commands[].unexpected_behaviors
+ * @property {CommandSupportJSON} commands[].support
+ * @property {SubmitResultAssertionsJSON[]} commands[].assertions
+ * @property {SubmitResultSummaryJSON} summary
+ */
+
+/**
+ * @typedef TestWindowHooks
+ * @property {() => void} windowOpened
+ * @property {() => void} windowClosed
+ */
+
+/** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
+
+/**
+ * @typedef ResultJSONDocument
+ * @property {SubmitResultJSON | null} resultsJSON
+ */
+
+/**
+ * @typedef {TestPageDocument & ResultJSONDocument} TestPageAndResultsDocument
+ */
+
+/**
+ * @typedef {import('./aria-at-test-run.js').EnumValues<T>} EnumValues<T>
+ * @template T
+ */
+
+/** @typedef {import('./aria-at-test-run.js').TestRunState} TestRunState */
+/** @typedef {import('./aria-at-test-run.js').TestRunAssertion} TestRunAssertion */
+/** @typedef {import('./aria-at-test-run.js').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
+/** @typedef {import('./aria-at-test-run.js').TestRunCommand} TestRunCommand */
+/** @typedef {import("./aria-at-test-run.js").TestRunUnexpectedBehavior} TestRunUnexpected */
+
+/** @typedef {import('./aria-at-test-run.js').Description} Description */
+
+/** @typedef {import('./aria-at-test-run.js').TestPageDocument} TestPageDocument */
+
+/** @typedef {import('./aria-at-test-run.js').InstructionDocument} InstructionDocument */
+/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructions} InstructionDocumentInstructions */
+/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructionsAssertions} InstructionDocumentInstructionsAssertions */
+/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsHeader} InstructionDocumentResultsHeader */
+/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommand} InstructionDocumentResultsCommand */
+/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommandsUnexpected} InstructionDocumentResultsCommandsUnexpected */
+/** @typedef {import("./aria-at-test-run.js").InstructionDocumentResultsCommandsAssertion} InstructionDocumentResultsCommandsAssertion */
+/** @typedef {import("./aria-at-test-run.js").InstructionDocumentAssertionChoice} InstructionDocumentAssertionChoice */
+/** @typedef {import("./aria-at-test-run.js").InstructionDocumentInstructionsInstructions} InstructionDocumentInstructionsInstructions */
+
+/** @typedef {import('./aria-at-test-run.js').ResultsTableDocument} ResultsTableDocument */

--- a/build/tests/resources/aria-at-test-run.mjs
+++ b/build/tests/resources/aria-at-test-run.mjs
@@ -1,0 +1,1252 @@
+export class TestRun {
+  /**
+   * @param {object} param0
+   * @param {Partial<TestRunHooks>} [param0.hooks]
+   * @param {TestRunState} param0.state
+   */
+  constructor({hooks, state}) {
+    /** @type {TestRunState} */
+    this.state = state;
+
+    const bindDispatch = transform => arg => this.dispatch(transform(arg));
+    /** @type {TestRunHooks} */
+    this.hooks = {
+      closeTestPage: bindDispatch(userCloseWindow),
+      focusCommandUnexpectedBehavior: bindDispatch(userFocusCommandUnexpectedBehavior),
+      openTestPage: bindDispatch(userOpenWindow),
+      postResults: () => {},
+      setCommandAdditionalAssertion: bindDispatch(userChangeCommandAdditionalAssertion),
+      setCommandAssertion: bindDispatch(userChangeCommandAssertion),
+      setCommandHasUnexpectedBehavior: bindDispatch(userChangeCommandHasUnexpectedBehavior),
+      setCommandUnexpectedBehavior: bindDispatch(userChangeCommandUnexpectedBehavior),
+      setCommandUnexpectedBehaviorMore: bindDispatch(userChangeCommandUnexpectedBehaviorMore),
+      setCommandOutput: bindDispatch(userChangeCommandOutput),
+      submit: () => submitResult(this),
+      ...hooks,
+    };
+
+    this.observers = [];
+
+    this.dispatch = this.dispatch.bind(this);
+  }
+
+  /**
+   * @param {(state: TestRunState) => TestRunState} updateMethod
+   */
+  dispatch(updateMethod) {
+    this.state = updateMethod(this.state);
+    this.observers.forEach(subscriber => subscriber(this));
+  }
+
+  /**
+   * @param {(app: TestRun) => void} subscriber
+   * @returns {() => void}
+   */
+  observe(subscriber) {
+    this.observers.push(subscriber);
+    return () => {
+      const index = this.observers.indexOf(subscriber);
+      if (index > -1) {
+        this.observers.splice(index, 1);
+      }
+    };
+  }
+
+  testPage() {
+    return testPageDocument(this.state, this.hooks);
+  }
+
+  instructions() {
+    return instructionDocument(this.state, this.hooks);
+  }
+
+  resultsTable() {
+    return resultsTableDocument(this.state);
+  }
+}
+
+/**
+ * @param {U} map
+ * @returns {Readonly<U>}
+ * @template {string} T
+ * @template {{[key: string]: T}} U
+ */
+export function createEnumMap(map) {
+  return Object.freeze(map);
+}
+
+export const WhitespaceStyleMap = createEnumMap({
+  LINE_BREAK: "lineBreak",
+});
+
+function bind(fn, ...args) {
+  return (...moreArgs) => fn(...args, ...moreArgs);
+}
+
+/**
+ * @param {TestRunState} resultState
+ * @param {TestRunHooks} hooks
+ * @returns {InstructionDocument}
+ */
+export function instructionDocument(resultState, hooks) {
+  const mode = resultState.info.mode;
+  const modeInstructions = resultState.info.modeInstructions;
+  const userInstructions = resultState.info.userInstructions;
+  const lastInstruction = userInstructions[userInstructions.length - 1];
+  const setupScriptDescription = resultState.info.setupScriptDescription
+    ? ` and runs a script that ${resultState.info.setupScriptDescription}.`
+    : resultState.info.setupScriptDescription;
+  // As a hack, special case mode instructions for VoiceOver for macOS until we
+  // support modeless tests. ToDo: remove this when resolving issue #194
+  const modePhrase =
+    resultState.config.at.name === "VoiceOver for macOS"
+      ? "Describe "
+      : `With ${resultState.config.at.name} in ${mode} mode, describe `;
+
+  const commands = resultState.commands.map(({description}) => description);
+  const assertions = resultState.commands[0].assertions.map(({description}) => description);
+  const additionalAssertions = resultState.commands[0].additionalAssertions.map(({description}) => description);
+
+  let firstRequired = true;
+  function focusFirstRequired() {
+    if (firstRequired) {
+      firstRequired = false;
+      return true;
+    }
+    return false;
+  }
+
+  return {
+    errors: {
+      visible: false,
+      header: "",
+      errors: [],
+    },
+    instructions: {
+      header: {
+        header: `Testing task: ${resultState.info.description}`,
+        focus: resultState.currentUserAction === UserActionMap.LOAD_PAGE,
+      },
+      description: `${modePhrase} how ${resultState.config.at.name} behaves when performing task "${lastInstruction}"`,
+      instructions: {
+        header: "Test instructions",
+        instructions: [
+          [
+            `Restore default settings for ${resultState.config.at.name}. For help, read `,
+            {
+              href: "https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing",
+              description: "Configuring Screen Readers for Testing",
+            },
+            `.`,
+          ],
+          `Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}`,
+        ],
+        strongInstructions: [modeInstructions, ...userInstructions],
+        commands: {
+          description: `Using the following commands, ${lastInstruction}`,
+          commands,
+        },
+      },
+      assertions: {
+        header: "Success Criteria",
+        description: `To pass this test, ${resultState.config.at.name} needs to meet all the following assertions when each  specified command is executed:`,
+        assertions,
+      },
+      openTestPage: {
+        button: "Open Test Page",
+        enabled: resultState.openTest.enabled,
+        click: hooks.openTestPage,
+      },
+    },
+    results: {
+      header: {
+        header: "Record Results",
+        description: `${resultState.info.description}`,
+      },
+      commands: commands.map(commandResult),
+    },
+    submit: resultState.config.displaySubmitButton
+      ? {
+          button: "Submit Results",
+          click: hooks.submit,
+        }
+      : null,
+  };
+
+  /**
+   * @param {T} resultAssertion
+   * @param {T["result"]} resultValue
+   * @param {Omit<InstructionDocumentAssertionChoice, 'checked' | 'focus'>} partialChoice
+   * @returns {InstructionDocumentAssertionChoice}
+   * @template {TestRunAssertion | TestRunAdditionalAssertion} T
+   */
+  function assertionChoice(resultAssertion, resultValue, partialChoice) {
+    return {
+      ...partialChoice,
+      checked: resultAssertion.result === resultValue,
+      focus:
+        resultState.currentUserAction === "validateResults" &&
+        resultAssertion.highlightRequired &&
+        focusFirstRequired(),
+    };
+  }
+
+  /**
+   * @param {string} command
+   * @param {number} commandIndex
+   * @returns {InstructionDocumentResultsCommand}
+   */
+  function commandResult(command, commandIndex) {
+    const resultStateCommand = resultState.commands[commandIndex];
+    const resultUnexpectedBehavior = resultStateCommand.unexpected;
+    return {
+      header: `After '${command}'`,
+      atOutput: {
+        description: [
+          `${resultState.config.at.name} output after ${command}`,
+          {
+            required: true,
+            highlightRequired: resultStateCommand.atOutput.highlightRequired,
+            description: "(required)",
+          },
+        ],
+        value: resultStateCommand.atOutput.value,
+        focus:
+          resultState.currentUserAction === "validateResults" &&
+          resultStateCommand.atOutput.highlightRequired &&
+          focusFirstRequired(),
+        change: atOutput => hooks.setCommandOutput({commandIndex, atOutput}),
+      },
+      assertionsHeader: {
+        descriptionHeader: "",
+        passHeader: "",
+        failHeader: "",
+      },
+      assertions: [
+        ...assertions.map(bind(assertionResult, commandIndex)),
+        ...additionalAssertions.map(bind(additionalAssertionResult, commandIndex)),
+      ],
+      unexpectedBehaviors: {
+        description: [
+          "Were there additional undesirable behaviors?",
+          {
+            required: true,
+            highlightRequired: resultStateCommand.unexpected.highlightRequired,
+            description: "(required)",
+          },
+        ],
+        passChoice: {
+          label: "No, there were no additional undesirable behaviors.",
+          checked: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+          focus:
+            resultState.currentUserAction === "validateResults" &&
+            resultUnexpectedBehavior.highlightRequired &&
+            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            focusFirstRequired(),
+          click: () =>
+            hooks.setCommandHasUnexpectedBehavior({
+              commandIndex,
+              hasUnexpected: HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+            }),
+        },
+        failChoice: {
+          label: "Yes, there were additional undesirable behaviors",
+          checked: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+          focus:
+            resultState.currentUserAction === "validateResults" &&
+            resultUnexpectedBehavior.highlightRequired &&
+            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            focusFirstRequired(),
+          click: () =>
+            hooks.setCommandHasUnexpectedBehavior({
+              commandIndex,
+              hasUnexpected: HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+            }),
+          options: {
+            header: "Undesirable behaviors",
+            options: resultUnexpectedBehavior.behaviors.map((behavior, unexpectedIndex) => {
+              return {
+                description: behavior.description,
+                enabled: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+                tabbable: resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex,
+                checked: behavior.checked,
+                focus:
+                  typeof resultState.currentUserAction === "object" &&
+                  resultState.currentUserAction.action === UserObjectActionMap.FOCUS_UNDESIRABLE
+                    ? resultState.currentUserAction.commandIndex === commandIndex &&
+                      resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex
+                    : resultState.currentUserAction === UserActionMap.VALIDATE_RESULTS &&
+                      resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+                      resultUnexpectedBehavior.behaviors.every(({checked}) => !checked) &&
+                      focusFirstRequired(),
+                change: checked => hooks.setCommandUnexpectedBehavior({commandIndex, unexpectedIndex, checked}),
+                keydown: key => {
+                  const increment = keyToFocusIncrement(key);
+                  if (increment) {
+                    hooks.focusCommandUnexpectedBehavior({commandIndex, unexpectedIndex, increment});
+                    return true;
+                  }
+                  return false;
+                },
+                more: behavior.more
+                  ? {
+                      description: /** @type {Description[]} */ ([
+                        `If "other" selected, explain`,
+                        {
+                          required: true,
+                          highlightRequired: behavior.more.highlightRequired,
+                          description: "(required)",
+                        },
+                      ]),
+                      enabled: behavior.checked,
+                      value: behavior.more.value,
+                      focus:
+                        resultState.currentUserAction === "validateResults" &&
+                        behavior.more.highlightRequired &&
+                        focusFirstRequired(),
+                      change: value =>
+                        hooks.setCommandUnexpectedBehaviorMore({commandIndex, unexpectedIndex, more: value}),
+                    }
+                  : null,
+              };
+            }),
+          },
+        },
+      },
+    };
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {string} assertion
+   * @param {number} assertionIndex
+   */
+  function assertionResult(commandIndex, assertion, assertionIndex) {
+    const resultAssertion = resultState.commands[commandIndex].assertions[assertionIndex];
+    return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
+      description: [
+        assertion,
+        {
+          required: true,
+          highlightRequired: resultAssertion.highlightRequired,
+          description: "(required: mark output)",
+        },
+      ],
+      passChoice: assertionChoice(resultAssertion, CommonResultMap.PASS, {
+        label: [
+          `Good Output `,
+          {
+            offScreen: true,
+            description: "for assertion",
+          },
+        ],
+        click: () => hooks.setCommandAssertion({commandIndex, assertionIndex, result: CommonResultMap.PASS}),
+      }),
+      failChoices: [
+        assertionChoice(resultAssertion, AssertionResultMap.FAIL_MISSING, {
+          label: [
+            `No Output `,
+            {
+              offScreen: true,
+              description: "for assertion",
+            },
+          ],
+          click: () =>
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+        }),
+        assertionChoice(resultAssertion, AssertionResultMap.FAIL_INCORRECT, {
+          label: [
+            `Incorrect Output `,
+            {
+              offScreen: true,
+              description: "for assertion",
+            },
+          ],
+          click: () =>
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+        }),
+      ],
+    });
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {string} assertion
+   * @param {number} assertionIndex
+   */
+  function additionalAssertionResult(commandIndex, assertion, assertionIndex) {
+    const resultAdditionalAssertion = resultState.commands[commandIndex].additionalAssertions[assertionIndex];
+    return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
+      description: [
+        assertion,
+        {
+          required: true,
+          highlightRequired: resultAdditionalAssertion.highlightRequired,
+          description: "(required: mark support)",
+        },
+      ],
+      passChoice: assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.PASS, {
+        label: ["Good Support ", {offScreen: true, description: "for assertion"}],
+        click: () =>
+          hooks.setCommandAdditionalAssertion({
+            commandIndex,
+            additionalAssertionIndex: assertionIndex,
+            result: AdditionalAssertionResultMap.PASS,
+          }),
+      }),
+      failChoices: [
+        assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.FAIL_SUPPORT, {
+          label: ["No Support ", {offScreen: true, description: "for assertion"}],
+          click: () =>
+            hooks.setCommandAdditionalAssertion({
+              commandIndex,
+              additionalAssertionIndex: assertionIndex,
+              result: AdditionalAssertionResultMap.FAIL_SUPPORT,
+            }),
+        }),
+      ],
+    });
+  }
+}
+
+/**
+ * @typedef {typeof UserActionMap[keyof typeof UserActionMap]} UserAction
+ */
+
+export const UserActionMap = createEnumMap({
+  LOAD_PAGE: "loadPage",
+  OPEN_TEST_WINDOW: "openTestWindow",
+  CLOSE_TEST_WINDOW: "closeTestWindow",
+  VALIDATE_RESULTS: "validateResults",
+  CHANGE_TEXT: "changeText",
+  CHANGE_SELECTION: "changeSelection",
+  SHOW_RESULTS: "showResults",
+});
+
+/**
+ * @typedef {typeof UserObjectActionMap[keyof typeof UserObjectActionMap]} UserObjectAction
+ */
+
+export const UserObjectActionMap = createEnumMap({
+  FOCUS_UNDESIRABLE: "focusUndesirable",
+});
+
+/**
+ * @typedef {UserAction | UserActionFocusUnexpected} TestRunUserAction
+ */
+
+/**
+ * @typedef {EnumValues<typeof HasUnexpectedBehaviorMap>} HasUnexpectedBehavior
+ */
+
+export const HasUnexpectedBehaviorMap = createEnumMap({
+  NOT_SET: "notSet",
+  HAS_UNEXPECTED: "hasUnexpected",
+  DOES_NOT_HAVE_UNEXPECTED: "doesNotHaveUnexpected",
+});
+
+export const CommonResultMap = createEnumMap({
+  NOT_SET: "notSet",
+  PASS: "pass",
+});
+
+/**
+ * @typedef {EnumValues<typeof AdditionalAssertionResultMap>} AdditionalAssertionResult
+ */
+
+export const AdditionalAssertionResultMap = createEnumMap({
+  ...CommonResultMap,
+  FAIL_SUPPORT: "failSupport",
+});
+
+/**
+ * @typedef {EnumValues<typeof AssertionResultMap>} AssertionResult
+ */
+
+export const AssertionResultMap = createEnumMap({
+  ...CommonResultMap,
+  FAIL_MISSING: "failMissing",
+  FAIL_INCORRECT: "failIncorrect",
+});
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {string} props.atOutput
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandOutput({commandIndex, atOutput}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_TEXT,
+      commands: state.commands.map((commandState, index) =>
+        index !== commandIndex
+          ? commandState
+          : {
+              ...commandState,
+              atOutput: {
+                ...commandState.atOutput,
+                value: atOutput,
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.assertionIndex
+ * @param {AssertionResult} props.result
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandAssertion({commandIndex, assertionIndex, result}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              assertions: command.assertions.map((assertion, assertionI) =>
+                assertionI !== assertionIndex ? assertion : {...assertion, result}
+              ),
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.additionalAssertionIndex
+ * @param {AdditionalAssertionResult} props.result
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandAdditionalAssertion({commandIndex, additionalAssertionIndex, result}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              additionalAssertions: command.additionalAssertions.map((assertion, assertionI) =>
+                assertionI !== additionalAssertionIndex ? assertion : {...assertion, result}
+              ),
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {HasUnexpectedBehavior} props.hasUnexpected
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandHasUnexpectedBehavior({commandIndex, hasUnexpected}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                hasUnexpected: hasUnexpected,
+                tabbedBehavior: hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED ? 0 : -1,
+                behaviors: command.unexpected.behaviors.map(behavior => ({
+                  ...behavior,
+                  checked: false,
+                  more: behavior.more ? {...behavior.more, value: ""} : null,
+                })),
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {boolean} props.checked
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandUnexpectedBehavior({commandIndex, unexpectedIndex, checked}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
+                  unexpectedI !== unexpectedIndex
+                    ? unexpected
+                    : {
+                        ...unexpected,
+                        checked,
+                      }
+                ),
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {string} props.more
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandUnexpectedBehaviorMore({commandIndex, unexpectedIndex, more}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_TEXT,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : /** @type {TestRunCommand} */ ({
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
+                  unexpectedI !== unexpectedIndex
+                    ? unexpected
+                    : /** @type {TestRunUnexpectedBehavior} */ ({
+                        ...unexpected,
+                        more: {
+                          ...unexpected.more,
+                          value: more,
+                        },
+                      })
+                ),
+              },
+            })
+      ),
+    };
+  };
+}
+
+/**
+ * @param {string} key
+ * @returns {TestRunFocusIncrement}
+ */
+function keyToFocusIncrement(key) {
+  switch (key) {
+    case "Up":
+    case "ArrowUp":
+    case "Left":
+    case "ArrowLeft":
+      return "previous";
+
+    case "Down":
+    case "ArrowDown":
+    case "Right":
+    case "ArrowRight":
+      return "next";
+  }
+}
+
+/**
+ * @param {TestRunState} state
+ * @param {TestRunHooks} hooks
+ * @returns {TestPageDocument}
+ */
+function testPageDocument(state, hooks) {
+  if (state.currentUserAction === UserActionMap.SHOW_RESULTS) {
+    return {
+      results: resultsTableDocument(state),
+    };
+  }
+  return {
+    errors: null,
+    instructions: instructionDocument(state, hooks),
+  };
+}
+
+/**
+ * @param {TestRun} app
+ */
+function submitResult(app) {
+  app.dispatch(userValidateState());
+
+  if (isSomeFieldRequired(app.state)) {
+    return;
+  }
+
+  app.hooks.postResults();
+
+  app.hooks.closeTestPage();
+
+  if (app.state.config.renderResultsAfterSubmit) {
+    app.dispatch(userShowResults());
+  }
+}
+
+export function userShowResults() {
+  return function (/** @type {TestRunState} */ state) {
+    return /** @type {TestRunState} */ ({...state, currentUserAction: UserActionMap.SHOW_RESULTS});
+  };
+}
+
+/**
+ * @param {TestRunState} state
+ * @returns
+ */
+function isSomeFieldRequired(state) {
+  return state.commands.some(
+    command =>
+      command.atOutput.value.trim() === "" ||
+      command.assertions.some(assertion => assertion.result === CommonResultMap.NOT_SET) ||
+      command.additionalAssertions.some(assertion => assertion.result === CommonResultMap.NOT_SET) ||
+      command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
+      (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+        (command.unexpected.behaviors.every(({checked}) => !checked) ||
+          command.unexpected.behaviors.some(
+            behavior => behavior.checked && behavior.more && behavior.more.value.trim() === ""
+          )))
+  );
+}
+
+/**
+ * @param {TestRunState} state
+ * @returns {ResultsTableDocument}
+ */
+function resultsTableDocument(state) {
+  return {
+    header: state.info.description,
+    status: {
+      header: [
+        "Test result: ",
+        state.commands.some(
+          ({assertions, additionalAssertions, unexpected}) =>
+            [...assertions, ...additionalAssertions].some(
+              ({priority, result}) => priority === 1 && result !== CommonResultMap.PASS
+            ) || unexpected.behaviors.some(({checked}) => checked)
+        )
+          ? "FAIL"
+          : "PASS",
+      ],
+    },
+    table: {
+      headers: {
+        description: "Command",
+        support: "Support",
+        details: "Details",
+      },
+      commands: state.commands.map(command => {
+        const allAssertions = [...command.assertions, ...command.additionalAssertions];
+
+        let passingAssertions = ["No passing assertions."];
+        let failingAssertions = ["No failing assertions."];
+        let unexpectedBehaviors = ["No unexpect behaviors."];
+
+        if (allAssertions.some(({result}) => result === CommonResultMap.PASS)) {
+          passingAssertions = allAssertions
+            .filter(({result}) => result === CommonResultMap.PASS)
+            .map(({description}) => description);
+        }
+        if (allAssertions.some(({result}) => result !== CommonResultMap.PASS)) {
+          failingAssertions = allAssertions
+            .filter(({result}) => result !== CommonResultMap.PASS)
+            .map(({description}) => description);
+        }
+        if (command.unexpected.behaviors.some(({checked}) => checked)) {
+          unexpectedBehaviors = command.unexpected.behaviors
+            .filter(({checked}) => checked)
+            .map(({description, more}) => (more ? more.value : description));
+        }
+
+        return {
+          description: command.description,
+          support:
+            allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
+            command.unexpected.behaviors.some(({checked}) => checked)
+              ? "FAILING"
+              : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
+              ? "ALL_REQUIRED"
+              : "FULL",
+          details: {
+            output: /** @type {Description} */ [
+              "output:",
+              /** @type {DescriptionWhitespace} */ ({whitespace: WhitespaceStyleMap.LINE_BREAK}),
+              " ",
+              ...command.atOutput.value
+                .split(/(\r\n|\r|\n)/g)
+                .map(output =>
+                  /\r\n|\r|\n/.test(output)
+                    ? /** @type {DescriptionWhitespace} */ ({whitespace: WhitespaceStyleMap.LINE_BREAK})
+                    : output
+                ),
+            ],
+            passingAssertions: {
+              description: "Passing Assertions:",
+              items: passingAssertions,
+            },
+            failingAssertions: {
+              description: "Failing Assertions:",
+              items: failingAssertions,
+            },
+            unexpectedBehaviors: {
+              description: "Unexpected Behavior",
+              items: unexpectedBehaviors,
+            },
+          },
+        };
+      }),
+    },
+  };
+}
+
+export function userOpenWindow() {
+  return (/** @type {TestRunState} */ state) =>
+    /** @type {TestRunState} */ ({
+      ...state,
+      currentUserAction: UserActionMap.OPEN_TEST_WINDOW,
+      openTest: {...state.openTest, enabled: false},
+    });
+}
+
+export function userCloseWindow() {
+  return (/** @type {TestRunState} */ state) =>
+    /** @type {TestRunState} */ ({
+      ...state,
+      currentUserAction: UserActionMap.CLOSE_TEST_WINDOW,
+      openTest: {...state.openTest, enabled: true},
+    });
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {TestRunFocusIncrement} props.increment
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userFocusCommandUnexpectedBehavior({commandIndex, unexpectedIndex, increment}) {
+  return function (state) {
+    const unexpectedLength = state.commands[commandIndex].unexpected.behaviors.length;
+    const incrementValue = increment === "next" ? 1 : -1;
+    const newUnexpectedIndex = (unexpectedIndex + incrementValue + unexpectedLength) % unexpectedLength;
+
+    return {
+      ...state,
+      currentUserAction: {
+        action: UserObjectActionMap.FOCUS_UNDESIRABLE,
+        commandIndex,
+        unexpectedIndex: newUnexpectedIndex,
+      },
+      commands: state.commands.map((command, commandI) => {
+        const tabbed = command.unexpected.tabbedBehavior;
+        const unexpectedLength = command.unexpected.behaviors.length;
+        const newTabbed = (tabbed + (increment === "next" ? 1 : -1) + unexpectedLength) % unexpectedLength;
+        return commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                tabbedBehavior: newTabbed,
+              },
+            };
+      }),
+    };
+  };
+}
+
+/**
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userValidateState() {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.VALIDATE_RESULTS,
+      commands: state.commands.map(command => {
+        return {
+          ...command,
+          atOutput: {
+            ...command.atOutput,
+            highlightRequired: !command.atOutput.value.trim(),
+          },
+          assertions: command.assertions.map(assertion => ({
+            ...assertion,
+            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
+          })),
+          additionalAssertions: command.additionalAssertions.map(assertion => ({
+            ...assertion,
+            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
+          })),
+          unexpected: {
+            ...command.unexpected,
+            highlightRequired:
+              command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
+              (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+                command.unexpected.behaviors.every(({checked}) => !checked)),
+            behaviors: command.unexpected.behaviors.map(unexpected => {
+              return unexpected.more
+                ? {
+                    ...unexpected,
+                    more: {
+                      ...unexpected.more,
+                      highlightRequired: unexpected.checked && !unexpected.more.value.trim(),
+                    },
+                  }
+                : unexpected;
+            }),
+          },
+        };
+      }),
+    };
+  };
+}
+
+/**
+ * @typedef AT
+ * @property {string} name
+ * @property {string} key
+ */
+
+/**
+ * @typedef Behavior
+ * @property {string} description
+ * @property {string} task
+ * @property {string} mode
+ * @property {string} modeInstructions
+ * @property {string[]} appliesTo
+ * @property {string} specificUserInstruction
+ * @property {string} setupScriptDescription
+ * @property {string} setupTestPage
+ * @property {string[]} commands
+ * @property {[string, string][]} outputAssertions
+ * @property {[number, string][]} additionalAssertions
+ */
+
+/**
+ * @typedef {"previous" | "next"} TestRunFocusIncrement
+ */
+
+/**
+ * @typedef {(action: (state: TestRunState) => TestRunState) => void} Dispatcher
+ */
+
+/**
+ * @typedef InstructionDocumentButton
+ * @property {Description} button
+ * @property {boolean} [enabled]
+ * @property {() => void} click
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptionsOptionsMore
+ * @property {Description} description
+ * @property {string} value
+ * @property {boolean} enabled
+ * @property {boolean} [focus]
+ * @property {(value: string) => void} change
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptionsOption
+ * @property {Description} description
+ * @property {boolean} checked
+ * @property {boolean} enabled
+ * @property {boolean} tabbable
+ * @property {boolean} [focus]
+ * @property {(checked: boolean) => void} change
+ * @property {(key: string) => boolean} keydown
+ * @property {InstructionDocumentAssertionChoiceOptionsOptionsMore} [more]
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptions
+ * @property {Description} header
+ * @property {InstructionDocumentAssertionChoiceOptionsOption[]} options
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoice
+ * @property {Description} label
+ * @property {boolean} checked
+ * @property {boolean} [focus]
+ * @property {() => void} click
+ * @property {InstructionDocumentAssertionChoiceOptions} [options]
+ */
+
+/**
+ * @typedef DescriptionRich
+ * @property {string} [href]
+ * @property {boolean} [required]
+ * @property {boolean} [highlightRequired]
+ * @property {boolean} [offScreen]
+ * @property {Description} description
+ */
+
+/**
+ * @typedef DescriptionWhitespace
+ * @property {typeof WhitespaceStyleMap["LINE_BREAK"]} whitespace
+ */
+
+/** @typedef {string | DescriptionRich | DescriptionWhitespace | DescriptionArray} Description */
+
+/** @typedef {Description[]} DescriptionArray */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsAssertion
+ * @property {Description} description
+ * @property {InstructionDocumentAssertionChoice} passChoice
+ * @property {InstructionDocumentAssertionChoice[]} failChoices
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsAssertionsHeader
+ * @property {Description} descriptionHeader
+ * @property {Description} passHeader
+ * @property {Description} failHeader
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsATOutput
+ * @property {Description} description
+ * @property {string} value
+ * @property {boolean} focus
+ * @property {(value: string) => void} change
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsUnexpected
+ * @property {Description} description
+ * @property {InstructionDocumentAssertionChoice} passChoice
+ * @property {InstructionDocumentAssertionChoice} failChoice
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommand
+ * @property {Description} header
+ * @property {InstructionDocumentResultsCommandsATOutput} atOutput
+ * @property {InstructionDocumentResultsCommandsAssertionsHeader} assertionsHeader
+ * @property {InstructionDocumentResultsCommandsAssertion[]} assertions
+ * @property {InstructionDocumentResultsCommandsUnexpected} unexpectedBehaviors
+ */
+
+/**
+ * @typedef InstructionDocumentResultsHeader
+ * @property {Description} header
+ * @property {Description} description
+ */
+
+/**
+ * @typedef InstructionDocumentResults
+ * @property {InstructionDocumentResultsHeader} header
+ * @property {InstructionDocumentResultsCommand[]} commands
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsInstructionsCommands
+ * @property {Description} description
+ * @property {Description[]} commands
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsInstructions
+ * @property {Description} header
+ * @property {Description[]} instructions
+ * @property {Description[]} strongInstructions
+ * @property {InstructionDocumentInstructionsInstructionsCommands} commands
+ */
+
+/**
+ * @typedef InstructionDocumentErrors
+ * @property {boolean} visible
+ * @property {Description} header
+ * @property {Description[]} errors
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsHeader
+ * @property {Description} header
+ * @property {boolean} focus
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsAssertions
+ * @property {Description} header
+ * @property {Description} description
+ * @property {Description[]} assertions
+ */
+
+/**
+ * @typedef InstructionDocumentInstructions
+ * @property {InstructionDocumentInstructionsHeader} header
+ * @property {Description} description
+ * @property {InstructionDocumentInstructionsInstructions} instructions
+ * @property {InstructionDocumentInstructionsAssertions} assertions
+ * @property {InstructionDocumentButton} openTestPage
+ */
+
+/**
+ * @typedef InstructionDocument
+ * @property {InstructionDocumentErrors} errors
+ * @property {InstructionDocumentInstructions} instructions
+ * @property {InstructionDocumentResults} results
+ * @property {InstructionDocumentButton} submit
+ */
+
+/**
+ * @typedef TestRunHooks
+ * @property {() => void} closeTestPage
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, increment: TestRunFocusIncrement}) => void} focusCommandUnexpectedBehavior
+ * @property {() => void} openTestPage
+ * @property {() => void} postResults
+ * @property {(options: {commandIndex: number, additionalAssertionIndex: number, result: AdditionalAssertionResult}) => void} setCommandAdditionalAssertion
+ * @property {(options: {commandIndex: number, assertionIndex: number, result: AssertionResult}) => void} setCommandAssertion
+ * @property {(options: {commandIndex: number, hasUnexpected: HasUnexpectedBehavior}) => void } setCommandHasUnexpectedBehavior
+ * @property {(options: {commandIndex: number, atOutput: string}) => void} setCommandOutput
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, checked}) => void } setCommandUnexpectedBehavior
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, more: string}) => void } setCommandUnexpectedBehaviorMore
+ * @property {() => void} submit
+ */
+
+/**
+ * @typedef UserActionFocusUnexpected
+ * @property {typeof UserObjectActionMap["FOCUS_UNDESIRABLE"]} action
+ * @property {number} commandIndex
+ * @property {number} unexpectedIndex
+ */
+
+/**
+ * @typedef {T[keyof T]} EnumValues
+ * @template {{[key: string]: string}} T
+ */
+
+/**
+ * @typedef TestRunAssertion
+ * @property {string} description
+ * @property {boolean} highlightRequired
+ * @property {number} priority
+ * @property {AssertionResult} result
+ */
+
+/**
+ * @typedef TestRunAdditionalAssertion
+ * @property {string} description
+ * @property {boolean} highlightRequired
+ * @property {number} priority
+ * @property {AdditionalAssertionResult} result
+ */
+
+/**
+ * @typedef TestRunUnexpectedBehavior
+ * @property {string} description
+ * @property {boolean} checked
+ * @property {object} [more]
+ * @property {boolean} more.highlightRequired
+ * @property {string} more.value
+ */
+
+/**
+ * @typedef TestRunUnexpectedGroup
+ * @property {boolean} highlightRequired
+ * @property {HasUnexpectedBehavior} hasUnexpected
+ * @property {number} tabbedBehavior
+ * @property {TestRunUnexpectedBehavior[]} behaviors
+ */
+
+/**
+ * @typedef TestRunCommand
+ * @property {string} description
+ * @property {object} atOutput
+ * @property {boolean} atOutput.highlightRequired
+ * @property {string} atOutput.value
+ * @property {TestRunAssertion[]} assertions
+ * @property {TestRunAdditionalAssertion[]} additionalAssertions
+ * @property {TestRunUnexpectedGroup} unexpected
+ */
+
+/**
+ * @typedef TestRunState
+ * This state contains all the serializable values that are needed to render any
+ * of the documents (InstructionDocument, ResultsTableDocument, and
+ * TestPageDocument) from this module.
+ *
+ * @property {string[] | null} errors
+ * @property {object} info
+ * @property {string} info.description
+ * @property {string} info.task
+ * @property {ATMode} info.mode
+ * @property {string} info.modeInstructions
+ * @property {string[]} info.userInstructions
+ * @property {string} info.setupScriptDescription
+ * @property {object} config
+ * @property {AT} config.at
+ * @property {boolean} config.renderResultsAfterSubmit
+ * @property {boolean} config.displaySubmitButton
+ * @property {TestRunUserAction} currentUserAction
+ * @property {TestRunCommand[]} commands
+ * @property {object} openTest
+ * @property {boolean} openTest.enabled
+ */
+
+/**
+ * @typedef ResultsTableDetailsList
+ * @property {Description} description
+ * @property {Description[]} items
+ */
+
+/**
+ * @typedef ResultsTableDocument
+ * @property {string} header
+ * @property {object} status
+ * @property {Description} status.header
+ * @property {object} table
+ * @property {object} table.headers
+ * @property {string} table.headers.description
+ * @property {string} table.headers.support
+ * @property {string} table.headers.details
+ * @property {object[]} table.commands
+ * @property {string} table.commands[].description
+ * @property {Description} table.commands[].support
+ * @property {object} table.commands[].details
+ * @property {Description} table.commands[].details.output
+ * @property {ResultsTableDetailsList} table.commands[].details.passingAssertions
+ * @property {ResultsTableDetailsList} table.commands[].details.failingAssertions
+ * @property {ResultsTableDetailsList} table.commands[].details.unexpectedBehaviors
+ */
+
+/**
+ * @typedef TestPageDocumentResults
+ * @property {ResultsTableDocument} results
+ */
+
+/**
+ * @typedef TestPageDocumentInstructions
+ * @property {string[] | null} errors
+ * @property {InstructionDocument} instructions
+ */
+
+/** @typedef {TestPageDocumentInstructions | TestPageDocumentResults} TestPageDocument */
+
+/** @typedef {"reading" | "interaction"} ATMode */

--- a/build/tests/resources/vrender.mjs
+++ b/build/tests/resources/vrender.mjs
@@ -1,0 +1,980 @@
+const mounts = new WeakMap();
+
+/**
+ * @param {HTMLElement} mount
+ * @param {NodeNode} newValue
+ */
+export function render(mount, newValue) {
+  let lastValue = mounts.get(mount);
+  if (!lastValue) {
+    lastValue = ElementType.init(newQueue(), null, null, element(mount.tagName));
+    lastValue.ref = mount;
+    mounts.set(mount, lastValue);
+  }
+  const queue = newQueue();
+  lastValue.type.diff(queue, lastValue, element(mount.tagName, newValue));
+  runQueue(queue);
+  if (!newValue) {
+    mounts.delete(mount);
+  }
+}
+
+/**
+ * @param {string} shape
+ * @param  {...NodeNode} content
+ * @returns {ElementNode}
+ */
+export function element(shape, ...content) {
+  return {
+    type: ELEMENT_TYPE_NAME,
+    shape,
+    content: content.map(asNode),
+  };
+}
+
+/**
+ * @param  {...NodeNode} content
+ * @returns {FragmentNode}
+ */
+export function fragment(...content) {
+  return {
+    type: FRAGMENT_TYPE_NAME,
+    shape: FRAGMENT_TYPE_NAME,
+    content: content.map(asNode),
+  };
+}
+
+/**
+ * @param  {string} content
+ * @returns {TextNode}
+ */
+export function text(content) {
+  return {
+    type: TEXT_TYPE_NAME,
+    shape: TEXT_TYPE_NAME,
+    content,
+  };
+}
+
+/**
+ * @param {function} shape
+ * @param {...NodeNode} content
+ * @returns {ComponentNode}
+ */
+export function component(shape, ...content) {
+  return {
+    type: COMPONENT_TYPE_NAME,
+    shape,
+    content,
+  };
+}
+
+/**
+ * @param {{[key: string]: string}} styleMap
+ * @returns {MemberNode}
+ */
+export function style(styleMap) {
+  return attribute(
+    "style",
+    Object.keys(styleMap)
+      .map(key => `${key}: ${styleMap[key]};`)
+      .join(" ")
+  );
+}
+
+/**
+ * @param {string[]} names
+ * @returns {MemberNode}
+ */
+export function className(names) {
+  return attribute("class", names.filter(Boolean).join(" "));
+}
+
+/**
+ * @param {string} name
+ * @param  {string | boolean} value
+ * @returns {MemberNode}
+ */
+export function attribute(name, value) {
+  return {
+    type: ATTRIBUTE_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+/**
+ * @param {string} name
+ * @param  {any} value
+ * @returns {MemberNode}
+ */
+export function property(name, value) {
+  return {
+    type: PROPERTY_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+/**
+ * @param {string} name
+ * @param  {any} value
+ * @returns {MemberNode}
+ */
+export function meta(name, value) {
+  return {
+    type: META_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+const refMap = new WeakMap();
+
+/**
+ * @param {{ref: HTMLElement | null}} value
+ * @returns {MemberNode}
+ */
+export function ref(value) {
+  let refHook = refMap.get(value);
+  if (!refHook) {
+    refHook = (/** @type {HTMLElement} */ element) => {
+      value.ref = element;
+    };
+    refMap.set(value, refHook);
+  }
+  return {
+    type: REF_TYPE_NAME,
+    name: "ref",
+    value: refHook,
+  };
+}
+
+const noop = function () {};
+
+/**
+ * @param {boolean} shouldFocus
+ */
+export function focus(shouldFocus) {
+  return {
+    type: REF_TYPE_NAME,
+    name: "focus",
+    value: shouldFocus ? element => element.focus() : noop,
+  };
+}
+
+function asNode(item) {
+  if (typeof item === "string") {
+    return text(item);
+  } else if (Array.isArray(item)) {
+    return fragment(...item);
+  } else if (item === null || item === undefined) {
+    return fragment();
+  }
+  return item;
+}
+
+const ELEMENT_TYPE_NAME = "element";
+const FRAGMENT_TYPE_NAME = "fragment";
+const COMPONENT_TYPE_NAME = "component";
+const TEXT_TYPE_NAME = "text";
+const ATTRIBUTE_TYPE_NAME = "attribute";
+const PROPERTY_TYPE_NAME = "property";
+const REF_TYPE_NAME = "ref";
+const META_TYPE_NAME = "meta";
+
+/** @type ElementStateType */
+const ElementType = {
+  name: ELEMENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {ElementNode} */ node) {
+      const state = {
+        type: ElementType,
+        parent,
+        after,
+        shape: node.shape,
+        content: null,
+        ref: null,
+        refHooks: null,
+        rewriteChildIndex: 0,
+        children: null,
+        rewriteMemberIndex: 0,
+        members: null,
+      };
+      enqueueChange(queue, addElement, state);
+      return state;
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {ElementState} */ lastValue, /** @type {ElementNode} */ newValue) {
+      lastValue.rewriteMemberIndex = 0;
+      diffFragment(queue, lastValue, newValue);
+      if (lastValue.members !== null) {
+        const group = lastValue.members;
+        let index;
+        for (index = lastValue.rewriteMemberIndex; index < group.length; index++) {
+          const node = group[index];
+          node.type.teardown(queue, node);
+        }
+        if (lastValue.rewriteMemberIndex === 0) {
+          lastValue.members = null;
+        } else {
+          group.length = lastValue.rewriteMemberIndex;
+        }
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {ElementState} */ state) {
+      enqueueChange(queue, removeElement, state);
+      const {children} = state;
+      if (children !== null) {
+        for (let i = 0; i < children.length; i++) {
+          children[i].type.softTeardown(children[i]);
+        }
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (softTeardownElement),
+};
+
+/** @type {FragmentStateType} */
+const FragmentType = {
+  name: FRAGMENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init(queue, parent, after) {
+    return {
+      type: FragmentType,
+      parent,
+      after,
+      shape: FRAGMENT_TYPE_NAME,
+      content: null,
+      rewriteChildIndex: 0,
+      children: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (diffFragment),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {FragmentState} */ state) {
+      const {children} = state;
+      if (children !== null) {
+        for (let i = 0; i < children.length; i++) {
+          children[i].type.teardown(queue, children[i]);
+        }
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (softTeardownElement),
+};
+
+/** @type ComponentStateType */
+const ComponentType = {
+  name: COMPONENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {ComponentNode} */ node) {
+      return {
+        type: ComponentType,
+        parent,
+        after,
+        shape: node.shape,
+        content: null,
+        rendered: null,
+      };
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {ComponentState} */ lastChild, /** @type {ComponentNode} */ node) {
+      /** @type {MemberNode} */
+      const componentOptionsMeta = node.content.find(isOptions) || null;
+      const componentOptions = componentOptionsMeta ? componentOptionsMeta.value : null;
+      if (shallowEquals(lastChild.content, componentOptions) === false) {
+        lastChild.content = componentOptions;
+        queue.prepare.push(lastChild);
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {ComponentState} */ state) {
+      if (state.rendered !== null) {
+        state.rendered.type.teardown(queue, state.rendered);
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (
+    function (/** @type {ComponentState} */ state) {
+      if (state.rendered !== null) {
+        state.rendered.type.softTeardown(state.rendered);
+      }
+    }
+  ),
+};
+
+/** @type TextStateType */
+const TextType = {
+  name: TEXT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {TextNode} */ node) {
+      /** @type {TextState} */
+      const state = {
+        type: TextType,
+        parent,
+        after,
+        shape: TEXT_TYPE_NAME,
+        content: node.content,
+        ref: null,
+      };
+      enqueueChange(queue, addText, state);
+      return state;
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {TextState} */ lastChild, /** @type {TextNode} */ node) {
+      if (lastChild.content !== node.content) {
+        lastChild.content = node.content;
+        enqueueChange(queue, changeText, lastChild);
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {TextState} */ state) {
+      enqueueChange(queue, removeText, state);
+    }
+  ),
+  softTeardown() {},
+};
+
+/** @type {MemberStateType} */
+const AttributeType = {
+  name: ATTRIBUTE_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: AttributeType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ old, /** @type {MemberNode} */ memberNode) {
+      if (old.value !== memberNode.value) {
+        old.value = memberNode.value;
+        if (old.value === false) {
+          enqueueChange(queue, removeAttribute, old);
+        } else {
+          enqueueChange(queue, changeAttribute, old);
+        }
+      }
+    }
+  ),
+  teardown(queue, state) {
+    enqueueChange(queue, removeAttribute, state);
+  },
+};
+
+/** @type {MemberStateType} */
+const PropertyType = {
+  name: PROPERTY_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: PropertyType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ old, /** @type {MemberNode} */ memberNode) {
+      if (old.value !== memberNode.value) {
+        old.value = memberNode.value;
+        enqueueChange(queue, changeProperty, old);
+      }
+    }
+  ),
+  teardown(queue, state) {
+    state.value = undefined;
+    enqueueChange(queue, changeProperty, state);
+  },
+};
+
+/** @type {MemberStateType} */
+const RefType = {
+  name: REF_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: RefType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ state, /** @type {MemberNode} */ node) {
+      if (state.value !== node.value) {
+        state.value = node.value;
+        if (state.parent.refHooks === null) {
+          state.parent.refHooks = [];
+        }
+        if (state.parent.refHooks.indexOf(state) === -1) {
+          state.parent.refHooks.push(state);
+        }
+        enqueuePost(queue, updateRef, state);
+      }
+    }
+  ),
+  teardown(queue, state) {
+    const index = state.parent.refHooks.indexOf(state);
+    state.parent.refHooks.splice(index, 1);
+    if (state.parent.refHooks.length === 0) {
+      state.parent.refHooks = null;
+    }
+    enqueuePost(queue, unsetRef, state);
+  },
+};
+
+const typeMap = {
+  [ELEMENT_TYPE_NAME]: ElementType,
+  [FRAGMENT_TYPE_NAME]: FragmentType,
+  [COMPONENT_TYPE_NAME]: ComponentType,
+  [TEXT_TYPE_NAME]: TextType,
+  [ATTRIBUTE_TYPE_NAME]: AttributeType,
+  [PROPERTY_TYPE_NAME]: PropertyType,
+  [REF_TYPE_NAME]: RefType,
+};
+
+/** @type DiffEntryFunction */
+function diffChildEntry(queue, parent, /** @type NodeStateType */ metaType, /** @type NodeNode */ element) {
+  if (!parent.children) {
+    parent.children = [];
+  }
+  const index = parent.rewriteChildIndex++;
+  let state = parent.children[index];
+  if (!state || state.shape !== element.shape) {
+    if (state) {
+      state.type.teardown(queue, state);
+    }
+    state = /** @type {NodeState} */ (metaType.init(queue, parent, parent.children[index - 1] || null, element));
+    parent.children[index] = state;
+
+    const sibling = parent.children[index + 1];
+    if (sibling) {
+      sibling.after = state;
+    }
+  }
+  state.type.diff(queue, state, element);
+}
+
+/** @type {DiffFunction} */
+function diffFragment(
+  queue,
+  /** @type {ElementState | FragmentState} */ lastValue,
+  /** @type {ElementNode | FragmentNode} */ newValue
+) {
+  lastValue.rewriteChildIndex = 0;
+  const {content} = newValue;
+  for (let i = 0; i < content.length; i++) {
+    const node = content[i];
+    const metaType = typeMap[node.type];
+    metaType.diffEntry(queue, lastValue, metaType, node);
+  }
+  const children = lastValue.children;
+  if (children !== null) {
+    const childIndex = lastValue.rewriteChildIndex;
+    for (let i = childIndex; i < children.length; i++) {
+      const node = children[i];
+      node.type.teardown(queue, node);
+    }
+    if (childIndex === 0) {
+      lastValue.children = null;
+    } else {
+      children.length = childIndex;
+    }
+  }
+}
+
+/** @type {DiffEntryFunction} */
+function diffMemberEntry(
+  queue,
+  /** @type {ElementState} */ element,
+  /** @type {MemberStateType} */ nodeType,
+  /** @type {MemberNode} */ node
+) {
+  if (element.members === null) {
+    element.members = [];
+  }
+  const group = element.members;
+
+  const writeIndex = element.rewriteMemberIndex++;
+  let index;
+  for (index = writeIndex; index < group.length; index++) {
+    const item = group[index];
+    if (item.type.name === node.type && item.name === node.name) {
+      break;
+    }
+  }
+
+  let old = group[index];
+  if (index !== writeIndex) {
+    group[index] = group[writeIndex];
+  }
+  if (!old) {
+    old = nodeType.init(element, node.name);
+    group[writeIndex] = old;
+  }
+  old.type.diff(queue, old, node);
+}
+
+/** @type {SoftTeardownFunction} */
+function softTeardownElement(/** @type {ElementState} */ state) {
+  const {children} = state;
+  if (children !== null) {
+    for (let i = 0; i < children.length; i++) {
+      children[i].type.softTeardown(children[i]);
+    }
+  }
+}
+
+/**
+ * @param {Data} node
+ * @returns {node is MemberNode}
+ */
+function isOptions(node) {
+  return node.type === META_TYPE_NAME && node.name === "options";
+}
+
+/**
+ * @param {Queue} queue
+ */
+function runQueue(queue) {
+  const {prepare, changes: apply, post} = queue;
+  for (let i = 0; i < prepare.length; i++) {
+    changeViewRender(prepare[i], queue);
+  }
+  for (let i = 0; i < apply.length; i += 2) {
+    apply[i](apply[i + 1]);
+  }
+  for (let i = 0; i < post.length; i += 2) {
+    post[i](post[i + 1]);
+  }
+}
+
+/**
+ * @param {ComponentState} componentState
+ * @param {Queue} queue
+ */
+function changeViewRender(componentState, queue) {
+  const newRender = componentState.shape(componentState.content) || null;
+  if (newRender) {
+    const metaType = typeMap[newRender.type];
+    let lastRender = componentState.rendered;
+    if (!lastRender || lastRender.shape !== newRender.shape) {
+      if (lastRender) {
+        lastRender.type.teardown(queue, lastRender);
+      }
+      lastRender = metaType.init(queue, componentState, null, newRender);
+      componentState.rendered = lastRender;
+    }
+    lastRender.type.diff(queue, lastRender, newRender);
+  } else if (componentState.rendered) {
+    componentState.rendered.type.teardown(queue, componentState.rendered);
+    componentState.rendered = null;
+  }
+}
+
+/**
+ * @param {MemberState} state
+ */
+function changeProperty(state) {
+  state.parent.ref[state.name] = state.value;
+}
+
+/**
+ * @param {MemberState} state
+ */
+function removeAttribute(state) {
+  state.parent.ref.removeAttribute(state.name);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function changeAttribute(state) {
+  state.parent.ref.setAttribute(state.name, state.value);
+}
+
+/**
+ * @param {TextState} state
+ */
+function removeText(state) {
+  state.ref.parentNode.removeChild(state.ref);
+}
+
+/**
+ * @param {TextState} state
+ */
+function changeText(state) {
+  state.ref.textContent = state.content;
+}
+
+/**
+ * @param {TextState} state
+ */
+function addText(state) {
+  state.ref = document.createTextNode(state.content);
+  state.ref.textContent = state.content;
+  insertAfterSibling(state);
+}
+
+/**
+ * @param {NodeState} after
+ * @returns {NodeState}
+ */
+function deepestDescendant(after) {
+  if (after === null) {
+    return after;
+  } else if (after.type === FragmentType) {
+    const {children} = /** @type {FragmentState} */ (after);
+    if (children !== null) {
+      return deepestDescendant(children[children.length - 1]);
+    }
+  } else if (after.type === ComponentType) {
+    const {rendered} = /** @type {ComponentState} */ (after);
+    if (rendered !== null) {
+      return deepestDescendant(rendered);
+    }
+  }
+  return after;
+}
+
+/**
+ * @param {ElementState | TextState} element
+ */
+function insertAfterSibling(element) {
+  /** @type {NodeState} */
+  let state = element;
+  let after = deepestDescendant(state.after);
+  do {
+    if (after === null) {
+      if (state.parent.type === ElementType) {
+        break;
+      }
+      state = state.parent;
+      after = state;
+    }
+    if (after.type !== ElementType && after.type !== TextType) {
+      after = deepestDescendant(after.after);
+    }
+  } while (after === null || (after.type !== ElementType && after.type !== TextType));
+
+  if (after !== null) {
+    const {ref} = /** @type {ElementState | TextState} */ (after);
+    ref.parentNode.insertBefore(element.ref, ref.nextSibling);
+  } else {
+    const {ref} = /** @type {ElementState} */ (state.parent);
+    if (ref.childNodes.length) {
+      ref.insertBefore(element.ref, ref.childNodes[0]);
+    } else {
+      ref.appendChild(element.ref);
+    }
+  }
+}
+
+/**
+ * @param {ElementState} state
+ */
+function removeElement(state) {
+  state.ref.parentNode.removeChild(state.ref);
+  state.ref = null;
+}
+
+/**
+ * @param {ElementState} state
+ */
+function addElement(state) {
+  state.ref = document.createElement(state.shape);
+  insertAfterSibling(state);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function updateRef(state) {
+  state.value(state.parent.ref);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function unsetRef(state) {
+  state.value(null);
+}
+
+function shallowEquals(a, b) {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  for (const key of Object.keys(a)) {
+    if (key in b) {
+      if (a[key] !== b[key]) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  for (const key of Object.keys(b)) {
+    if (!(key in a)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @callback StateAction
+ * @param {S} state
+ * @template {State} S
+ */
+
+/**
+ * @returns {Queue}
+ */
+function newQueue() {
+  return {prepare: [], changes: [], post: []};
+}
+
+/**
+ * @param {Queue} queue
+ * @param {StateAction<S>} fn
+ * @param {S} state
+ * @template {State} S
+ */
+function enqueueChange(queue, fn, state) {
+  queue.changes.push(fn, state);
+}
+
+/**
+ * @param {Queue} queue
+ * @param {StateAction<S>} fn
+ * @param {S} state
+ * @template {State} S
+ */
+function enqueuePost(queue, fn, state) {
+  queue.post.push(fn, state);
+}
+
+/**
+ * @typedef Queue
+ * @property {Array} prepare
+ * @property {Array} changes
+ * @property {Array} post
+ */
+
+/**
+ * @callback DiffEntryFunction
+ * @param {Queue} queue
+ * @param {ElementState | FragmentState} parent
+ * @param {StateType} nodeType
+ * @param {Data} node
+ * @returns {void}
+ */
+
+/**
+ * @callback InitNodeFunction
+ * @param {Queue} queue
+ * @param {NodeState} parent
+ * @param {NodeState | null} after
+ * @param {NodeNode} node
+ * @returns {NodeState}
+ */
+
+/**
+ * @callback DiffFunction
+ * @param {Queue} queue
+ * @param {State} state
+ * @param {Data} node
+ * @returns {void}
+ */
+
+/**
+ * @callback TeardownFunction
+ * @param {Queue} queue
+ * @param {NodeState} state
+ * @returns {void}
+ */
+
+/**
+ * @callback SoftTeardownFunction
+ * @param {NodeState} state
+ * @returns {void}
+ */
+
+/**
+ * @typedef NodeStateTypeGeneric
+ * @property {Name} name
+ * @property {DiffEntryFunction} diffEntry
+ * @property {DiffFunction} diff
+ * @property {InitNodeFunction} init
+ * @property {TeardownFunction} teardown
+ * @property {SoftTeardownFunction} softTeardown
+ * @template {string | symbol} Name
+ */
+
+/**
+ * @typedef NodeStateTypeCreate
+ * @property {Name} name
+ * @property {(queue: Queue, parent: ElementState | FragmentState, meta: StateType, node: Node) => void} diffEntry
+ * @property {(queue: Queue, state: S, node: Node) => void} diff
+ * @property {(queue: Queue, parent: ElementState | FragmentState, after: NodeState, node: Node) => void} init
+ * @property {(queue: Queue, state: S) => void} teardown
+ * @property {(state: S) => void} softTeardown
+ * @template {string | symbol} Name
+ * @template {State} S
+ * @template {Data} Node
+ */
+
+/** @typedef {NodeStateTypeGeneric<typeof ELEMENT_TYPE_NAME>} ElementStateType */
+/** @typedef {NodeStateTypeGeneric<typeof FRAGMENT_TYPE_NAME>} FragmentStateType */
+/** @typedef {NodeStateTypeGeneric<typeof COMPONENT_TYPE_NAME>} ComponentStateType */
+/** @typedef {NodeStateTypeGeneric<typeof TEXT_TYPE_NAME>} TextStateType */
+
+/** @typedef {ElementStateType | FragmentStateType| ComponentStateType | TextStateType} NodeStateType */
+
+/**
+ * @callback InitMemberFunction
+ * @param {ElementState} parent
+ * @param {string} name
+ * @returns {MemberState}
+ */
+
+/**
+ * @callback TeardownMemberFunction
+ * @param {Queue} queue
+ * @param {MemberState} member
+ * @returns {void}
+ */
+
+/**
+ * @typedef MemberStateType
+ * @property {string | symbol} name
+ * @property {DiffEntryFunction} diffEntry
+ * @property {DiffFunction} diff
+ * @property {InitMemberFunction} init
+ * @property {TeardownMemberFunction} teardown
+ */
+
+/**
+ * @typedef {NodeStateType | MemberStateType} StateType
+ */
+
+/**
+ * @typedef ElementState
+ * @property {ElementStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {string} shape
+ * @property {null} content
+ * @property {HTMLElement | null} ref
+ * @property {MemberState[] | null} refHooks
+ * @property {number} rewriteChildIndex
+ * @property {NodeState[] | null} children
+ * @property {number} rewriteMemberIndex
+ * @property {MemberState[] | null} members
+ */
+
+/**
+ * @typedef FragmentState
+ * @property {FragmentStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {typeof FRAGMENT_TYPE_NAME} shape
+ * @property {null} content
+ * @property {number} rewriteChildIndex
+ * @property {NodeState[] | null} children
+ */
+
+/** @typedef {ElementState | FragmentState} ParentState */
+
+/**
+ * @typedef ComponentState
+ * @property {ComponentStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {function} shape
+ * @property {object} content
+ * @property {NodeState | null} rendered
+ */
+
+/**
+ * @typedef TextState
+ * @property {TextStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {typeof TEXT_TYPE_NAME} shape
+ * @property {string} content
+ * @property {Text | null} ref
+ */
+
+/**
+ * @typedef {ElementState | FragmentState | ComponentState | TextState} NodeState
+ */
+
+/**
+ * @typedef MemberState
+ * @property {MemberStateType} type
+ * @property {ElementState} parent
+ * @property {string} name
+ * @property {*} value
+ */
+
+/** @typedef {NodeState | MemberState} State */
+
+/** @typedef {typeof ELEMENT_TYPE_NAME | typeof FRAGMENT_TYPE_NAME | typeof COMPONENT_TYPE_NAME | typeof TEXT_TYPE_NAME} NodeNodeType */
+
+/** @typedef {typeof ATTRIBUTE_TYPE_NAME | typeof PROPERTY_TYPE_NAME | typeof REF_TYPE_NAME | typeof META_TYPE_NAME} MemberNodeType */
+
+/**
+ * @typedef ElementNode
+ * @property {typeof ELEMENT_TYPE_NAME} type
+ * @property {string} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef FragmentNode
+ * @property {typeof FRAGMENT_TYPE_NAME} type
+ * @property {typeof FRAGMENT_TYPE_NAME} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef TextNode
+ * @property {typeof TEXT_TYPE_NAME} type
+ * @property {typeof TEXT_TYPE_NAME} shape
+ * @property {string} content
+ */
+
+/**
+ * @typedef ComponentNode
+ * @property {typeof COMPONENT_TYPE_NAME} type
+ * @property {function} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef {ElementNode | FragmentNode | TextNode | ComponentNode} NodeNode
+ */
+
+/**
+ * @typedef MemberNode
+ * @property {MemberNodeType} type
+ * @property {string} name
+ * @property {*} value
+ */
+
+/** @typedef {NodeNode | MemberNode} Data */

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -44,9 +44,13 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
   const testPlanDirectory = path.join(rootDirectory, directory);
 
   const resourcesDirectory = path.join(testsDirectory, 'resources');
+
   const ariaAtHarnessFilePath = path.join(resourcesDirectory, 'aria-at-harness.mjs');
+  const ariaAtTestRunFilePath = path.join(resourcesDirectory, 'aria-at-test-run.mjs');
   const atCommandsFilePath = path.join(resourcesDirectory, 'at-commands.mjs');
   const keysFilePath = path.join(resourcesDirectory, 'keys.mjs');
+  const vrenderFilePath = path.join(resourcesDirectory, 'vrender.mjs');
+
   const supportFilePath = path.join(testsDirectory, 'support.json');
   const javascriptDirectory = path.join(testPlanDirectory, 'data', 'js');
   const testsCsvFilePath = path.join(testPlanDirectory, 'data', 'tests.csv');
@@ -63,9 +67,12 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
 
   const indexFileBuildOutputPath = path.join(testPlanBuildDirectory, 'index.html');
   const supportFileBuildPath = path.join(testsBuildDirectory, 'support.json');
+
   const ariaAtHarnessFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-harness.mjs');
+  const ariaAtTestRunFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-test-run.mjs');
   const atCommandsFileBuildPath = path.join(resourcesBuildDirectory, 'at-commands.mjs');
   const keysFileBuildPath = path.join(resourcesBuildDirectory, 'keys.mjs');
+  const vrenderFileBuildPath = path.join(resourcesBuildDirectory, 'vrender.mjs');
 
   // create directories if not exists
   fs.existsSync(buildDirectory) || fs.mkdirSync(buildDirectory);
@@ -75,9 +82,13 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
 
   // ensure the build folder has the files it needs for running local server
   fse.copySync(supportFilePath, supportFileBuildPath, {overwrite: true});
+
   fse.copySync(ariaAtHarnessFilePath, ariaAtHarnessFileBuildPath, {overwrite: true});
+  fse.copySync(ariaAtTestRunFilePath, ariaAtTestRunFileBuildPath, {overwrite: true});
   fse.copySync(atCommandsFilePath, atCommandsFileBuildPath, {overwrite: true});
   fse.copySync(keysFilePath, keysFileBuildPath, {overwrite: true});
+  fse.copySync(vrenderFilePath, vrenderFileBuildPath, {overwrite: true});
+
   fse.copySync(referenceDirectory, referenceBuildDirectory, {overwrite: true});
 
   const keyDefs = {};

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -573,7 +573,11 @@ function renderVirtualInstructionDocument(doc) {
 
     instructAssertions(doc.instructions.assertions),
 
-    button(onclick(doc.instructions.openTestPage.click), rich(doc.instructions.openTestPage.button)),
+    button(
+      disabled(!doc.instructions.openTestPage.enabled),
+      onclick(doc.instructions.openTestPage.click),
+      rich(doc.instructions.openTestPage.button)
+    ),
 
     resultHeader(doc.results.header),
 

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -791,6 +791,10 @@ function renderVirtualResultsTable(results) {
 }
 
 /**
+ * Passing assertion values submitted from the tester result form.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ *
  * @typedef SubmitResultDetailsCommandsAssertionsPass
  * @property {string} assertion
  * @property {string} priority
@@ -802,6 +806,11 @@ const AssertionPassJSONMap = createEnumMap({
 });
 
 /**
+ * Failing assertion values from the tester result form as are submitted in the
+ * JSON result object.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ *
  * @typedef SubmitResultDetailsCommandsAssertionsFail
  * @property {string} assertion
  * @property {string} priority
@@ -816,7 +825,16 @@ const AssertionFailJSONMap = createEnumMap({
 
 /** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
 
-/** @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON */
+/**
+ * Command result derived from priority 1 and 2 assertions.
+ *
+ * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
+ * if priority 2 assertions fail.
+ *
+ * In the submitted json object values may contain spaces and are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
+ */
 
 const CommandSupportJSONMap = createEnumMap({
   FULL: "FULL",
@@ -825,6 +843,10 @@ const CommandSupportJSONMap = createEnumMap({
 });
 
 /**
+ * Highest level status submitted from test result.
+ *
+ * In the submitted json object values are in ALL CAPS.
+ *
  * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
  */
 

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -791,14 +791,17 @@ function renderVirtualResultsTable(results) {
 }
 
 /**
- * Passing assertion values submitted from the tester result form.
- *
- * In the submitted json object the values contain spaces and are title cased.
- *
  * @typedef SubmitResultDetailsCommandsAssertionsPass
  * @property {string} assertion
  * @property {string} priority
- * @property {EnumValues<typeof AssertionPassJSONMap>} pass
+ * @property {AssertionPassJSON} pass
+ */
+
+/**
+ * Passing assertion values submitted from the tester result form.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
  */
 
 const AssertionPassJSONMap = createEnumMap({
@@ -806,15 +809,18 @@ const AssertionPassJSONMap = createEnumMap({
 });
 
 /**
+ * @typedef SubmitResultDetailsCommandsAssertionsFail
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionFailJSON} fail
+ */
+
+/**
  * Failing assertion values from the tester result form as are submitted in the
  * JSON result object.
  *
  * In the submitted json object the values contain spaces and are title cased.
- *
- * @typedef SubmitResultDetailsCommandsAssertionsFail
- * @property {string} assertion
- * @property {string} priority
- * @property {EnumValues<typeof AssertionFailJSONMap>} fail
+ * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
  */
 
 const AssertionFailJSONMap = createEnumMap({

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -1,0 +1,1252 @@
+export class TestRun {
+  /**
+   * @param {object} param0
+   * @param {Partial<TestRunHooks>} [param0.hooks]
+   * @param {TestRunState} param0.state
+   */
+  constructor({hooks, state}) {
+    /** @type {TestRunState} */
+    this.state = state;
+
+    const bindDispatch = transform => arg => this.dispatch(transform(arg));
+    /** @type {TestRunHooks} */
+    this.hooks = {
+      closeTestPage: bindDispatch(userCloseWindow),
+      focusCommandUnexpectedBehavior: bindDispatch(userFocusCommandUnexpectedBehavior),
+      openTestPage: bindDispatch(userOpenWindow),
+      postResults: () => {},
+      setCommandAdditionalAssertion: bindDispatch(userChangeCommandAdditionalAssertion),
+      setCommandAssertion: bindDispatch(userChangeCommandAssertion),
+      setCommandHasUnexpectedBehavior: bindDispatch(userChangeCommandHasUnexpectedBehavior),
+      setCommandUnexpectedBehavior: bindDispatch(userChangeCommandUnexpectedBehavior),
+      setCommandUnexpectedBehaviorMore: bindDispatch(userChangeCommandUnexpectedBehaviorMore),
+      setCommandOutput: bindDispatch(userChangeCommandOutput),
+      submit: () => submitResult(this),
+      ...hooks,
+    };
+
+    this.observers = [];
+
+    this.dispatch = this.dispatch.bind(this);
+  }
+
+  /**
+   * @param {(state: TestRunState) => TestRunState} updateMethod
+   */
+  dispatch(updateMethod) {
+    this.state = updateMethod(this.state);
+    this.observers.forEach(subscriber => subscriber(this));
+  }
+
+  /**
+   * @param {(app: TestRun) => void} subscriber
+   * @returns {() => void}
+   */
+  observe(subscriber) {
+    this.observers.push(subscriber);
+    return () => {
+      const index = this.observers.indexOf(subscriber);
+      if (index > -1) {
+        this.observers.splice(index, 1);
+      }
+    };
+  }
+
+  testPage() {
+    return testPageDocument(this.state, this.hooks);
+  }
+
+  instructions() {
+    return instructionDocument(this.state, this.hooks);
+  }
+
+  resultsTable() {
+    return resultsTableDocument(this.state);
+  }
+}
+
+/**
+ * @param {U} map
+ * @returns {Readonly<U>}
+ * @template {string} T
+ * @template {{[key: string]: T}} U
+ */
+export function createEnumMap(map) {
+  return Object.freeze(map);
+}
+
+export const WhitespaceStyleMap = createEnumMap({
+  LINE_BREAK: "lineBreak",
+});
+
+function bind(fn, ...args) {
+  return (...moreArgs) => fn(...args, ...moreArgs);
+}
+
+/**
+ * @param {TestRunState} resultState
+ * @param {TestRunHooks} hooks
+ * @returns {InstructionDocument}
+ */
+export function instructionDocument(resultState, hooks) {
+  const mode = resultState.info.mode;
+  const modeInstructions = resultState.info.modeInstructions;
+  const userInstructions = resultState.info.userInstructions;
+  const lastInstruction = userInstructions[userInstructions.length - 1];
+  const setupScriptDescription = resultState.info.setupScriptDescription
+    ? ` and runs a script that ${resultState.info.setupScriptDescription}.`
+    : resultState.info.setupScriptDescription;
+  // As a hack, special case mode instructions for VoiceOver for macOS until we
+  // support modeless tests. ToDo: remove this when resolving issue #194
+  const modePhrase =
+    resultState.config.at.name === "VoiceOver for macOS"
+      ? "Describe "
+      : `With ${resultState.config.at.name} in ${mode} mode, describe `;
+
+  const commands = resultState.commands.map(({description}) => description);
+  const assertions = resultState.commands[0].assertions.map(({description}) => description);
+  const additionalAssertions = resultState.commands[0].additionalAssertions.map(({description}) => description);
+
+  let firstRequired = true;
+  function focusFirstRequired() {
+    if (firstRequired) {
+      firstRequired = false;
+      return true;
+    }
+    return false;
+  }
+
+  return {
+    errors: {
+      visible: false,
+      header: "",
+      errors: [],
+    },
+    instructions: {
+      header: {
+        header: `Testing task: ${resultState.info.description}`,
+        focus: resultState.currentUserAction === UserActionMap.LOAD_PAGE,
+      },
+      description: `${modePhrase} how ${resultState.config.at.name} behaves when performing task "${lastInstruction}"`,
+      instructions: {
+        header: "Test instructions",
+        instructions: [
+          [
+            `Restore default settings for ${resultState.config.at.name}. For help, read `,
+            {
+              href: "https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing",
+              description: "Configuring Screen Readers for Testing",
+            },
+            `.`,
+          ],
+          `Activate the "Open test page" button below, which opens the example to test in a new window${setupScriptDescription}`,
+        ],
+        strongInstructions: [modeInstructions, ...userInstructions],
+        commands: {
+          description: `Using the following commands, ${lastInstruction}`,
+          commands,
+        },
+      },
+      assertions: {
+        header: "Success Criteria",
+        description: `To pass this test, ${resultState.config.at.name} needs to meet all the following assertions when each  specified command is executed:`,
+        assertions,
+      },
+      openTestPage: {
+        button: "Open Test Page",
+        enabled: resultState.openTest.enabled,
+        click: hooks.openTestPage,
+      },
+    },
+    results: {
+      header: {
+        header: "Record Results",
+        description: `${resultState.info.description}`,
+      },
+      commands: commands.map(commandResult),
+    },
+    submit: resultState.config.displaySubmitButton
+      ? {
+          button: "Submit Results",
+          click: hooks.submit,
+        }
+      : null,
+  };
+
+  /**
+   * @param {T} resultAssertion
+   * @param {T["result"]} resultValue
+   * @param {Omit<InstructionDocumentAssertionChoice, 'checked' | 'focus'>} partialChoice
+   * @returns {InstructionDocumentAssertionChoice}
+   * @template {TestRunAssertion | TestRunAdditionalAssertion} T
+   */
+  function assertionChoice(resultAssertion, resultValue, partialChoice) {
+    return {
+      ...partialChoice,
+      checked: resultAssertion.result === resultValue,
+      focus:
+        resultState.currentUserAction === "validateResults" &&
+        resultAssertion.highlightRequired &&
+        focusFirstRequired(),
+    };
+  }
+
+  /**
+   * @param {string} command
+   * @param {number} commandIndex
+   * @returns {InstructionDocumentResultsCommand}
+   */
+  function commandResult(command, commandIndex) {
+    const resultStateCommand = resultState.commands[commandIndex];
+    const resultUnexpectedBehavior = resultStateCommand.unexpected;
+    return {
+      header: `After '${command}'`,
+      atOutput: {
+        description: [
+          `${resultState.config.at.name} output after ${command}`,
+          {
+            required: true,
+            highlightRequired: resultStateCommand.atOutput.highlightRequired,
+            description: "(required)",
+          },
+        ],
+        value: resultStateCommand.atOutput.value,
+        focus:
+          resultState.currentUserAction === "validateResults" &&
+          resultStateCommand.atOutput.highlightRequired &&
+          focusFirstRequired(),
+        change: atOutput => hooks.setCommandOutput({commandIndex, atOutput}),
+      },
+      assertionsHeader: {
+        descriptionHeader: "",
+        passHeader: "",
+        failHeader: "",
+      },
+      assertions: [
+        ...assertions.map(bind(assertionResult, commandIndex)),
+        ...additionalAssertions.map(bind(additionalAssertionResult, commandIndex)),
+      ],
+      unexpectedBehaviors: {
+        description: [
+          "Were there additional undesirable behaviors?",
+          {
+            required: true,
+            highlightRequired: resultStateCommand.unexpected.highlightRequired,
+            description: "(required)",
+          },
+        ],
+        passChoice: {
+          label: "No, there were no additional undesirable behaviors.",
+          checked: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+          focus:
+            resultState.currentUserAction === "validateResults" &&
+            resultUnexpectedBehavior.highlightRequired &&
+            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            focusFirstRequired(),
+          click: () =>
+            hooks.setCommandHasUnexpectedBehavior({
+              commandIndex,
+              hasUnexpected: HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+            }),
+        },
+        failChoice: {
+          label: "Yes, there were additional undesirable behaviors",
+          checked: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+          focus:
+            resultState.currentUserAction === "validateResults" &&
+            resultUnexpectedBehavior.highlightRequired &&
+            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            focusFirstRequired(),
+          click: () =>
+            hooks.setCommandHasUnexpectedBehavior({
+              commandIndex,
+              hasUnexpected: HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+            }),
+          options: {
+            header: "Undesirable behaviors",
+            options: resultUnexpectedBehavior.behaviors.map((behavior, unexpectedIndex) => {
+              return {
+                description: behavior.description,
+                enabled: resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+                tabbable: resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex,
+                checked: behavior.checked,
+                focus:
+                  typeof resultState.currentUserAction === "object" &&
+                  resultState.currentUserAction.action === UserObjectActionMap.FOCUS_UNDESIRABLE
+                    ? resultState.currentUserAction.commandIndex === commandIndex &&
+                      resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex
+                    : resultState.currentUserAction === UserActionMap.VALIDATE_RESULTS &&
+                      resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+                      resultUnexpectedBehavior.behaviors.every(({checked}) => !checked) &&
+                      focusFirstRequired(),
+                change: checked => hooks.setCommandUnexpectedBehavior({commandIndex, unexpectedIndex, checked}),
+                keydown: key => {
+                  const increment = keyToFocusIncrement(key);
+                  if (increment) {
+                    hooks.focusCommandUnexpectedBehavior({commandIndex, unexpectedIndex, increment});
+                    return true;
+                  }
+                  return false;
+                },
+                more: behavior.more
+                  ? {
+                      description: /** @type {Description[]} */ ([
+                        `If "other" selected, explain`,
+                        {
+                          required: true,
+                          highlightRequired: behavior.more.highlightRequired,
+                          description: "(required)",
+                        },
+                      ]),
+                      enabled: behavior.checked,
+                      value: behavior.more.value,
+                      focus:
+                        resultState.currentUserAction === "validateResults" &&
+                        behavior.more.highlightRequired &&
+                        focusFirstRequired(),
+                      change: value =>
+                        hooks.setCommandUnexpectedBehaviorMore({commandIndex, unexpectedIndex, more: value}),
+                    }
+                  : null,
+              };
+            }),
+          },
+        },
+      },
+    };
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {string} assertion
+   * @param {number} assertionIndex
+   */
+  function assertionResult(commandIndex, assertion, assertionIndex) {
+    const resultAssertion = resultState.commands[commandIndex].assertions[assertionIndex];
+    return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
+      description: [
+        assertion,
+        {
+          required: true,
+          highlightRequired: resultAssertion.highlightRequired,
+          description: "(required: mark output)",
+        },
+      ],
+      passChoice: assertionChoice(resultAssertion, CommonResultMap.PASS, {
+        label: [
+          `Good Output `,
+          {
+            offScreen: true,
+            description: "for assertion",
+          },
+        ],
+        click: () => hooks.setCommandAssertion({commandIndex, assertionIndex, result: CommonResultMap.PASS}),
+      }),
+      failChoices: [
+        assertionChoice(resultAssertion, AssertionResultMap.FAIL_MISSING, {
+          label: [
+            `No Output `,
+            {
+              offScreen: true,
+              description: "for assertion",
+            },
+          ],
+          click: () =>
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+        }),
+        assertionChoice(resultAssertion, AssertionResultMap.FAIL_INCORRECT, {
+          label: [
+            `Incorrect Output `,
+            {
+              offScreen: true,
+              description: "for assertion",
+            },
+          ],
+          click: () =>
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+        }),
+      ],
+    });
+  }
+
+  /**
+   * @param {number} commandIndex
+   * @param {string} assertion
+   * @param {number} assertionIndex
+   */
+  function additionalAssertionResult(commandIndex, assertion, assertionIndex) {
+    const resultAdditionalAssertion = resultState.commands[commandIndex].additionalAssertions[assertionIndex];
+    return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
+      description: [
+        assertion,
+        {
+          required: true,
+          highlightRequired: resultAdditionalAssertion.highlightRequired,
+          description: "(required: mark support)",
+        },
+      ],
+      passChoice: assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.PASS, {
+        label: ["Good Support ", {offScreen: true, description: "for assertion"}],
+        click: () =>
+          hooks.setCommandAdditionalAssertion({
+            commandIndex,
+            additionalAssertionIndex: assertionIndex,
+            result: AdditionalAssertionResultMap.PASS,
+          }),
+      }),
+      failChoices: [
+        assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.FAIL_SUPPORT, {
+          label: ["No Support ", {offScreen: true, description: "for assertion"}],
+          click: () =>
+            hooks.setCommandAdditionalAssertion({
+              commandIndex,
+              additionalAssertionIndex: assertionIndex,
+              result: AdditionalAssertionResultMap.FAIL_SUPPORT,
+            }),
+        }),
+      ],
+    });
+  }
+}
+
+/**
+ * @typedef {typeof UserActionMap[keyof typeof UserActionMap]} UserAction
+ */
+
+export const UserActionMap = createEnumMap({
+  LOAD_PAGE: "loadPage",
+  OPEN_TEST_WINDOW: "openTestWindow",
+  CLOSE_TEST_WINDOW: "closeTestWindow",
+  VALIDATE_RESULTS: "validateResults",
+  CHANGE_TEXT: "changeText",
+  CHANGE_SELECTION: "changeSelection",
+  SHOW_RESULTS: "showResults",
+});
+
+/**
+ * @typedef {typeof UserObjectActionMap[keyof typeof UserObjectActionMap]} UserObjectAction
+ */
+
+export const UserObjectActionMap = createEnumMap({
+  FOCUS_UNDESIRABLE: "focusUndesirable",
+});
+
+/**
+ * @typedef {UserAction | UserActionFocusUnexpected} TestRunUserAction
+ */
+
+/**
+ * @typedef {EnumValues<typeof HasUnexpectedBehaviorMap>} HasUnexpectedBehavior
+ */
+
+export const HasUnexpectedBehaviorMap = createEnumMap({
+  NOT_SET: "notSet",
+  HAS_UNEXPECTED: "hasUnexpected",
+  DOES_NOT_HAVE_UNEXPECTED: "doesNotHaveUnexpected",
+});
+
+export const CommonResultMap = createEnumMap({
+  NOT_SET: "notSet",
+  PASS: "pass",
+});
+
+/**
+ * @typedef {EnumValues<typeof AdditionalAssertionResultMap>} AdditionalAssertionResult
+ */
+
+export const AdditionalAssertionResultMap = createEnumMap({
+  ...CommonResultMap,
+  FAIL_SUPPORT: "failSupport",
+});
+
+/**
+ * @typedef {EnumValues<typeof AssertionResultMap>} AssertionResult
+ */
+
+export const AssertionResultMap = createEnumMap({
+  ...CommonResultMap,
+  FAIL_MISSING: "failMissing",
+  FAIL_INCORRECT: "failIncorrect",
+});
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {string} props.atOutput
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandOutput({commandIndex, atOutput}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_TEXT,
+      commands: state.commands.map((commandState, index) =>
+        index !== commandIndex
+          ? commandState
+          : {
+              ...commandState,
+              atOutput: {
+                ...commandState.atOutput,
+                value: atOutput,
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.assertionIndex
+ * @param {AssertionResult} props.result
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandAssertion({commandIndex, assertionIndex, result}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              assertions: command.assertions.map((assertion, assertionI) =>
+                assertionI !== assertionIndex ? assertion : {...assertion, result}
+              ),
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.additionalAssertionIndex
+ * @param {AdditionalAssertionResult} props.result
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandAdditionalAssertion({commandIndex, additionalAssertionIndex, result}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              additionalAssertions: command.additionalAssertions.map((assertion, assertionI) =>
+                assertionI !== additionalAssertionIndex ? assertion : {...assertion, result}
+              ),
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {HasUnexpectedBehavior} props.hasUnexpected
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandHasUnexpectedBehavior({commandIndex, hasUnexpected}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                hasUnexpected: hasUnexpected,
+                tabbedBehavior: hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED ? 0 : -1,
+                behaviors: command.unexpected.behaviors.map(behavior => ({
+                  ...behavior,
+                  checked: false,
+                  more: behavior.more ? {...behavior.more, value: ""} : null,
+                })),
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {boolean} props.checked
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandUnexpectedBehavior({commandIndex, unexpectedIndex, checked}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_SELECTION,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
+                  unexpectedI !== unexpectedIndex
+                    ? unexpected
+                    : {
+                        ...unexpected,
+                        checked,
+                      }
+                ),
+              },
+            }
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {string} props.more
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandUnexpectedBehaviorMore({commandIndex, unexpectedIndex, more}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_TEXT,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : /** @type {TestRunCommand} */ ({
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
+                  unexpectedI !== unexpectedIndex
+                    ? unexpected
+                    : /** @type {TestRunUnexpectedBehavior} */ ({
+                        ...unexpected,
+                        more: {
+                          ...unexpected.more,
+                          value: more,
+                        },
+                      })
+                ),
+              },
+            })
+      ),
+    };
+  };
+}
+
+/**
+ * @param {string} key
+ * @returns {TestRunFocusIncrement}
+ */
+function keyToFocusIncrement(key) {
+  switch (key) {
+    case "Up":
+    case "ArrowUp":
+    case "Left":
+    case "ArrowLeft":
+      return "previous";
+
+    case "Down":
+    case "ArrowDown":
+    case "Right":
+    case "ArrowRight":
+      return "next";
+  }
+}
+
+/**
+ * @param {TestRunState} state
+ * @param {TestRunHooks} hooks
+ * @returns {TestPageDocument}
+ */
+function testPageDocument(state, hooks) {
+  if (state.currentUserAction === UserActionMap.SHOW_RESULTS) {
+    return {
+      results: resultsTableDocument(state),
+    };
+  }
+  return {
+    errors: null,
+    instructions: instructionDocument(state, hooks),
+  };
+}
+
+/**
+ * @param {TestRun} app
+ */
+function submitResult(app) {
+  app.dispatch(userValidateState());
+
+  if (isSomeFieldRequired(app.state)) {
+    return;
+  }
+
+  app.hooks.postResults();
+
+  app.hooks.closeTestPage();
+
+  if (app.state.config.renderResultsAfterSubmit) {
+    app.dispatch(userShowResults());
+  }
+}
+
+export function userShowResults() {
+  return function (/** @type {TestRunState} */ state) {
+    return /** @type {TestRunState} */ ({...state, currentUserAction: UserActionMap.SHOW_RESULTS});
+  };
+}
+
+/**
+ * @param {TestRunState} state
+ * @returns
+ */
+function isSomeFieldRequired(state) {
+  return state.commands.some(
+    command =>
+      command.atOutput.value.trim() === "" ||
+      command.assertions.some(assertion => assertion.result === CommonResultMap.NOT_SET) ||
+      command.additionalAssertions.some(assertion => assertion.result === CommonResultMap.NOT_SET) ||
+      command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
+      (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+        (command.unexpected.behaviors.every(({checked}) => !checked) ||
+          command.unexpected.behaviors.some(
+            behavior => behavior.checked && behavior.more && behavior.more.value.trim() === ""
+          )))
+  );
+}
+
+/**
+ * @param {TestRunState} state
+ * @returns {ResultsTableDocument}
+ */
+function resultsTableDocument(state) {
+  return {
+    header: state.info.description,
+    status: {
+      header: [
+        "Test result: ",
+        state.commands.some(
+          ({assertions, additionalAssertions, unexpected}) =>
+            [...assertions, ...additionalAssertions].some(
+              ({priority, result}) => priority === 1 && result !== CommonResultMap.PASS
+            ) || unexpected.behaviors.some(({checked}) => checked)
+        )
+          ? "FAIL"
+          : "PASS",
+      ],
+    },
+    table: {
+      headers: {
+        description: "Command",
+        support: "Support",
+        details: "Details",
+      },
+      commands: state.commands.map(command => {
+        const allAssertions = [...command.assertions, ...command.additionalAssertions];
+
+        let passingAssertions = ["No passing assertions."];
+        let failingAssertions = ["No failing assertions."];
+        let unexpectedBehaviors = ["No unexpect behaviors."];
+
+        if (allAssertions.some(({result}) => result === CommonResultMap.PASS)) {
+          passingAssertions = allAssertions
+            .filter(({result}) => result === CommonResultMap.PASS)
+            .map(({description}) => description);
+        }
+        if (allAssertions.some(({result}) => result !== CommonResultMap.PASS)) {
+          failingAssertions = allAssertions
+            .filter(({result}) => result !== CommonResultMap.PASS)
+            .map(({description}) => description);
+        }
+        if (command.unexpected.behaviors.some(({checked}) => checked)) {
+          unexpectedBehaviors = command.unexpected.behaviors
+            .filter(({checked}) => checked)
+            .map(({description, more}) => (more ? more.value : description));
+        }
+
+        return {
+          description: command.description,
+          support:
+            allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
+            command.unexpected.behaviors.some(({checked}) => checked)
+              ? "FAILING"
+              : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
+              ? "ALL_REQUIRED"
+              : "FULL",
+          details: {
+            output: /** @type {Description} */ [
+              "output:",
+              /** @type {DescriptionWhitespace} */ ({whitespace: WhitespaceStyleMap.LINE_BREAK}),
+              " ",
+              ...command.atOutput.value
+                .split(/(\r\n|\r|\n)/g)
+                .map(output =>
+                  /\r\n|\r|\n/.test(output)
+                    ? /** @type {DescriptionWhitespace} */ ({whitespace: WhitespaceStyleMap.LINE_BREAK})
+                    : output
+                ),
+            ],
+            passingAssertions: {
+              description: "Passing Assertions:",
+              items: passingAssertions,
+            },
+            failingAssertions: {
+              description: "Failing Assertions:",
+              items: failingAssertions,
+            },
+            unexpectedBehaviors: {
+              description: "Unexpected Behavior",
+              items: unexpectedBehaviors,
+            },
+          },
+        };
+      }),
+    },
+  };
+}
+
+export function userOpenWindow() {
+  return (/** @type {TestRunState} */ state) =>
+    /** @type {TestRunState} */ ({
+      ...state,
+      currentUserAction: UserActionMap.OPEN_TEST_WINDOW,
+      openTest: {...state.openTest, enabled: false},
+    });
+}
+
+export function userCloseWindow() {
+  return (/** @type {TestRunState} */ state) =>
+    /** @type {TestRunState} */ ({
+      ...state,
+      currentUserAction: UserActionMap.CLOSE_TEST_WINDOW,
+      openTest: {...state.openTest, enabled: true},
+    });
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
+ * @param {TestRunFocusIncrement} props.increment
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userFocusCommandUnexpectedBehavior({commandIndex, unexpectedIndex, increment}) {
+  return function (state) {
+    const unexpectedLength = state.commands[commandIndex].unexpected.behaviors.length;
+    const incrementValue = increment === "next" ? 1 : -1;
+    const newUnexpectedIndex = (unexpectedIndex + incrementValue + unexpectedLength) % unexpectedLength;
+
+    return {
+      ...state,
+      currentUserAction: {
+        action: UserObjectActionMap.FOCUS_UNDESIRABLE,
+        commandIndex,
+        unexpectedIndex: newUnexpectedIndex,
+      },
+      commands: state.commands.map((command, commandI) => {
+        const tabbed = command.unexpected.tabbedBehavior;
+        const unexpectedLength = command.unexpected.behaviors.length;
+        const newTabbed = (tabbed + (increment === "next" ? 1 : -1) + unexpectedLength) % unexpectedLength;
+        return commandI !== commandIndex
+          ? command
+          : {
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                tabbedBehavior: newTabbed,
+              },
+            };
+      }),
+    };
+  };
+}
+
+/**
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userValidateState() {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.VALIDATE_RESULTS,
+      commands: state.commands.map(command => {
+        return {
+          ...command,
+          atOutput: {
+            ...command.atOutput,
+            highlightRequired: !command.atOutput.value.trim(),
+          },
+          assertions: command.assertions.map(assertion => ({
+            ...assertion,
+            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
+          })),
+          additionalAssertions: command.additionalAssertions.map(assertion => ({
+            ...assertion,
+            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
+          })),
+          unexpected: {
+            ...command.unexpected,
+            highlightRequired:
+              command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
+              (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+                command.unexpected.behaviors.every(({checked}) => !checked)),
+            behaviors: command.unexpected.behaviors.map(unexpected => {
+              return unexpected.more
+                ? {
+                    ...unexpected,
+                    more: {
+                      ...unexpected.more,
+                      highlightRequired: unexpected.checked && !unexpected.more.value.trim(),
+                    },
+                  }
+                : unexpected;
+            }),
+          },
+        };
+      }),
+    };
+  };
+}
+
+/**
+ * @typedef AT
+ * @property {string} name
+ * @property {string} key
+ */
+
+/**
+ * @typedef Behavior
+ * @property {string} description
+ * @property {string} task
+ * @property {string} mode
+ * @property {string} modeInstructions
+ * @property {string[]} appliesTo
+ * @property {string} specificUserInstruction
+ * @property {string} setupScriptDescription
+ * @property {string} setupTestPage
+ * @property {string[]} commands
+ * @property {[string, string][]} outputAssertions
+ * @property {[number, string][]} additionalAssertions
+ */
+
+/**
+ * @typedef {"previous" | "next"} TestRunFocusIncrement
+ */
+
+/**
+ * @typedef {(action: (state: TestRunState) => TestRunState) => void} Dispatcher
+ */
+
+/**
+ * @typedef InstructionDocumentButton
+ * @property {Description} button
+ * @property {boolean} [enabled]
+ * @property {() => void} click
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptionsOptionsMore
+ * @property {Description} description
+ * @property {string} value
+ * @property {boolean} enabled
+ * @property {boolean} [focus]
+ * @property {(value: string) => void} change
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptionsOption
+ * @property {Description} description
+ * @property {boolean} checked
+ * @property {boolean} enabled
+ * @property {boolean} tabbable
+ * @property {boolean} [focus]
+ * @property {(checked: boolean) => void} change
+ * @property {(key: string) => boolean} keydown
+ * @property {InstructionDocumentAssertionChoiceOptionsOptionsMore} [more]
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoiceOptions
+ * @property {Description} header
+ * @property {InstructionDocumentAssertionChoiceOptionsOption[]} options
+ */
+
+/**
+ * @typedef InstructionDocumentAssertionChoice
+ * @property {Description} label
+ * @property {boolean} checked
+ * @property {boolean} [focus]
+ * @property {() => void} click
+ * @property {InstructionDocumentAssertionChoiceOptions} [options]
+ */
+
+/**
+ * @typedef DescriptionRich
+ * @property {string} [href]
+ * @property {boolean} [required]
+ * @property {boolean} [highlightRequired]
+ * @property {boolean} [offScreen]
+ * @property {Description} description
+ */
+
+/**
+ * @typedef DescriptionWhitespace
+ * @property {typeof WhitespaceStyleMap["LINE_BREAK"]} whitespace
+ */
+
+/** @typedef {string | DescriptionRich | DescriptionWhitespace | DescriptionArray} Description */
+
+/** @typedef {Description[]} DescriptionArray */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsAssertion
+ * @property {Description} description
+ * @property {InstructionDocumentAssertionChoice} passChoice
+ * @property {InstructionDocumentAssertionChoice[]} failChoices
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsAssertionsHeader
+ * @property {Description} descriptionHeader
+ * @property {Description} passHeader
+ * @property {Description} failHeader
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsATOutput
+ * @property {Description} description
+ * @property {string} value
+ * @property {boolean} focus
+ * @property {(value: string) => void} change
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommandsUnexpected
+ * @property {Description} description
+ * @property {InstructionDocumentAssertionChoice} passChoice
+ * @property {InstructionDocumentAssertionChoice} failChoice
+ */
+
+/**
+ * @typedef InstructionDocumentResultsCommand
+ * @property {Description} header
+ * @property {InstructionDocumentResultsCommandsATOutput} atOutput
+ * @property {InstructionDocumentResultsCommandsAssertionsHeader} assertionsHeader
+ * @property {InstructionDocumentResultsCommandsAssertion[]} assertions
+ * @property {InstructionDocumentResultsCommandsUnexpected} unexpectedBehaviors
+ */
+
+/**
+ * @typedef InstructionDocumentResultsHeader
+ * @property {Description} header
+ * @property {Description} description
+ */
+
+/**
+ * @typedef InstructionDocumentResults
+ * @property {InstructionDocumentResultsHeader} header
+ * @property {InstructionDocumentResultsCommand[]} commands
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsInstructionsCommands
+ * @property {Description} description
+ * @property {Description[]} commands
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsInstructions
+ * @property {Description} header
+ * @property {Description[]} instructions
+ * @property {Description[]} strongInstructions
+ * @property {InstructionDocumentInstructionsInstructionsCommands} commands
+ */
+
+/**
+ * @typedef InstructionDocumentErrors
+ * @property {boolean} visible
+ * @property {Description} header
+ * @property {Description[]} errors
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsHeader
+ * @property {Description} header
+ * @property {boolean} focus
+ */
+
+/**
+ * @typedef InstructionDocumentInstructionsAssertions
+ * @property {Description} header
+ * @property {Description} description
+ * @property {Description[]} assertions
+ */
+
+/**
+ * @typedef InstructionDocumentInstructions
+ * @property {InstructionDocumentInstructionsHeader} header
+ * @property {Description} description
+ * @property {InstructionDocumentInstructionsInstructions} instructions
+ * @property {InstructionDocumentInstructionsAssertions} assertions
+ * @property {InstructionDocumentButton} openTestPage
+ */
+
+/**
+ * @typedef InstructionDocument
+ * @property {InstructionDocumentErrors} errors
+ * @property {InstructionDocumentInstructions} instructions
+ * @property {InstructionDocumentResults} results
+ * @property {InstructionDocumentButton} submit
+ */
+
+/**
+ * @typedef TestRunHooks
+ * @property {() => void} closeTestPage
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, increment: TestRunFocusIncrement}) => void} focusCommandUnexpectedBehavior
+ * @property {() => void} openTestPage
+ * @property {() => void} postResults
+ * @property {(options: {commandIndex: number, additionalAssertionIndex: number, result: AdditionalAssertionResult}) => void} setCommandAdditionalAssertion
+ * @property {(options: {commandIndex: number, assertionIndex: number, result: AssertionResult}) => void} setCommandAssertion
+ * @property {(options: {commandIndex: number, hasUnexpected: HasUnexpectedBehavior}) => void } setCommandHasUnexpectedBehavior
+ * @property {(options: {commandIndex: number, atOutput: string}) => void} setCommandOutput
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, checked}) => void } setCommandUnexpectedBehavior
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, more: string}) => void } setCommandUnexpectedBehaviorMore
+ * @property {() => void} submit
+ */
+
+/**
+ * @typedef UserActionFocusUnexpected
+ * @property {typeof UserObjectActionMap["FOCUS_UNDESIRABLE"]} action
+ * @property {number} commandIndex
+ * @property {number} unexpectedIndex
+ */
+
+/**
+ * @typedef {T[keyof T]} EnumValues
+ * @template {{[key: string]: string}} T
+ */
+
+/**
+ * @typedef TestRunAssertion
+ * @property {string} description
+ * @property {boolean} highlightRequired
+ * @property {number} priority
+ * @property {AssertionResult} result
+ */
+
+/**
+ * @typedef TestRunAdditionalAssertion
+ * @property {string} description
+ * @property {boolean} highlightRequired
+ * @property {number} priority
+ * @property {AdditionalAssertionResult} result
+ */
+
+/**
+ * @typedef TestRunUnexpectedBehavior
+ * @property {string} description
+ * @property {boolean} checked
+ * @property {object} [more]
+ * @property {boolean} more.highlightRequired
+ * @property {string} more.value
+ */
+
+/**
+ * @typedef TestRunUnexpectedGroup
+ * @property {boolean} highlightRequired
+ * @property {HasUnexpectedBehavior} hasUnexpected
+ * @property {number} tabbedBehavior
+ * @property {TestRunUnexpectedBehavior[]} behaviors
+ */
+
+/**
+ * @typedef TestRunCommand
+ * @property {string} description
+ * @property {object} atOutput
+ * @property {boolean} atOutput.highlightRequired
+ * @property {string} atOutput.value
+ * @property {TestRunAssertion[]} assertions
+ * @property {TestRunAdditionalAssertion[]} additionalAssertions
+ * @property {TestRunUnexpectedGroup} unexpected
+ */
+
+/**
+ * @typedef TestRunState
+ * This state contains all the serializable values that are needed to render any
+ * of the documents (InstructionDocument, ResultsTableDocument, and
+ * TestPageDocuement) from this module.
+ *
+ * @property {string[] | null} errors
+ * @property {object} info
+ * @property {string} info.description
+ * @property {string} info.task
+ * @property {ATMode} info.mode
+ * @property {string} info.modeInstructions
+ * @property {string[]} info.userInstructions
+ * @property {string} info.setupScriptDescription
+ * @property {object} config
+ * @property {AT} config.at
+ * @property {boolean} config.renderResultsAfterSubmit
+ * @property {boolean} config.displaySubmitButton
+ * @property {TestRunUserAction} currentUserAction
+ * @property {TestRunCommand[]} commands
+ * @property {object} openTest
+ * @property {boolean} openTest.enabled
+ */
+
+/**
+ * @typedef ResultsTableDetailsList
+ * @property {Description} description
+ * @property {Description[]} items
+ */
+
+/**
+ * @typedef ResultsTableDocument
+ * @property {string} header
+ * @property {object} status
+ * @property {Description} status.header
+ * @property {object} table
+ * @property {object} table.headers
+ * @property {string} table.headers.description
+ * @property {string} table.headers.support
+ * @property {string} table.headers.details
+ * @property {object[]} table.commands
+ * @property {string} table.commands[].description
+ * @property {Description} table.commands[].support
+ * @property {object} table.commands[].details
+ * @property {Description} table.commands[].details.output
+ * @property {ResultsTableDetailsList} table.commands[].details.passingAssertions
+ * @property {ResultsTableDetailsList} table.commands[].details.failingAssertions
+ * @property {ResultsTableDetailsList} table.commands[].details.unexpectedBehaviors
+ */
+
+/**
+ * @typedef TestPageDocumentResults
+ * @property {ResultsTableDocument} results
+ */
+
+/**
+ * @typedef TestPageDocumentInstructions
+ * @property {string[] | null} errors
+ * @property {InstructionDocument} instructions
+ */
+
+/** @typedef {TestPageDocumentInstructions | TestPageDocumentResults} TestPageDocument */
+
+/** @typedef {"reading" | "interaction"} ATMode */

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -1190,7 +1190,7 @@ export function userValidateState() {
  * @typedef TestRunState
  * This state contains all the serializable values that are needed to render any
  * of the documents (InstructionDocument, ResultsTableDocument, and
- * TestPageDocuement) from this module.
+ * TestPageDocument) from this module.
  *
  * @property {string[] | null} errors
  * @property {object} info

--- a/tests/resources/vrender.mjs
+++ b/tests/resources/vrender.mjs
@@ -1,0 +1,980 @@
+const mounts = new WeakMap();
+
+/**
+ * @param {HTMLElement} mount
+ * @param {NodeNode} newValue
+ */
+export function render(mount, newValue) {
+  let lastValue = mounts.get(mount);
+  if (!lastValue) {
+    lastValue = ElementType.init(newQueue(), null, null, element(mount.tagName));
+    lastValue.ref = mount;
+    mounts.set(mount, lastValue);
+  }
+  const queue = newQueue();
+  lastValue.type.diff(queue, lastValue, element(mount.tagName, newValue));
+  runQueue(queue);
+  if (!newValue) {
+    mounts.delete(mount);
+  }
+}
+
+/**
+ * @param {string} shape
+ * @param  {...NodeNode} content
+ * @returns {ElementNode}
+ */
+export function element(shape, ...content) {
+  return {
+    type: ELEMENT_TYPE_NAME,
+    shape,
+    content: content.map(asNode),
+  };
+}
+
+/**
+ * @param  {...NodeNode} content
+ * @returns {FragmentNode}
+ */
+export function fragment(...content) {
+  return {
+    type: FRAGMENT_TYPE_NAME,
+    shape: FRAGMENT_TYPE_NAME,
+    content: content.map(asNode),
+  };
+}
+
+/**
+ * @param  {string} content
+ * @returns {TextNode}
+ */
+export function text(content) {
+  return {
+    type: TEXT_TYPE_NAME,
+    shape: TEXT_TYPE_NAME,
+    content,
+  };
+}
+
+/**
+ * @param {function} shape
+ * @param {...NodeNode} content
+ * @returns {ComponentNode}
+ */
+export function component(shape, ...content) {
+  return {
+    type: COMPONENT_TYPE_NAME,
+    shape,
+    content,
+  };
+}
+
+/**
+ * @param {{[key: string]: string}} styleMap
+ * @returns {MemberNode}
+ */
+export function style(styleMap) {
+  return attribute(
+    "style",
+    Object.keys(styleMap)
+      .map(key => `${key}: ${styleMap[key]};`)
+      .join(" ")
+  );
+}
+
+/**
+ * @param {string[]} names
+ * @returns {MemberNode}
+ */
+export function className(names) {
+  return attribute("class", names.filter(Boolean).join(" "));
+}
+
+/**
+ * @param {string} name
+ * @param  {string | boolean} value
+ * @returns {MemberNode}
+ */
+export function attribute(name, value) {
+  return {
+    type: ATTRIBUTE_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+/**
+ * @param {string} name
+ * @param  {any} value
+ * @returns {MemberNode}
+ */
+export function property(name, value) {
+  return {
+    type: PROPERTY_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+/**
+ * @param {string} name
+ * @param  {any} value
+ * @returns {MemberNode}
+ */
+export function meta(name, value) {
+  return {
+    type: META_TYPE_NAME,
+    name,
+    value,
+  };
+}
+
+const refMap = new WeakMap();
+
+/**
+ * @param {{ref: HTMLElement | null}} value
+ * @returns {MemberNode}
+ */
+export function ref(value) {
+  let refHook = refMap.get(value);
+  if (!refHook) {
+    refHook = (/** @type {HTMLElement} */ element) => {
+      value.ref = element;
+    };
+    refMap.set(value, refHook);
+  }
+  return {
+    type: REF_TYPE_NAME,
+    name: "ref",
+    value: refHook,
+  };
+}
+
+const noop = function () {};
+
+/**
+ * @param {boolean} shouldFocus
+ */
+export function focus(shouldFocus) {
+  return {
+    type: REF_TYPE_NAME,
+    name: "focus",
+    value: shouldFocus ? element => element.focus() : noop,
+  };
+}
+
+function asNode(item) {
+  if (typeof item === "string") {
+    return text(item);
+  } else if (Array.isArray(item)) {
+    return fragment(...item);
+  } else if (item === null || item === undefined) {
+    return fragment();
+  }
+  return item;
+}
+
+const ELEMENT_TYPE_NAME = "element";
+const FRAGMENT_TYPE_NAME = "fragment";
+const COMPONENT_TYPE_NAME = "component";
+const TEXT_TYPE_NAME = "text";
+const ATTRIBUTE_TYPE_NAME = "attribute";
+const PROPERTY_TYPE_NAME = "property";
+const REF_TYPE_NAME = "ref";
+const META_TYPE_NAME = "meta";
+
+/** @type ElementStateType */
+const ElementType = {
+  name: ELEMENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {ElementNode} */ node) {
+      const state = {
+        type: ElementType,
+        parent,
+        after,
+        shape: node.shape,
+        content: null,
+        ref: null,
+        refHooks: null,
+        rewriteChildIndex: 0,
+        children: null,
+        rewriteMemberIndex: 0,
+        members: null,
+      };
+      enqueueChange(queue, addElement, state);
+      return state;
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {ElementState} */ lastValue, /** @type {ElementNode} */ newValue) {
+      lastValue.rewriteMemberIndex = 0;
+      diffFragment(queue, lastValue, newValue);
+      if (lastValue.members !== null) {
+        const group = lastValue.members;
+        let index;
+        for (index = lastValue.rewriteMemberIndex; index < group.length; index++) {
+          const node = group[index];
+          node.type.teardown(queue, node);
+        }
+        if (lastValue.rewriteMemberIndex === 0) {
+          lastValue.members = null;
+        } else {
+          group.length = lastValue.rewriteMemberIndex;
+        }
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {ElementState} */ state) {
+      enqueueChange(queue, removeElement, state);
+      const {children} = state;
+      if (children !== null) {
+        for (let i = 0; i < children.length; i++) {
+          children[i].type.softTeardown(children[i]);
+        }
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (softTeardownElement),
+};
+
+/** @type {FragmentStateType} */
+const FragmentType = {
+  name: FRAGMENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init(queue, parent, after, node) {
+    return {
+      type: FragmentType,
+      parent,
+      after,
+      shape: FRAGMENT_TYPE_NAME,
+      content: null,
+      rewriteChildIndex: 0,
+      children: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (diffFragment),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {FragmentState} */ state) {
+      const {children} = state;
+      if (children !== null) {
+        for (let i = 0; i < children.length; i++) {
+          children[i].type.teardown(queue, children[i]);
+        }
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (softTeardownElement),
+};
+
+/** @type ComponentStateType */
+const ComponentType = {
+  name: COMPONENT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {ComponentNode} */ node) {
+      return {
+        type: ComponentType,
+        parent,
+        after,
+        shape: node.shape,
+        content: null,
+        rendered: null,
+      };
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {ComponentState} */ lastChild, /** @type {ComponentNode} */ node) {
+      /** @type {MemberNode} */
+      const componentOptionsMeta = node.content.find(isOptions) || null;
+      const componentOptions = componentOptionsMeta ? componentOptionsMeta.value : null;
+      if (shallowEquals(lastChild.content, componentOptions) === false) {
+        lastChild.content = componentOptions;
+        queue.prepare.push(lastChild);
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {ComponentState} */ state) {
+      if (state.rendered !== null) {
+        state.rendered.type.teardown(queue, state.rendered);
+      }
+    }
+  ),
+  softTeardown: /** @type {SoftTeardownFunction} */ (
+    function (/** @type {ComponentState} */ state) {
+      if (state.rendered !== null) {
+        state.rendered.type.softTeardown(state.rendered);
+      }
+    }
+  ),
+};
+
+/** @type TextStateType */
+const TextType = {
+  name: TEXT_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
+  init: /** @type {InitNodeFunction} */ (
+    function (queue, parent, after, /** @type {TextNode} */ node) {
+      /** @type {TextState} */
+      const state = {
+        type: TextType,
+        parent,
+        after,
+        shape: TEXT_TYPE_NAME,
+        content: node.content,
+        ref: null,
+      };
+      enqueueChange(queue, addText, state);
+      return state;
+    }
+  ),
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {TextState} */ lastChild, /** @type {TextNode} */ node) {
+      if (lastChild.content !== node.content) {
+        lastChild.content = node.content;
+        enqueueChange(queue, changeText, lastChild);
+      }
+    }
+  ),
+  teardown: /** @type {TeardownFunction} */ (
+    function (queue, /** @type {TextState} */ state) {
+      enqueueChange(queue, removeText, state);
+    }
+  ),
+  softTeardown() {},
+};
+
+/** @type {MemberStateType} */
+const AttributeType = {
+  name: ATTRIBUTE_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: AttributeType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ old, /** @type {MemberNode} */ memberNode) {
+      if (old.value !== memberNode.value) {
+        old.value = memberNode.value;
+        if (old.value === false) {
+          enqueueChange(queue, removeAttribute, old);
+        } else {
+          enqueueChange(queue, changeAttribute, old);
+        }
+      }
+    }
+  ),
+  teardown(queue, state) {
+    enqueueChange(queue, removeAttribute, state);
+  },
+};
+
+/** @type {MemberStateType} */
+const PropertyType = {
+  name: PROPERTY_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: PropertyType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ old, /** @type {MemberNode} */ memberNode) {
+      if (old.value !== memberNode.value) {
+        old.value = memberNode.value;
+        enqueueChange(queue, changeProperty, old);
+      }
+    }
+  ),
+  teardown(queue, state) {
+    state.value = undefined;
+    enqueueChange(queue, changeProperty, state);
+  },
+};
+
+/** @type {MemberStateType} */
+const RefType = {
+  name: REF_TYPE_NAME,
+  diffEntry: /** @type {DiffEntryFunction} */ (diffMemberEntry),
+  init(parent, name) {
+    return {
+      type: RefType,
+      parent,
+      name,
+      value: null,
+    };
+  },
+  diff: /** @type {DiffFunction} */ (
+    function (queue, /** @type {MemberState} */ state, /** @type {MemberNode} */ node) {
+      if (state.value !== node.value) {
+        state.value = node.value;
+        if (state.parent.refHooks === null) {
+          state.parent.refHooks = [];
+        }
+        if (state.parent.refHooks.indexOf(state) === -1) {
+          state.parent.refHooks.push(state);
+        }
+        enqueuePost(queue, updateRef, state);
+      }
+    }
+  ),
+  teardown(queue, state) {
+    const index = state.parent.refHooks.indexOf(state);
+    state.parent.refHooks.splice(index, 1);
+    if (state.parent.refHooks.length === 0) {
+      state.parent.refHooks = null;
+    }
+    enqueuePost(queue, unsetRef, state);
+  },
+};
+
+const typeMap = {
+  [ELEMENT_TYPE_NAME]: ElementType,
+  [FRAGMENT_TYPE_NAME]: FragmentType,
+  [COMPONENT_TYPE_NAME]: ComponentType,
+  [TEXT_TYPE_NAME]: TextType,
+  [ATTRIBUTE_TYPE_NAME]: AttributeType,
+  [PROPERTY_TYPE_NAME]: PropertyType,
+  [REF_TYPE_NAME]: RefType,
+};
+
+/** @type DiffEntryFunction */
+function diffChildEntry(queue, parent, /** @type NodeStateType */ metaType, /** @type NodeNode */ element) {
+  if (!parent.children) {
+    parent.children = [];
+  }
+  const index = parent.rewriteChildIndex++;
+  let state = parent.children[index];
+  if (!state || state.shape !== element.shape) {
+    if (state) {
+      state.type.teardown(queue, state);
+    }
+    state = /** @type {NodeState} */ (metaType.init(queue, parent, parent.children[index - 1] || null, element));
+    parent.children[index] = state;
+
+    const sibling = parent.children[index + 1];
+    if (sibling) {
+      sibling.after = state;
+    }
+  }
+  state.type.diff(queue, state, element);
+}
+
+/** @type {DiffFunction} */
+function diffFragment(
+  queue,
+  /** @type {ElementState | FragmentState} */ lastValue,
+  /** @type {ElementNode | FragmentNode} */ newValue
+) {
+  lastValue.rewriteChildIndex = 0;
+  const {content} = newValue;
+  for (let i = 0; i < content.length; i++) {
+    const node = content[i];
+    const metaType = typeMap[node.type];
+    metaType.diffEntry(queue, lastValue, metaType, node);
+  }
+  const children = lastValue.children;
+  if (children !== null) {
+    const childIndex = lastValue.rewriteChildIndex;
+    for (let i = childIndex; i < children.length; i++) {
+      const node = children[i];
+      node.type.teardown(queue, node);
+    }
+    if (childIndex === 0) {
+      lastValue.children = null;
+    } else {
+      children.length = childIndex;
+    }
+  }
+}
+
+/** @type {DiffEntryFunction} */
+function diffMemberEntry(
+  queue,
+  /** @type {ElementState} */ element,
+  /** @type {MemberStateType} */ nodeType,
+  /** @type {MemberNode} */ node
+) {
+  if (element.members === null) {
+    element.members = [];
+  }
+  const group = element.members;
+
+  const writeIndex = element.rewriteMemberIndex++;
+  let index;
+  for (index = writeIndex; index < group.length; index++) {
+    const item = group[index];
+    if (item.type.name === node.type && item.name === node.name) {
+      break;
+    }
+  }
+
+  let old = group[index];
+  if (index !== writeIndex) {
+    group[index] = group[writeIndex];
+  }
+  if (!old) {
+    old = nodeType.init(element, node.name);
+    group[writeIndex] = old;
+  }
+  old.type.diff(queue, old, node);
+}
+
+/** @type {SoftTeardownFunction} */
+function softTeardownElement(/** @type {ElementState} */ state) {
+  const {children} = state;
+  if (children !== null) {
+    for (let i = 0; i < children.length; i++) {
+      children[i].type.softTeardown(children[i]);
+    }
+  }
+}
+
+/**
+ * @param {Data} node
+ * @returns {node is MemberNode}
+ */
+function isOptions(node) {
+  return node.type === META_TYPE_NAME && node.name === "options";
+}
+
+/**
+ * @param {Queue} queue
+ */
+function runQueue(queue) {
+  const {prepare, changes: apply, post} = queue;
+  for (let i = 0; i < prepare.length; i++) {
+    changeViewRender(prepare[i], queue);
+  }
+  for (let i = 0; i < apply.length; i += 2) {
+    apply[i](apply[i + 1]);
+  }
+  for (let i = 0; i < post.length; i += 2) {
+    post[i](post[i + 1]);
+  }
+}
+
+/**
+ * @param {ComponentState} componentState
+ * @param {Queue} queue
+ */
+function changeViewRender(componentState, queue) {
+  const newRender = componentState.shape(componentState.content) || null;
+  if (newRender) {
+    const metaType = typeMap[newRender.type];
+    let lastRender = componentState.rendered;
+    if (!lastRender || lastRender.shape !== newRender.shape) {
+      if (lastRender) {
+        lastRender.type.teardown(queue, lastRender);
+      }
+      lastRender = metaType.init(queue, componentState, null, newRender);
+      componentState.rendered = lastRender;
+    }
+    lastRender.type.diff(queue, lastRender, newRender);
+  } else if (componentState.rendered) {
+    componentState.rendered.type.teardown(queue, componentState.rendered);
+    componentState.rendered = null;
+  }
+}
+
+/**
+ * @param {MemberState} state
+ */
+function changeProperty(state) {
+  state.parent.ref[state.name] = state.value;
+}
+
+/**
+ * @param {MemberState} state
+ */
+function removeAttribute(state) {
+  state.parent.ref.removeAttribute(state.name);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function changeAttribute(state) {
+  state.parent.ref.setAttribute(state.name, state.value);
+}
+
+/**
+ * @param {TextState} state
+ */
+function removeText(state) {
+  state.ref.parentNode.removeChild(state.ref);
+}
+
+/**
+ * @param {TextState} state
+ */
+function changeText(state) {
+  state.ref.textContent = state.content;
+}
+
+/**
+ * @param {TextState} state
+ */
+function addText(state) {
+  state.ref = document.createTextNode(state.content);
+  state.ref.textContent = state.content;
+  insertAfterSibling(state);
+}
+
+/**
+ * @param {NodeState} after
+ * @returns {NodeState}
+ */
+function deepestDescendant(after) {
+  if (after === null) {
+    return after;
+  } else if (after.type === FragmentType) {
+    const {children} = /** @type {FragmentState} */ (after);
+    if (children !== null) {
+      return deepestDescendant(children[children.length - 1]);
+    }
+  } else if (after.type === ComponentType) {
+    const {rendered} = /** @type {ComponentState} */ (after);
+    if (rendered !== null) {
+      return deepestDescendant(rendered);
+    }
+  }
+  return after;
+}
+
+/**
+ * @param {ElementState | TextState} element
+ */
+function insertAfterSibling(element) {
+  /** @type {NodeState} */
+  let state = element;
+  let after = deepestDescendant(state.after);
+  do {
+    if (after === null) {
+      if (state.parent.type === ElementType) {
+        break;
+      }
+      state = state.parent;
+      after = state;
+    }
+    if (after.type !== ElementType && after.type !== TextType) {
+      after = deepestDescendant(after.after);
+    }
+  } while (after === null || (after.type !== ElementType && after.type !== TextType));
+
+  if (after !== null) {
+    const {ref} = /** @type {ElementState | TextState} */ (after);
+    ref.parentNode.insertBefore(element.ref, ref.nextSibling);
+  } else {
+    const {ref} = /** @type {ElementState} */ (state.parent);
+    if (ref.childNodes.length) {
+      ref.insertBefore(element.ref, ref.childNodes[0]);
+    } else {
+      ref.appendChild(element.ref);
+    }
+  }
+}
+
+/**
+ * @param {ElementState} state
+ */
+function removeElement(state) {
+  state.ref.parentNode.removeChild(state.ref);
+  state.ref = null;
+}
+
+/**
+ * @param {ElementState} state
+ */
+function addElement(state) {
+  state.ref = document.createElement(state.shape);
+  insertAfterSibling(state);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function updateRef(state) {
+  state.value(state.parent.ref);
+}
+
+/**
+ * @param {MemberState} state
+ */
+function unsetRef(state) {
+  state.value(null);
+}
+
+function shallowEquals(a, b) {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  for (const key of Object.keys(a)) {
+    if (key in b) {
+      if (a[key] !== b[key]) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  for (const key of Object.keys(b)) {
+    if (!(key in a)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @callback StateAction
+ * @param {S} state
+ * @template {State} S
+ */
+
+/**
+ * @returns {Queue}
+ */
+function newQueue() {
+  return {prepare: [], changes: [], post: []};
+}
+
+/**
+ * @param {Queue} queue
+ * @param {StateAction<S>} fn
+ * @param {S} state
+ * @template {State} S
+ */
+function enqueueChange(queue, fn, state) {
+  queue.changes.push(fn, state);
+}
+
+/**
+ * @param {Queue} queue
+ * @param {StateAction<S>} fn
+ * @param {S} state
+ * @template {State} S
+ */
+function enqueuePost(queue, fn, state) {
+  queue.post.push(fn, state);
+}
+
+/**
+ * @typedef Queue
+ * @property {Array} prepare
+ * @property {Array} changes
+ * @property {Array} post
+ */
+
+/**
+ * @callback DiffEntryFunction
+ * @param {Queue} queue
+ * @param {ElementState | FragmentState} parent
+ * @param {StateType} nodeType
+ * @param {Data} node
+ * @returns {void}
+ */
+
+/**
+ * @callback InitNodeFunction
+ * @param {Queue} queue
+ * @param {NodeState} parent
+ * @param {NodeState | null} after
+ * @param {NodeNode} node
+ * @returns {NodeState}
+ */
+
+/**
+ * @callback DiffFunction
+ * @param {Queue} queue
+ * @param {State} state
+ * @param {Data} node
+ * @returns {void}
+ */
+
+/**
+ * @callback TeardownFunction
+ * @param {Queue} queue
+ * @param {NodeState} state
+ * @returns {void}
+ */
+
+/**
+ * @callback SoftTeardownFunction
+ * @param {NodeState} state
+ * @returns {void}
+ */
+
+/**
+ * @typedef NodeStateTypeGeneric
+ * @property {Name} name
+ * @property {DiffEntryFunction} diffEntry
+ * @property {DiffFunction} diff
+ * @property {InitNodeFunction} init
+ * @property {TeardownFunction} teardown
+ * @property {SoftTeardownFunction} softTeardown
+ * @template {string | symbol} Name
+ */
+
+/**
+ * @typedef NodeStateTypeCreate
+ * @property {Name} name
+ * @property {(queue: Queue, parent: ElementState | FragmentState, meta: StateType, node: Node) => void} diffEntry
+ * @property {(queue: Queue, state: S, node: Node) => void} diff
+ * @property {(queue: Queue, parent: ElementState | FragmentState, after: NodeState, node: Node) => void} init
+ * @property {(queue: Queue, state: S) => void} teardown
+ * @property {(state: S) => void} softTeardown
+ * @template {string | symbol} Name
+ * @template {State} S
+ * @template {Data} Node
+ */
+
+/** @typedef {NodeStateTypeGeneric<typeof ELEMENT_TYPE_NAME>} ElementStateType */
+/** @typedef {NodeStateTypeGeneric<typeof FRAGMENT_TYPE_NAME>} FragmentStateType */
+/** @typedef {NodeStateTypeGeneric<typeof COMPONENT_TYPE_NAME>} ComponentStateType */
+/** @typedef {NodeStateTypeGeneric<typeof TEXT_TYPE_NAME>} TextStateType */
+
+/** @typedef {ElementStateType | FragmentStateType| ComponentStateType | TextStateType} NodeStateType */
+
+/**
+ * @callback InitMemberFunction
+ * @param {ElementState} parent
+ * @param {string} name
+ * @returns {MemberState}
+ */
+
+/**
+ * @callback TeardownMemberFunction
+ * @param {Queue} queue
+ * @param {MemberState} member
+ * @returns {void}
+ */
+
+/**
+ * @typedef MemberStateType
+ * @property {string | symbol} name
+ * @property {DiffEntryFunction} diffEntry
+ * @property {DiffFunction} diff
+ * @property {InitMemberFunction} init
+ * @property {TeardownMemberFunction} teardown
+ */
+
+/**
+ * @typedef {NodeStateType | MemberStateType} StateType
+ */
+
+/**
+ * @typedef ElementState
+ * @property {ElementStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {string} shape
+ * @property {null} content
+ * @property {HTMLElement | null} ref
+ * @property {MemberState[] | null} refHooks
+ * @property {number} rewriteChildIndex
+ * @property {NodeState[] | null} children
+ * @property {number} rewriteMemberIndex
+ * @property {MemberState[] | null} members
+ */
+
+/**
+ * @typedef FragmentState
+ * @property {FragmentStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {typeof FRAGMENT_TYPE_NAME} shape
+ * @property {null} content
+ * @property {number} rewriteChildIndex
+ * @property {NodeState[] | null} children
+ */
+
+/** @typedef {ElementState | FragmentState} ParentState */
+
+/**
+ * @typedef ComponentState
+ * @property {ComponentStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {function} shape
+ * @property {object} content
+ * @property {NodeState | null} rendered
+ */
+
+/**
+ * @typedef TextState
+ * @property {TextStateType} type
+ * @property {NodeState} parent
+ * @property {NodeState | null} after
+ * @property {typeof TEXT_TYPE_NAME} shape
+ * @property {string} content
+ * @property {Text | null} ref
+ */
+
+/**
+ * @typedef {ElementState | FragmentState | ComponentState | TextState} NodeState
+ */
+
+/**
+ * @typedef MemberState
+ * @property {MemberStateType} type
+ * @property {ElementState} parent
+ * @property {string} name
+ * @property {*} value
+ */
+
+/** @typedef {NodeState | MemberState} State */
+
+/** @typedef {typeof ELEMENT_TYPE_NAME | typeof FRAGMENT_TYPE_NAME | typeof COMPONENT_TYPE_NAME | typeof TEXT_TYPE_NAME} NodeNodeType */
+
+/** @typedef {typeof ATTRIBUTE_TYPE_NAME | typeof PROPERTY_TYPE_NAME | typeof REF_TYPE_NAME | typeof META_TYPE_NAME} MemberNodeType */
+
+/**
+ * @typedef ElementNode
+ * @property {typeof ELEMENT_TYPE_NAME} type
+ * @property {string} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef FragmentNode
+ * @property {typeof FRAGMENT_TYPE_NAME} type
+ * @property {typeof FRAGMENT_TYPE_NAME} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef TextNode
+ * @property {typeof TEXT_TYPE_NAME} type
+ * @property {typeof TEXT_TYPE_NAME} shape
+ * @property {string} content
+ */
+
+/**
+ * @typedef ComponentNode
+ * @property {typeof COMPONENT_TYPE_NAME} type
+ * @property {function} shape
+ * @property {Data[]} content
+ */
+
+/**
+ * @typedef {ElementNode | FragmentNode | TextNode | ComponentNode} NodeNode
+ */
+
+/**
+ * @typedef MemberNode
+ * @property {MemberNodeType} type
+ * @property {string} name
+ * @property {*} value
+ */
+
+/** @typedef {NodeNode | MemberNode} Data */

--- a/tests/resources/vrender.mjs
+++ b/tests/resources/vrender.mjs
@@ -243,7 +243,7 @@ const ElementType = {
 const FragmentType = {
   name: FRAGMENT_TYPE_NAME,
   diffEntry: /** @type {DiffEntryFunction} */ (diffChildEntry),
-  init(queue, parent, after, node) {
+  init(queue, parent, after) {
     return {
       type: FragmentType,
       parent,


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/mzgoddard-harness-controller-and-render/build/index.html)

The harness module is given a test json of commands to perform and assertions to record the results of. This change replaces the manual DOM rendering and manual updates of the test instructions and result form with an object representing the test results, from which a second object, the instruction document, is created representing the structure, text, and user event handlers to update the first object. This separates the application state of the instructions and result entry from the DOM so that it can be reused outside the harness module.

This change further uses the added instruction document type and produces the existing DOM with a small virtual dom module. From the perspective of someone running the commands and entering the results into the form, there should be no change in the page’s behavior.

## Progress

This change is almost complete. Briefly, I think to complete it, the result state needs to be turned into the summary object for submission. Below is an overview of the steps implemented.

- [x] Type definitions
  - [x] Define the type of the Test JSON input, stored in the harness `behavior` module scope variable
  - [x] Define the type of the Commands JSON input
  - [x] Define the type of the Support JSON input
  - [x] Define the type of the submitted results produced when Submit Results is clicked
  - [x] Define a type of the state of the user input results
  - [x] Define a type that represents the displayed text and result input fields of the test input and state of the results
- [x] Update state of results from user events sent to functions in the instruction document representation
  - [x] Update atOutput text for a command
  - [x] Update an assertion for a command
  - [x] Update an additional assertion for a command
  - [x] Update if there are or are not undesirable results
  - [x] Update individual undesirable entries
  - [x] Update other undesirable text input
  - [x] Update if field should highlight when required when validating
- [x] Create the document object following the defined type
- [x] Create the result submission following the defined type
- [x] Track document item focus when updating the result state
  - [x] Focus header after page load
  - [x] Focus next or previous checkbox when pressing relevant keyboard keys
  - [x] Focus first required and not set result input after validating before submitting the result
- [x] Render the document object into DOM
  - [x] Render updates with a virtual dom to maintain minimal changes to dom like prior manual change implementation
  - [x] Transform DOM events into relevant input to functions in document object
    - [x] Transform text input change event
    - [x] Transform radio click event
    - [x] Transform checkbox change and keydown event
    - [x] Transform open test pop click event
    - [x] Transform submit results click event
