### PR TITLE
Add harness input/output 

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -40,7 +40,7 @@
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -48,7 +48,7 @@
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -56,7 +56,7 @@
             <td><a href="./tests/combobox-autocomplete-both-updated/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both-updated.html">Review</a></td>
             <td>76</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -64,7 +64,7 @@
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -72,7 +72,7 @@
             <td><a href="./tests/command-button/index.html">Index</a></td>
             <td><a href="./review/command-button.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -80,7 +80,7 @@
             <td><a href="./tests/disclosure-faq/index.html">Index</a></td>
             <td><a href="./review/disclosure-faq.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -88,7 +88,7 @@
             <td><a href="./tests/disclosure-navigation/index.html">Index</a></td>
             <td><a href="./review/disclosure-navigation.html">Review</a></td>
             <td>46</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -96,7 +96,7 @@
             <td><a href="./tests/menu-button-actions/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -104,7 +104,7 @@
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -112,7 +112,7 @@
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -120,7 +120,7 @@
             <td><a href="./tests/minimal-data-grid/index.html">Index</a></td>
             <td><a href="./review/minimal-data-grid.html">Review</a></td>
             <td>55</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -128,7 +128,7 @@
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -136,7 +136,7 @@
             <td><a href="./tests/radiogroup-aria-activedescendant/index.html">Index</a></td>
             <td><a href="./review/radiogroup-aria-activedescendant.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -144,7 +144,7 @@
             <td><a href="./tests/radiogroup-roving-tabindex/index.html">Index</a></td>
             <td><a href="./review/radiogroup-roving-tabindex.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -152,7 +152,7 @@
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
           <tr>
@@ -160,7 +160,7 @@
             <td><a href="./tests/toggle-button/index.html">Index</a></td>
             <td><a href="./review/toggle-button.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/c0d798a" target="_blank">c0d798a Merge branch &#39;master&#39; into issue-456
+            <td><a href="https://github.com/w3c/aria-at/commit/f91bba1" target="_blank">f91bba1 fixup! fix some test run document issues
 </a></td>
           </tr>
     </table>

--- a/build/review/checkbox-tri-state.html
+++ b/build/review/checkbox-tri-state.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +722,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -956,7 +956,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1007,7 +1007,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1200,7 +1200,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1247,7 +1247,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1391,7 +1391,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1439,7 +1439,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1517,7 +1517,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1595,7 +1595,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1645,7 +1645,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1789,7 +1789,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1836,7 +1836,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1914,7 +1914,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1988,7 +1988,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2062,7 +2062,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2136,7 +2136,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2183,7 +2183,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox.html
+++ b/build/review/checkbox.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -713,7 +713,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -779,7 +779,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -825,7 +825,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -908,7 +908,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -984,7 +984,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1035,7 +1035,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1098,7 +1098,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1159,7 +1159,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1201,7 +1201,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1279,7 +1279,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1357,7 +1357,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1407,7 +1407,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1485,7 +1485,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1563,7 +1563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1613,7 +1613,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1677,7 +1677,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1741,7 +1741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1785,7 +1785,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1854,7 +1854,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1900,7 +1900,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1977,7 +1977,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2046,7 +2046,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2096,7 +2096,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2165,7 +2165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2234,7 +2234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-autocomplete-both-updated.html
+++ b/build/review/combobox-autocomplete-both-updated.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-01-navigate-forwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -729,7 +729,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-02-navigate-backwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -818,7 +818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-03-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -899,7 +899,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-04-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -980,7 +980,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-05-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1034,7 +1034,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-06-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1088,7 +1088,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-07-read-information-about-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1171,7 +1171,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-08-read-information-about-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1252,7 +1252,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-09-read-information-about-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1305,7 +1305,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-10-navigate-forwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1398,7 +1398,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-11-navigate-backwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1491,7 +1491,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-12-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1576,7 +1576,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-13-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-14-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-15-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1773,7 +1773,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-16-read-information-about-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1860,7 +1860,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-17-read-information-about-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1945,7 +1945,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-18-read-information-about-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2000,7 +2000,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-19-open-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2073,7 +2073,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-20-open-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2146,7 +2146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-21-open-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2193,7 +2193,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-22-open-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2266,7 +2266,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-23-open-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2339,7 +2339,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-24-open-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2386,7 +2386,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-25-open-empty-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2461,7 +2461,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-26-open-an-empty-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2509,7 +2509,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-27-open-a-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2584,7 +2584,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-28-open-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2632,7 +2632,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-29-read-information-about-empty-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2715,7 +2715,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-30-read-information-about-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2796,7 +2796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-31-read-information-about-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2849,7 +2849,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-32-read-information-about-filled-in-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2936,7 +2936,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-33-read-information-about-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3021,7 +3021,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-34-read-information-about-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3076,7 +3076,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-35-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3148,7 +3148,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-36-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3194,7 +3194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-37-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3266,7 +3266,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-38-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3312,7 +3312,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-39-close-empty-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3383,7 +3383,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-40-close-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3456,7 +3456,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-41-close-empty-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3503,7 +3503,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-42-close-filled-in-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3574,7 +3574,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-43-close-filled-in-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3647,7 +3647,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-44-close-filled-in-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3694,7 +3694,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-45-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3781,7 +3781,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-46-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3837,7 +3837,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-47-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3922,7 +3922,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-48-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3977,7 +3977,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-49-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4064,7 +4064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-50-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4120,7 +4120,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-51-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4207,7 +4207,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-52-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4263,7 +4263,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-53-navigate-from-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4348,7 +4348,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-54-navigate-from-an-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4403,7 +4403,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-55-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4488,7 +4488,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-56-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4543,7 +4543,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-57-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4628,7 +4628,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-58-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4683,7 +4683,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-59-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4768,7 +4768,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-60-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4823,7 +4823,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-61-navigate-to-next-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4910,7 +4910,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-62-navigate-to-next-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4967,7 +4967,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-63-navigate-to-previous-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5054,7 +5054,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-64-navigate-to-previous-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5111,7 +5111,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-65-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5195,7 +5195,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-66-read-information-about-a-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5250,7 +5250,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-67-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=jaws">jaws</a></li>
@@ -5335,7 +5335,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-68-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=jaws">jaws</a></li>
@@ -5420,7 +5420,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-69-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5474,7 +5474,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-70-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5528,7 +5528,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-71-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5613,7 +5613,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-72-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5698,7 +5698,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-73-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5752,7 +5752,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-74-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5806,7 +5806,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-75-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5892,7 +5892,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-76-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-select-only.html
+++ b/build/review/combobox-select-only.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +725,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -810,7 +810,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -889,7 +889,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -968,7 +968,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1021,7 +1021,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1074,7 +1074,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1155,7 +1155,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1234,7 +1234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1286,7 +1286,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1373,7 +1373,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1468,7 +1468,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1529,7 +1529,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1672,7 +1672,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1759,7 +1759,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1815,7 +1815,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -1902,7 +1902,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1958,7 +1958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2042,7 +2042,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2097,7 +2097,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2175,7 +2175,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2253,7 +2253,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2305,7 +2305,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2357,7 +2357,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2435,7 +2435,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2485,7 +2485,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2563,7 +2563,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2641,7 +2641,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2691,7 +2691,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2741,7 +2741,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2819,7 +2819,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2897,7 +2897,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2947,7 +2947,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2997,7 +2997,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3080,7 +3080,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3134,7 +3134,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3213,7 +3213,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/command-button.html
+++ b/build/review/command-button.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-01-navigate-forwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-02-navigate-backwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-03-navigate-forwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-04-navigate-backwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-05-navigate-forwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-06-navigate-backwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-07-read-information-about-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-08-read-information-about-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-09-read-information-about-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-faq.html
+++ b/build/review/disclosure-faq.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -802,7 +802,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -877,7 +877,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -952,7 +952,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1002,7 +1002,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1052,7 +1052,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1133,7 +1133,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1214,7 +1214,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1289,7 +1289,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1364,7 +1364,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1414,7 +1414,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1464,7 +1464,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1541,7 +1541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1665,7 +1665,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1742,7 +1742,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1817,7 +1817,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1866,7 +1866,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1939,7 +1939,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2012,7 +2012,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2060,7 +2060,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2133,7 +2133,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2206,7 +2206,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2254,7 +2254,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-25-navigate-from-expanded-disclosure-button-to-text-of-question-answer-reading.html?at=jaws">jaws</a></li>
@@ -2325,7 +2325,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-26-navigate-from-expanded-disclosure-button-to-text-of-question-answer-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-navigation.html
+++ b/build/review/disclosure-navigation.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -802,7 +802,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -877,7 +877,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -958,7 +958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1008,7 +1008,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1139,7 +1139,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1220,7 +1220,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1295,7 +1295,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1376,7 +1376,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1425,7 +1425,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1475,7 +1475,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1552,7 +1552,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1627,7 +1627,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1676,7 +1676,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1828,7 +1828,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1877,7 +1877,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2023,7 +2023,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2071,7 +2071,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2144,7 +2144,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2217,7 +2217,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2265,7 +2265,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-25-navigate-from-expanded-disclosure-button-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2346,7 +2346,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-26-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -2424,7 +2424,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-27-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2475,7 +2475,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-28-navigate-from-expanded-disclosure-button-to-current-page-link-reading.html?at=jaws">jaws</a></li>
@@ -2559,7 +2559,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-29-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=jaws">jaws</a></li>
@@ -2640,7 +2640,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-30-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2693,7 +2693,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-31-navigate-from-dropdown-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2768,7 +2768,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-32-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2843,7 +2843,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-33-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2891,7 +2891,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-34-navigate-forwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2968,7 +2968,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-35-navigate-backwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3045,7 +3045,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-36-navigate-forwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3121,7 +3121,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-37-navigate-backwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3197,7 +3197,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-38-navigate-forwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3247,7 +3247,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-39-navigate-backwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3297,7 +3297,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-40-navigate-to-first-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3369,7 +3369,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-41-navigate-to-last-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3441,7 +3441,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-42-navigate-to-first-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3487,7 +3487,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-43-navigate-to-last-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3533,7 +3533,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-44-activate-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3609,7 +3609,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-45-activate-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3685,7 +3685,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-46-activate-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions-active-descendant.html
+++ b/build/review/menu-button-actions-active-descendant.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1326,7 +1326,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1414,7 +1414,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1470,7 +1470,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1554,7 +1554,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1608,7 +1608,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1688,7 +1688,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1739,7 +1739,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1819,7 +1819,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1870,7 +1870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2001,7 +2001,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2079,7 +2079,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2129,7 +2129,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2202,7 +2202,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2250,7 +2250,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2323,7 +2323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions.html
+++ b/build/review/menu-button-actions.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -719,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -798,7 +798,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -871,7 +871,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -993,7 +993,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1117,7 +1117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1192,7 +1192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1325,7 +1325,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1412,7 +1412,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1468,7 +1468,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1551,7 +1551,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1604,7 +1604,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1683,7 +1683,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1733,7 +1733,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1812,7 +1812,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1862,7 +1862,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1941,7 +1941,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1991,7 +1991,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2068,7 +2068,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2117,7 +2117,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2190,7 +2190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2238,7 +2238,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2311,7 +2311,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menubar-editor.html
+++ b/build/review/menubar-editor.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -721,7 +721,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -784,7 +784,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -865,7 +865,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -995,7 +995,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1064,7 +1064,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1143,7 +1143,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1194,7 +1194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1273,7 +1273,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1323,7 +1323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1403,7 +1403,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1455,7 +1455,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1533,7 +1533,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1583,7 +1583,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1712,7 +1712,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1790,7 +1790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1841,7 +1841,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1921,7 +1921,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1973,7 +1973,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2059,7 +2059,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2114,7 +2114,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -2188,7 +2188,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -2272,7 +2272,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2326,7 +2326,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2410,7 +2410,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2494,7 +2494,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2548,7 +2548,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2632,7 +2632,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2716,7 +2716,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2770,7 +2770,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2854,7 +2854,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2938,7 +2938,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2992,7 +2992,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3076,7 +3076,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3160,7 +3160,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3214,7 +3214,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3296,7 +3296,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3378,7 +3378,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/minimal-data-grid.html
+++ b/build/review/minimal-data-grid.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-01-navigate-forwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -724,7 +724,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-02-navigate-backwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -806,7 +806,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-03-navigate-forwards-to-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -859,7 +859,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-04-navigate-into-end-of-grid-reading.html?at=jaws">jaws</a></li>
@@ -944,7 +944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-05-navigate-into-end-of-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -997,7 +997,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-06-move-focus-forwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1081,7 +1081,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-07-move-focus-backwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1165,7 +1165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-08-move-focus-forwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1249,7 +1249,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-09-move-focus-backwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1333,7 +1333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-10-move-focus-forwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1386,7 +1386,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-11-move-focus-backwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1439,7 +1439,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-12-read-information-about-grid-cell-reading.html?at=jaws">jaws</a></li>
@@ -1515,7 +1515,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-13-read-information-about-grid-cell-interaction.html?at=jaws">jaws</a></li>
@@ -1591,7 +1591,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-14-read-information-about-grid-cell-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1639,7 +1639,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-15-read-information-about-grid-cell-containing-link-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-16-read-information-about-grid-cell-containing-link-interaction.html?at=jaws">jaws</a></li>
@@ -1795,7 +1795,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-17-read-information-about-grid-cell-containing-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1844,7 +1844,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-18-navigate-to-next-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -1918,7 +1918,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-19-navigate-to-next-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1992,7 +1992,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-20-navigate-to-next-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2041,7 +2041,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-21-navigate-to-previous-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2115,7 +2115,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-22-navigate-to-previous-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2189,7 +2189,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-23-navigate-to-previous-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2238,7 +2238,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-24-navigate-to-next-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2317,7 +2317,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-25-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2394,7 +2394,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-26-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2445,7 +2445,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-27-navigate-to-previous-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2524,7 +2524,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-28-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2600,7 +2600,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-29-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2651,7 +2651,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-30-navigate-to-next-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2725,7 +2725,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-31-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2799,7 +2799,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-32-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2848,7 +2848,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-33-navigate-to-previous-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2922,7 +2922,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-34-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2996,7 +2996,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-35-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3046,7 +3046,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-36-navigate-to-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3120,7 +3120,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-37-navigate-to-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3194,7 +3194,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-38-navigate-to-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3242,7 +3242,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-39-navigate-to-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3316,7 +3316,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-40-navigate-to-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3390,7 +3390,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-41-navigate-to-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3438,7 +3438,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-42-navigate-to-cell-containing-link-on-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3514,7 +3514,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-43-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3590,7 +3590,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-44-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3639,7 +3639,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-45-navigate-to-cell-containing-link-on-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3715,7 +3715,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-46-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3791,7 +3791,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-47-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3840,7 +3840,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-48-navigate-to-first-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3914,7 +3914,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-49-navigate-to-first-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3961,7 +3961,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-50-navigate-to-last-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4035,7 +4035,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-51-navigate-to-last-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4082,7 +4082,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-52-navigate-to-first-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4156,7 +4156,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-53-navigate-to-first-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4203,7 +4203,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-54-navigate-to-last-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4277,7 +4277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-55-navigate-to-last-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/modal-dialog.html
+++ b/build/review/modal-dialog.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -720,7 +720,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -800,7 +800,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -852,7 +852,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -996,7 +996,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1042,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1116,7 +1116,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1190,7 +1190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1238,7 +1238,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1310,7 +1310,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1356,7 +1356,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1428,7 +1428,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1474,7 +1474,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1548,7 +1548,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1595,7 +1595,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1667,7 +1667,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1713,7 +1713,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1796,7 +1796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1879,7 +1879,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1933,7 +1933,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -2011,7 +2011,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2089,7 +2089,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2139,7 +2139,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -2219,7 +2219,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -2299,7 +2299,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2351,7 +2351,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2432,7 +2432,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2513,7 +2513,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-aria-activedescendant.html
+++ b/build/review/radiogroup-aria-activedescendant.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -731,7 +731,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -788,7 +788,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -879,7 +879,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -936,7 +936,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1027,7 +1027,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1084,7 +1084,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1175,7 +1175,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1232,7 +1232,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1375,7 +1375,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1462,7 +1462,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1518,7 +1518,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1605,7 +1605,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1661,7 +1661,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1748,7 +1748,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1804,7 +1804,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1886,7 +1886,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1966,7 +1966,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2018,7 +2018,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2100,7 +2100,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2180,7 +2180,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2232,7 +2232,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2315,7 +2315,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2398,7 +2398,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2451,7 +2451,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2534,7 +2534,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2617,7 +2617,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2670,7 +2670,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2753,7 +2753,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2807,7 +2807,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2890,7 +2890,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2944,7 +2944,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3027,7 +3027,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3080,7 +3080,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3163,7 +3163,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3216,7 +3216,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3287,7 +3287,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3358,7 +3358,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-roving-tabindex.html
+++ b/build/review/radiogroup-roving-tabindex.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -730,7 +730,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -786,7 +786,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -876,7 +876,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -932,7 +932,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1078,7 +1078,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1168,7 +1168,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1224,7 +1224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1310,7 +1310,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1365,7 +1365,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1506,7 +1506,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1592,7 +1592,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1647,7 +1647,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1733,7 +1733,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1788,7 +1788,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1870,7 +1870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2002,7 +2002,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2084,7 +2084,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2164,7 +2164,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2216,7 +2216,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2298,7 +2298,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2380,7 +2380,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2432,7 +2432,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2514,7 +2514,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2596,7 +2596,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2648,7 +2648,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2730,7 +2730,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2783,7 +2783,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2865,7 +2865,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2918,7 +2918,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3000,7 +3000,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3052,7 +3052,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3134,7 +3134,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3186,7 +3186,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3257,7 +3257,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3328,7 +3328,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/tabs-manual-activation.html
+++ b/build/review/tabs-manual-activation.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -729,7 +729,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -818,7 +818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -905,7 +905,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -992,7 +992,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1050,7 +1050,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1108,7 +1108,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1191,7 +1191,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1274,7 +1274,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1327,7 +1327,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1405,7 +1405,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1483,7 +1483,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1533,7 +1533,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1614,7 +1614,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1695,7 +1695,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1747,7 +1747,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1828,7 +1828,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1880,7 +1880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1958,7 +1958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2008,7 +2008,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2084,7 +2084,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2210,7 +2210,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2260,7 +2260,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2333,7 +2333,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2406,7 +2406,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2454,7 +2454,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2535,7 +2535,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2616,7 +2616,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/toggle-button.html
+++ b/build/review/toggle-button.html
@@ -640,7 +640,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-01-navigate-forwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +722,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-02-navigate-backwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -804,7 +804,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-03-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-04-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -956,7 +956,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-05-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1007,7 +1007,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-06-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1058,7 +1058,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-07-navigate-forwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1140,7 +1140,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-08-navigate-backwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1222,7 +1222,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-09-navigate-forwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1298,7 +1298,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-10-navigate-backwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1374,7 +1374,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-11-navigate-forwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1425,7 +1425,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-12-navigate-backwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1476,7 +1476,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-13-read-information-about-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1554,7 +1554,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-14-read-information-about-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1632,7 +1632,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-15-read-information-about-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1682,7 +1682,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-16-read-information-about-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1760,7 +1760,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-17-read-information-about-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1838,7 +1838,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-18-read-information-about-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1888,7 +1888,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-19-operate-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1962,7 +1962,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-20-operate-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2036,7 +2036,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-21-operate-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2086,7 +2086,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-22-operate-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-23-operate-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2234,7 +2234,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Fri Aug 6 10:28:02 2021 -0500</li>
+        <li>Last edited: Mon Aug 23 11:14:37 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-24-operate-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/tests/resources/aria-at-harness.mjs
+++ b/build/tests/resources/aria-at-harness.mjs
@@ -274,9 +274,9 @@ function renderVirtualTestPage(doc) {
       ? div(
           section(
             id("errors"),
-            style({display: doc.errors ? "block" : "none"}),
+            style({display: doc.errors && doc.errors.visible ? "block" : "none"}),
             h2("Test cannot be performed due to error(s)!"),
-            ul(...(doc.errors ? doc.errors.map(error => li(error)) : [])),
+            ul(...(doc.errors && doc.errors.errors ? doc.errors.errors.map(error => li(error)) : [])),
             hr()
           ),
           section(id("instructions"), renderVirtualInstructionDocument(doc.instructions)),
@@ -524,9 +524,9 @@ function renderVirtualResultsTable(results) {
   }
 }
 
-/** @typedef {import('./aria-at-test-io-format.js').SupportJSON} SupportJSON */
-/** @typedef {import('./aria-at-test-io-format.js').CommandsJSON} CommandsJSON */
-/** @typedef {import('./aria-at-test-io-format.js').BehaviorJSON} BehaviorJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').SupportJSON} SupportJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').CommandsJSON} CommandsJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').BehaviorJSON} BehaviorJSON */
 
 /** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
 
@@ -545,5 +545,5 @@ function renderVirtualResultsTable(results) {
 /** @typedef {import('./aria-at-test-run.mjs').ResultsTableDocument} ResultsTableDocument */
 
 /**
- * @typedef {import('./aria-at-test-io-format.js').TestPageAndResultsDocument} TestPageAndResultsDocument
+ * @typedef {import('./aria-at-test-io-format.mjs').TestPageAndResultsDocument} TestPageAndResultsDocument
  */

--- a/build/tests/resources/aria-at-harness.mjs
+++ b/build/tests/resources/aria-at-harness.mjs
@@ -1,24 +1,7 @@
-import {commandsAPI} from "./at-commands.mjs";
 import {element, fragment, property, attribute, className, style, focus, render} from "./vrender.mjs";
-import {
-  AssertionResultMap,
-  CommonResultMap,
-  createEnumMap,
-  HasUnexpectedBehaviorMap,
-  TestRun,
-  UserActionMap,
-  userCloseWindow,
-  userOpenWindow,
-  WhitespaceStyleMap,
-} from "./aria-at-test-run.mjs";
-
-const UNEXPECTED_BEHAVIORS = [
-  "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
-  "Reading cursor position changed in an unexpected manner",
-  "Screen reader became extremely sluggish",
-  "Screen reader crashed",
-  "Browser crashed",
-];
+import {userCloseWindow, userOpenWindow, WhitespaceStyleMap} from "./aria-at-test-run.mjs";
+import {TestRunExport, TestRunInputOutput} from "./aria-at-test-io-format.mjs";
+import {TestWindow} from "./aria-at-test-window.mjs";
 
 const PAGE_STYLES = `
   table {
@@ -77,94 +60,31 @@ const PAGE_STYLES = `
   }
 `;
 
-/** @type {string[]} */
-const errors = [];
-let showResults = true;
-let showSubmitButton = true;
-
-/** @type {AT} */
-let at;
-/** @type {CommandsAPI} */
-let commapi;
-/** @type {Behavior} */
-let behavior;
-/** @type {TestRunState} */
-let firstState;
+let testRunIO = new TestRunInputOutput();
+testRunIO.setTitleInputFromTitle(document.title);
+testRunIO.setUnexpectedInputFromBuiltin();
+testRunIO.setScriptsInputFromMap(typeof scripts === "object" ? scripts : {});
 
 /**
- * @param {Support} newSupport
- * @param {Commands} newCommandsData
+ * @param {SupportJSON} newSupport
+ * @param {CommandsJSON} newCommandsData
  */
 export function initialize(newSupport, newCommandsData) {
-  commapi = new commandsAPI(newCommandsData, newSupport);
-
-  // Get the AT under test from the URL search params
-  // set the showResults flag from the URL search params
-  let params = new URL(document.location).searchParams;
-  at = newSupport.ats[0];
-  for (const [key, value] of params) {
-    if (key === "at") {
-      let requestedAT = value;
-      if (commapi.isKnownAT(requestedAT)) {
-        at = commapi.isKnownAT(requestedAT);
-      } else {
-        errors.push(
-          `Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`
-        );
-      }
-    }
-    if (key === "showResults") {
-      if (value === "true") {
-        showResults = true;
-      } else if (value === "false") {
-        showResults = false;
-      }
-    }
-    if (key === "showSubmitButton") {
-      if (value === "true") {
-        showSubmitButton = true;
-      } else if (value === "false") {
-        showSubmitButton = false;
-      }
-    }
-  }
+  testRunIO.setSupportInputFromJSON(newSupport);
+  testRunIO.setConfigInputFromQueryParamsAndSupport(Array.from(new URL(document.location).searchParams));
+  testRunIO.setKeysInputFromBuiltinAndConfig();
+  testRunIO.setCommandsInputFromJSONAndConfigKeys(newCommandsData);
 }
 
 /**
  * @param {BehaviorJSON} atBehavior
  */
 export function verifyATBehavior(atBehavior) {
-  // This is temporary until transition is complete from multiple modes to one mode
-  let mode = typeof atBehavior.mode === "string" ? atBehavior.mode : atBehavior.mode[0];
-
-  /** @type {Behavior} */
-  behavior = {
-    description: document.title,
-    task: atBehavior.task,
-    mode,
-    modeInstructions: commapi.getModeInstructions(mode, at),
-    appliesTo: atBehavior.applies_to,
-    specificUserInstruction: atBehavior.specific_user_instruction,
-    setupScriptDescription: atBehavior.setup_script_description,
-    setupTestPage: atBehavior.setupTestPage,
-    commands: commapi.getATCommands(mode, atBehavior.task, at),
-    outputAssertions: atBehavior.output_assertions ? atBehavior.output_assertions : [],
-    additionalAssertions: atBehavior.additional_assertions ? atBehavior.additional_assertions[at.key] || [] : [],
-    unexpectedBehaviors: [
-      ...UNEXPECTED_BEHAVIORS.map(content => ({content})),
-      {content: "Other", requireExplanation: true},
-    ],
-  };
-
-  if (!firstState && behavior.commands.length) {
-    firstState = initializeTestRunState({
-      errors: errors.length ? errors : null,
-      test: behavior,
-      config: {at, displaySubmitButton: showSubmitButton, renderResultsAfterSubmit: showResults},
-    });
-  } else {
+  if (testRunIO.behaviorInput !== null) {
     throw new Error("Test files should only contain one verifyATBehavior call.");
   }
+
+  testRunIO.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected(atBehavior);
 }
 
 export function displayTestPageAndInstructions(testPage) {
@@ -175,23 +95,19 @@ export function displayTestPageAndInstructions(testPage) {
     return;
   }
 
+  testRunIO.setPageUriInputFromPageUri(testPage);
+
   document.querySelector("html").setAttribute("lang", "en");
   var style = document.createElement("style");
   style.innerHTML = PAGE_STYLES;
   document.head.appendChild(style);
 
-  displayInstructionsForBehaviorTest(testPage, behavior);
+  displayInstructionsForBehaviorTest();
 }
 
-/**
- * @param {string} testPage
- * @param {Behavior} behavior
- */
-function displayInstructionsForBehaviorTest(testPage, behavior) {
+function displayInstructionsForBehaviorTest() {
   const windowManager = new TestWindow({
-    pageUri: testPage,
-    setupScriptName: behavior.setupTestPage,
-    scripts: typeof scripts === "object" ? scripts : {},
+    ...testRunIO.testWindowOptions(),
     hooks: {
       windowOpened() {
         app.dispatch(userOpenWindow());
@@ -206,7 +122,6 @@ function displayInstructionsForBehaviorTest(testPage, behavior) {
   windowManager.prepare();
 
   const app = new TestRunExport({
-    behavior,
     hooks: {
       openTestPage() {
         windowManager.open();
@@ -214,9 +129,10 @@ function displayInstructionsForBehaviorTest(testPage, behavior) {
       closeTestPage() {
         windowManager.close();
       },
-      postResults: () => postResults(app),
+      postResults: () => postResults(testRunIO.submitResultsJSON(app.state)),
     },
-    state: firstState,
+    state: testRunIO.testRunState(),
+    resultsJSON: state => testRunIO.submitResultsJSON(state),
   });
   app.observe(() => {
     render(document.body, renderVirtualTestPage(app.testPageAndResults()));
@@ -259,205 +175,23 @@ function validateMessage(message, type) {
 }
 
 /**
- * @param {TestRunExport} app
+ * @param {resultsJSON} resultsJSON
  */
-function postResults(app) {
+function postResults(resultsJSON) {
   // send message to parent if test is loaded in iFrame
   if (window.parent && window.parent.postMessage) {
     window.parent.postMessage(
       {
         type: "results",
-        data: app.resultsJSON(),
+        data: resultsJSON,
       },
       "*"
     );
   }
 }
 
-/** @typedef {ConstructorParameters<typeof TestRun>[0]} TestRunOptions */
-/**
- * @typedef TestRunExportOptions
- * @property {Behavior} behavior
- */
-
-class TestRunExport extends TestRun {
-  /**
-   * @param {TestRunOptions & TestRunExportOptions} options
-   */
-  constructor({behavior, ...parentOptions}) {
-    super(parentOptions);
-
-    this.behavior = behavior;
-  }
-
-  testPageAndResults() {
-    const testPage = this.testPage();
-    if ("results" in testPage) {
-      return {
-        ...testPage,
-        resultsJSON: this.resultsJSON(),
-      };
-    }
-    return {
-      ...testPage,
-      resultsJSON: this.state.currentUserAction === UserActionMap.CLOSE_TEST_WINDOW ? this.resultsJSON() : null,
-    };
-  }
-
-  resultsJSON() {
-    return toSubmitResultJSON(this.state, this.behavior);
-  }
-}
-
-class TestWindow {
-  /**
-   * @param {object} options
-   * @param {Window | null} [options.window]
-   * @param {string} options.pageUri
-   * @param {string} [options.setupScriptName]
-   * @param {TestWindowHooks} [options.hooks]
-   * @param {SetupScripts} [options.scripts]
-   */
-  constructor({window = null, pageUri, setupScriptName, hooks, scripts = {}}) {
-    /** @type {Window | null} */
-    this.window = window;
-
-    /** @type {string} */
-    this.pageUri = pageUri;
-
-    /** @type {string} */
-    this.setupScriptName = setupScriptName;
-
-    /** @type {TestWindowHooks} */
-    this.hooks = {
-      windowOpened: () => {},
-      windowClosed: () => {},
-      ...hooks,
-    };
-
-    /** @type {SetupScripts} */
-    this.scripts = scripts;
-  }
-
-  open() {
-    this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
-
-    this.hooks.windowOpened();
-
-    // If the window is closed, re-enable open popup button
-    this.window.onunload = () => {
-      window.setTimeout(() => {
-        if (this.window.closed) {
-          this.window = undefined;
-
-          this.hooks.windowClosed();
-        }
-      }, 100);
-    };
-
-    this.prepare();
-  }
-
-  prepare() {
-    if (!this.window) {
-      return;
-    }
-
-    let setupScriptName = this.setupScriptName;
-    if (!setupScriptName) {
-      return;
-    }
-    if (
-      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
-      this.window.document.readyState !== "complete"
-    ) {
-      window.setTimeout(() => {
-        this.prepare();
-      }, 100);
-      return;
-    }
-
-    this.scripts[setupScriptName](this.window.document);
-  }
-
-  close() {
-    if (this.window) {
-      this.window.close();
-    }
-  }
-}
-
 function bind(fn, ...args) {
   return (...moreArgs) => fn(...args, ...moreArgs);
-}
-
-/**
- * @param {object} options
- * @param {string[] | null} [options.errors]
- * @param {Behavior} options.test
- * @param {object} options.config
- * @param {AT} options.config.at
- * @param {boolean} [options.config.displaySubmitButton]
- * @param {boolean} [options.config.renderResultsAfterSubmit]
- * @returns {TestRunState}
- */
-function initializeTestRunState({
-  errors = null,
-  test,
-  config: {at, displaySubmitButton = true, renderResultsAfterSubmit = true},
-}) {
-  return {
-    errors,
-    info: {
-      description: test.description,
-      task: test.task,
-      mode: test.mode,
-      modeInstructions: test.modeInstructions,
-      userInstructions: test.specificUserInstruction.split("|"),
-      setupScriptDescription: test.setupScriptDescription,
-    },
-    config: {
-      at,
-      displaySubmitButton,
-      renderResultsAfterSubmit,
-    },
-    currentUserAction: UserActionMap.LOAD_PAGE,
-    openTest: {
-      enabled: true,
-    },
-    commands: test.commands.map(
-      command =>
-        /** @type {TestRunCommand} */ ({
-          description: command,
-          atOutput: {
-            highlightRequired: false,
-            value: "",
-          },
-          assertions: test.outputAssertions.map(assertion => ({
-            description: assertion[1],
-            highlightRequired: false,
-            priority: Number(assertion[0]),
-            result: CommonResultMap.NOT_SET,
-          })),
-          additionalAssertions: test.additionalAssertions.map(assertion => ({
-            description: assertion[1],
-            highlightRequired: false,
-            priority: Number(assertion[0]),
-            result: CommonResultMap.NOT_SET,
-          })),
-          unexpected: {
-            highlightRequired: false,
-            hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
-            tabbedBehavior: 0,
-            behaviors: test.unexpectedBehaviors.map(({content: description, requireExplanation}) => ({
-              description,
-              checked: false,
-              more: requireExplanation ? {highlightRequired: false, value: ""} : null,
-            })),
-          },
-        })
-    ),
-  };
 }
 
 const a = bind(element, "a");
@@ -790,350 +524,26 @@ function renderVirtualResultsTable(results) {
   }
 }
 
-/**
- * @typedef SubmitResultDetailsCommandsAssertionsPass
- * @property {string} assertion
- * @property {string} priority
- * @property {AssertionPassJSON} pass
- */
+/** @typedef {import('./aria-at-test-io-format.js').SupportJSON} SupportJSON */
+/** @typedef {import('./aria-at-test-io-format.js').CommandsJSON} CommandsJSON */
+/** @typedef {import('./aria-at-test-io-format.js').BehaviorJSON} BehaviorJSON */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
+
+/** @typedef {import('./aria-at-test-run.mjs').Description} Description */
+
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocument} InstructionDocument */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentInstructions} InstructionDocumentInstructions */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentInstructionsAssertions} InstructionDocumentInstructionsAssertions */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsHeader} InstructionDocumentResultsHeader */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsCommand} InstructionDocumentResultsCommand */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsCommandsUnexpected} InstructionDocumentResultsCommandsUnexpected */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentResultsCommandsAssertion} InstructionDocumentResultsCommandsAssertion */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentAssertionChoice} InstructionDocumentAssertionChoice */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentInstructionsInstructions} InstructionDocumentInstructionsInstructions */
+
+/** @typedef {import('./aria-at-test-run.mjs').ResultsTableDocument} ResultsTableDocument */
 
 /**
- * Passing assertion values submitted from the tester result form.
- *
- * In the submitted json object the values contain spaces and are title cased.
- * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
+ * @typedef {import('./aria-at-test-io-format.js').TestPageAndResultsDocument} TestPageAndResultsDocument
  */
-
-const AssertionPassJSONMap = createEnumMap({
-  GOOD_OUTPUT: "Good Output",
-});
-
-/**
- * @typedef SubmitResultDetailsCommandsAssertionsFail
- * @property {string} assertion
- * @property {string} priority
- * @property {AssertionFailJSON} fail
- */
-
-/**
- * Failing assertion values from the tester result form as are submitted in the
- * JSON result object.
- *
- * In the submitted json object the values contain spaces and are title cased.
- * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
- */
-
-const AssertionFailJSONMap = createEnumMap({
-  NO_OUTPUT: "No Output",
-  INCORRECT_OUTPUT: "Incorrect Output",
-  NO_SUPPORT: "No Support",
-});
-
-/** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
-
-/**
- * Command result derived from priority 1 and 2 assertions.
- *
- * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
- * if priority 2 assertions fail.
- *
- * In the submitted json object values may contain spaces and are in ALL CAPS.
- *
- * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
- */
-
-const CommandSupportJSONMap = createEnumMap({
-  FULL: "FULL",
-  FAILING: "FAILING",
-  ALL_REQUIRED: "ALL REQUIRED",
-});
-
-/**
- * Highest level status submitted from test result.
- *
- * In the submitted json object values are in ALL CAPS.
- *
- * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
- */
-
-const StatusJSONMap = createEnumMap({
-  PASS: "PASS",
-  FAIL: "FAIL",
-});
-
-/**
- * @param {TestRunState} state
- * @param {Behavior} behavior
- * @returns {SubmitResultJSON}
- */
-function toSubmitResultJSON(state, behavior) {
-  /** @type {SubmitResultDetailsJSON} */
-  const details = {
-    name: state.info.description,
-    task: state.info.task,
-    specific_user_instruction: behavior.specificUserInstruction,
-    summary: {
-      1: {
-        pass: countAssertions(({priority, result}) => priority === 1 && result === CommonResultMap.PASS),
-        fail: countAssertions(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS),
-      },
-      2: {
-        pass: countAssertions(({priority, result}) => priority === 2 && result === CommonResultMap.PASS),
-        fail: countAssertions(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS),
-      },
-      unexpectedCount: countUnexpectedBehaviors(({checked}) => checked),
-    },
-    commands: state.commands.map(command => ({
-      command: command.description,
-      output: command.atOutput.value,
-      support: commandSupport(command),
-      assertions: [...command.assertions, ...command.additionalAssertions].map(assertionToAssertion),
-      unexpected_behaviors: command.unexpected.behaviors
-        .filter(({checked}) => checked)
-        .map(({description, more}) => (more ? more.value : description)),
-    })),
-  };
-  /** @type {SubmitResultStatusJSON} */
-  const status = state.commands.map(commandSupport).some(support => support === CommandSupportJSONMap.FAILING)
-    ? StatusJSONMap.FAIL
-    : StatusJSONMap.PASS;
-  return {
-    test: state.info.description,
-    details,
-    status,
-  };
-
-  function commandSupport(command) {
-    const allAssertions = [...command.assertions, ...command.additionalAssertions];
-    return allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
-      command.unexpected.behaviors.some(({checked}) => checked)
-      ? CommandSupportJSONMap.FAILING
-      : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
-      ? CommandSupportJSONMap.ALL_REQUIRED
-      : CommandSupportJSONMap.FULL;
-  }
-
-  /**
-   * @param {(assertion: TestRunAssertion | TestRunAdditionalAssertion) => boolean} filter
-   * @returns {number}
-   */
-  function countAssertions(filter) {
-    return state.commands.reduce(
-      (carry, command) => carry + [...command.assertions, ...command.additionalAssertions].filter(filter).length,
-      0
-    );
-  }
-
-  /**
-   * @param {(behavior: TestRunUnexpected) => boolean} filter
-   * @returns {number}
-   */
-  function countUnexpectedBehaviors(filter) {
-    return state.commands.reduce((carry, command) => carry + command.unexpected.behaviors.filter(filter).length, 0);
-  }
-
-  /**
-   * @param {TestRunAssertion | TestRunAdditionalAssertion} assertion
-   * @returns {SubmitResultAssertionsJSON}
-   */
-  function assertionToAssertion(assertion) {
-    return assertion.result === CommonResultMap.PASS
-      ? {
-          assertion: assertion.description,
-          priority: assertion.priority.toString(),
-          pass: AssertionPassJSONMap.GOOD_OUTPUT,
-        }
-      : {
-          assertion: assertion.description,
-          priority: assertion.priority.toString(),
-          fail:
-            assertion.result === AssertionResultMap.FAIL_MISSING
-              ? AssertionFailJSONMap.NO_OUTPUT
-              : assertion.result === AssertionResultMap.FAIL_INCORRECT
-              ? AssertionFailJSONMap.INCORRECT_OUTPUT
-              : AssertionFailJSONMap.NO_SUPPORT,
-        };
-  }
-}
-
-/**
- * @typedef AT
- * @property {string} name
- * @property {string} key
- */
-
-/**
- * @typedef Support
- * @property {AT[]} ats
- * @property {{system: string[]}} applies_to
- * @property {{directory: string, name: string}[]} examples
- */
-
-/**
- * @typedef {{[mode in ATMode]: {[atName: string]: string;};}} CommandsAPI_ModeInstructions
- */
-
-/**
- * @typedef {([string] | [string, string])[]} CommandAT
- */
-
-/**
- * @typedef {{[atMode: string]: CommandAT}} CommandMode
- */
-
-/**
- * @typedef Command
- * @property {CommandMode} [reading]
- * @property {CommandMode} [interaction]
- */
-
-/**
- * @typedef {{[commandDescription: string]: Command}} Commands
- */
-
-/**
- * @callback CommandsAPI_getATCommands
- * @param {ATMode} mode
- * @param {string} task
- * @param {AT} assistiveTech
- * @returns {string[]}
- */
-
-/** @typedef {"reading" | "interaction"} ATMode */
-
-/**
- * @callback CommandsAPI_getModeInstructions
- * @param {ATMode} mode
- * @param {AT} assistiveTech
- * @returns {string}
- */
-
-/**
- * @callback CommandsAPI_isKnownAT
- * @param {string} assistiveTech
- * @returns {AT}
- */
-
-/**
- * @typedef CommandsAPI
- * @property {Commands} AT_COMMAND_MAP
- * @property {CommandsAPI_ModeInstructions} MODE_INSTRUCTIONS
- * @property {Support} support
- * @property {CommandsAPI_getATCommands} getATCommands
- * @property {CommandsAPI_getModeInstructions} getModeInstructions
- * @property {CommandsAPI_isKnownAT} isKnownAT
- */
-
-/**
- * @typedef BehaviorJSON
- * @property {string} setup_script_description
- * @property {string} setupTestPage
- * @property {string[]} applies_to
- * @property {ATMode | ATMode[]} mode
- * @property {string} task
- * @property {string} specific_user_instruction
- * @property {[string, string][]} [output_assertions]
- * @property {{[atKey: string]: [number, string][]}} [additional_assertions]
- */
-
-/**
- * @typedef Behavior
- * @property {string} description
- * @property {string} task
- * @property {ATMode} mode
- * @property {string} modeInstructions
- * @property {string[]} appliesTo
- * @property {string} specificUserInstruction
- * @property {string} setupScriptDescription
- * @property {string} setupTestPage
- * @property {string[]} commands
- * @property {[string, string][]} outputAssertions
- * @property {[number, string][]} additionalAssertions
- * @property {object[]} unexpectedBehaviors
- * @property {string} unexpectedBehaviors[].content
- * @property {boolean} [unexpectedBehaviors[].requireExplanation]
- */
-
-/**
- * @typedef SubmitResultJSON
- * @property {string} test
- * @property {SubmitResultDetailsJSON} details
- * @property {SubmitResultStatusJSON} status
- */
-
-/**
- * @typedef SubmitResultSummaryPriorityJSON
- * @property {number} pass
- * @property {number} fail
- */
-
-/**
- * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
- */
-
-/**
- * @typedef SubmitResultSummaryPropsJSON
- * @property {number} unexpectedCount
- */
-
-/**
- * @typedef {SubmitResultSummaryPriorityMapJSON & SubmitResultSummaryPropsJSON} SubmitResultSummaryJSON
- */
-
-/**
- * @typedef SubmitResultDetailsJSON
- * @property {string} name
- * @property {string} specific_user_instruction
- * @property {string} task
- * @property {object[]} commands
- * @property {string} commands[].command
- * @property {string} commands[].output
- * @property {string[]} commands[].unexpected_behaviors
- * @property {CommandSupportJSON} commands[].support
- * @property {SubmitResultAssertionsJSON[]} commands[].assertions
- * @property {SubmitResultSummaryJSON} summary
- */
-
-/**
- * @typedef TestWindowHooks
- * @property {() => void} windowOpened
- * @property {() => void} windowClosed
- */
-
-/** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
-
-/**
- * @typedef ResultJSONDocument
- * @property {SubmitResultJSON | null} resultsJSON
- */
-
-/**
- * @typedef {TestPageDocument & ResultJSONDocument} TestPageAndResultsDocument
- */
-
-/**
- * @typedef {import('./aria-at-test-run.js').EnumValues<T>} EnumValues<T>
- * @template T
- */
-
-/** @typedef {import('./aria-at-test-run.js').TestRunState} TestRunState */
-/** @typedef {import('./aria-at-test-run.js').TestRunAssertion} TestRunAssertion */
-/** @typedef {import('./aria-at-test-run.js').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
-/** @typedef {import('./aria-at-test-run.js').TestRunCommand} TestRunCommand */
-/** @typedef {import("./aria-at-test-run.js").TestRunUnexpectedBehavior} TestRunUnexpected */
-
-/** @typedef {import('./aria-at-test-run.js').Description} Description */
-
-/** @typedef {import('./aria-at-test-run.js').TestPageDocument} TestPageDocument */
-
-/** @typedef {import('./aria-at-test-run.js').InstructionDocument} InstructionDocument */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructions} InstructionDocumentInstructions */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructionsAssertions} InstructionDocumentInstructionsAssertions */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsHeader} InstructionDocumentResultsHeader */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommand} InstructionDocumentResultsCommand */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommandsUnexpected} InstructionDocumentResultsCommandsUnexpected */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentResultsCommandsAssertion} InstructionDocumentResultsCommandsAssertion */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentAssertionChoice} InstructionDocumentAssertionChoice */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentInstructionsInstructions} InstructionDocumentInstructionsInstructions */
-
-/** @typedef {import('./aria-at-test-run.js').ResultsTableDocument} ResultsTableDocument */

--- a/build/tests/resources/aria-at-test-io-format.mjs
+++ b/build/tests/resources/aria-at-test-io-format.mjs
@@ -1,0 +1,1104 @@
+import {
+  HasUnexpectedBehaviorMap,
+  createEnumMap,
+  TestRun,
+  AssertionResultMap,
+  UserActionMap,
+  CommonResultMap,
+} from "./aria-at-test-run.mjs";
+import * as keysModule from "./keys.mjs";
+
+const UNEXPECTED_BEHAVIORS = [
+  "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
+  "Reading cursor position changed in an unexpected manner",
+  "Screen reader became extremely sluggish",
+  "Screen reader crashed",
+  "Browser crashed",
+];
+
+/** Depends on ConfigInput. */
+class KeysInput {
+  /**
+   * @param {object} value
+   * @param {string} value.origin
+   * @param {{[KEY_ID: string]: string}} value.keys
+   * @param {ATJSON} value.at
+   * @param {{[atMode in ATMode]: string}} value.modeInstructions
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  origin() {
+    return this._value.origin;
+  }
+
+  /**
+   * @param {string} keyId
+   * @returns {string}
+   */
+  keysForCommand(keyId) {
+    return this._value.keys[keyId];
+  }
+
+  /**
+   * @param {ATMode} atMode
+   */
+  modeInstructions(atMode) {
+    if (this._value.modeInstructions[atMode]) {
+      return this._value.modeInstructions[atMode];
+    }
+    return "";
+  }
+
+  /**
+   * @param {object} data
+   * @param {ConfigInput} data.configInput
+   */
+  static fromBuiltinAndConfig({configInput}) {
+    const keys = keysModule;
+    const atKey = configInput.at().key;
+
+    invariant(
+      ['jaws', 'nvda', 'voiceover_macos'].includes(atKey),
+      '%s is one of "jaws", "nvda", or "voiceover_macos"', atKey
+    );
+
+    return new KeysInput({
+      origin: "resources/keys.mjs",
+      keys,
+      at: atKey,
+      modeInstructions: {
+        reading: {
+          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          nvda: `Insure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
+          voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
+        }[atKey],
+        interaction: {
+          jaws: `Verify the PC Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn off the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          nvda: `If NVDA did not make the focus mode sound when the test page loaded, press ${keys.INS_SPACE} to turn focus mode on.`,
+          voiceover_macos: `Toggle Quick Nav OFF by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
+        }[atKey],
+      },
+    });
+  }
+}
+
+class SupportInput {
+  /**
+   * @param {SupportJSON} value
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  defaultAT() {
+    return this._value.ats[0];
+  }
+
+  /**
+   * @param {string} atKey
+   * @returns {ATJSON | undefined}
+   */
+  findAT(atKey) {
+    const lowercaseATKey = atKey.toLowerCase();
+    return this._value.ats.find(({key}) => key === lowercaseATKey);
+  }
+
+  /**
+   * @param {SupportJSON} json
+   */
+  static fromJSON(json) {
+    return new SupportInput(json);
+  }
+}
+
+/** Depends on ConfigInput and KeysInput. */
+class CommandsInput {
+  /**
+   * @param {object} value
+   * @param {CommandsJSON} value.commands
+   * @param {ATJSON} value.at
+   * @param {KeysInput} keysInput
+   * @private
+   */
+  constructor(value, keysInput) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+
+    /** @private */
+    this._keysInput = keysInput;
+  }
+
+  /**
+   * @param {string} task
+   * @param {ATMode} atMode
+   * @returns {string[]}
+   */
+  getCommands(task, atMode) {
+    const assistiveTech = this._value.at;
+
+    if (!this._value.commands[task]) {
+      throw new Error(`Task "${task}" does not exist, please add to at-commands or correct your spelling.`);
+    } else if (!this._value.commands[task][atMode]) {
+      throw new Error(
+        `Mode "${atMode}" instructions for task "${task}" does not exist, please add to at-commands or correct your spelling.`
+      );
+    }
+
+    let commandsData = this._value.commands[task][atMode][assistiveTech.key] || [];
+    let commands = [];
+
+    for (let c of commandsData) {
+      let innerCommands = [];
+      let commandSequence = c[0].split(",");
+      for (let command of commandSequence) {
+        command = this._keysInput.keysForCommand(command);
+        if (typeof command === "undefined") {
+          throw new Error(
+            `Key instruction identifier "${c}" for AT "${assistiveTech.name}", mode "${atMode}", task "${task}" is not an available identified. Update you commands.json file to the correct identifier or add your identifier to resources/keys.mjs.`
+          );
+        }
+
+        let furtherInstruction = c[1];
+        command = furtherInstruction ? `${command} ${furtherInstruction}` : command;
+        innerCommands.push(command);
+      }
+      commands.push(innerCommands.join(", then "));
+    }
+
+    return commands;
+  }
+
+  /**
+   * @param {CommandsJSON} json
+   * @param {object} data
+   * @param {ConfigInput} data.configInput
+   * @param {KeysInput} data.keysInput
+   */
+  static fromJSONAndConfigKeys(json, {configInput, keysInput}) {
+    return new CommandsInput({commands: json, at: configInput.at()}, keysInput);
+  }
+}
+
+/**
+ * Depends on SupportInput.
+ */
+class ConfigInput {
+  /**
+   * @param {string[]} errors
+   * @param {object} value
+   * @param {ATJSON} value.at
+   * @param {boolean} value.displaySubmitButton
+   * @param {boolean} value.renderResultsAfterSubmit
+   * @private
+   */
+  constructor(errors, value) {
+    this.errors = errors;
+
+    /** @private */
+    this._value = value;
+  }
+
+  at() {
+    return this._value.at;
+  }
+
+  displaySubmitButton() {
+    return this._value.displaySubmitButton;
+  }
+
+  renderResultsAfterSubmit() {
+    return this._value.renderResultsAfterSubmit;
+  }
+
+  /**
+   * @param {ConfigQueryParams} queryParams
+   * @param {object} data
+   * @param {SupportInput} data.supportInput
+   */
+  static fromQueryParamsAndSupport(queryParams, {supportInput}) {
+    const errors = [];
+
+    let at = supportInput.defaultAT();
+    let displaySubmitButton = true;
+    let renderResultsAfterSubmit = true;
+
+    for (const [key, value] of queryParams) {
+      if (key === "at") {
+        const requestedAT = value;
+        const knownAt = supportInput.findAT(requestedAT);
+        if (knownAt) {
+          at = knownAt;
+        } else {
+          errors.push(
+            `Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`
+          );
+        }
+      } else if (key === "showResults") {
+        displaySubmitButton = decodeBooleanParam(value, displaySubmitButton);
+      } else if (key === "showSubmitButton") {
+        renderResultsAfterSubmit = decodeBooleanParam(value, renderResultsAfterSubmit);
+      }
+    }
+
+    return new ConfigInput(errors, {
+      at,
+      displaySubmitButton,
+      renderResultsAfterSubmit,
+    });
+
+    /**
+     * @param {string} param
+     * @param {boolean} defaultValue
+     * @returns {boolean}
+     */
+    function decodeBooleanParam(param, defaultValue) {
+      if (param === "true") {
+        return true;
+      } else if (param === "false") {
+        return false;
+      }
+      return defaultValue;
+    }
+  }
+}
+
+class ScriptsInput {
+  /**
+   * @param {object} value
+   * @param {SetupScripts} value.scripts
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  scripts() {
+    return this._value.scripts;
+  }
+
+  /**
+   * @param {SetupScripts} scripts
+   */
+  static fromScriptsMap(scripts) {
+    return new ScriptsInput({scripts});
+  }
+}
+
+class UnexpectedInput {
+  /**
+   * @param {object} value
+   * @param {BehaviorUnexpectedItem[]} value.behaviors
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    this._value = value;
+  }
+
+  behaviors() {
+    return this._value.behaviors;
+  }
+
+  static fromBuiltin() {
+    return new UnexpectedInput({
+      behaviors: [
+        ...UNEXPECTED_BEHAVIORS.map(description => ({description, requireExplanation: false})),
+        {description: "Other", requireExplanation: true},
+      ],
+    });
+  }
+}
+
+class TitleInput {
+  /**
+   * @param {object} value
+   * @param {string} value.title
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  title() {
+    return this._value.title;
+  }
+
+  /** @param {string} title */
+  static fromTitle(title) {
+    return new TitleInput({
+      title,
+    });
+  }
+}
+
+/** Depends on CommandsInput, ConfigInput, KeysInput, TitleInput, and UnexpectedInput. */
+class BehaviorInput {
+  /**
+   * @param {object} value
+   * @param {Behavior} value.behavior
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  behavior() {
+    return this._value.behavior;
+  }
+
+  /**
+   * @param {BehaviorJSON} json
+   * @param {object} data
+   * @param {KeysInput} data.keysInput
+   * @param {CommandsInput} data.commandsInput
+   * @param {ConfigInput} data.configInput
+   * @param {UnexpectedInput} data.unexpectedInput
+   * @param {TitleInput} data.titleInput
+   */
+  static fromJSONCommandsConfigKeysTitleUnexpected(
+    json,
+    {commandsInput, configInput, keysInput, titleInput, unexpectedInput}
+  ) {
+    const mode = Array.isArray(json.mode) ? json.mode[0] : json.mode;
+    const at = configInput.at();
+
+    return new BehaviorInput({
+      behavior: {
+        description: titleInput.title(),
+        task: json.task,
+        mode,
+        modeInstructions: keysInput.modeInstructions(mode),
+        appliesTo: json.applies_to,
+        specificUserInstruction: json.specific_user_instruction,
+        setupScriptDescription: json.setup_script_description,
+        setupTestPage: json.setupTestPage,
+        commands: commandsInput.getCommands(json.task, mode),
+        assertions: (json.output_assertions ? json.output_assertions : []).map(assertionTuple => ({
+          priority: Number(assertionTuple[0]),
+          assertion: assertionTuple[1],
+        })),
+        additionalAssertions: (json.additional_assertions ? json.additional_assertions[at.key] || [] : []).map(
+          assertionTuple => ({
+            priority: Number(assertionTuple[0]),
+            assertion: assertionTuple[1],
+          })
+        ),
+        unexpectedBehaviors: unexpectedInput.behaviors(),
+      },
+    });
+  }
+}
+
+class PageUriInput {
+  /**
+   * @param {object} value
+   * @param {string} value.pageUri
+   * @private
+   */
+  constructor(value) {
+    this._errors = [];
+    this._value = value;
+  }
+
+  pageUri() {
+    return this._value.pageUri;
+  }
+
+  /**
+   * @param {string} pageUri
+   */
+  static fromPageUri(pageUri) {
+    return new PageUriInput({pageUri});
+  }
+}
+
+export class TestRunInputOutput {
+  constructor() {
+    /** @type {BehaviorInput} */
+    this.behaviorInput = null;
+    /** @type {CommandsInput} */
+    this.commandsInput = null;
+    /** @type {ConfigInput} */
+    this.configInput = null;
+    /** @type {KeysInput} */
+    this.keysInput = null;
+    /** @type {PageUriInput} */
+    this.pageUriInput = null;
+    /** @type {ScriptsInput} */
+    this.scriptsInput = null;
+    /** @type {SupportInput} */
+    this.supportInput = null;
+    /** @type {TitleInput} */
+    this.titleInput = null;
+    /** @type {UnexpectedInput} */
+    this.unexpectedInput = null;
+  }
+
+  /** @param {BehaviorInput} behaviorInput */
+  setBehaviorInput(behaviorInput) {
+    this.behaviorInput = behaviorInput;
+  }
+
+  /** @param {BehaviorJSON} behaviorJSON */
+  setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected(behaviorJSON) {
+    invariant(
+      this.commandsInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setCommandsInput.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.keysInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setKeysInput.name,
+      this.setKeysInputFromBuiltinAndConfig.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.titleInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setTitleInput.name,
+      this.setTitleInputFromTitle.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.unexpectedInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setUnexpectedInput.name,
+      this.setUnexpectedInputFromBuiltin.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+
+    this.setBehaviorInput(
+      BehaviorInput.fromJSONCommandsConfigKeysTitleUnexpected(behaviorJSON, {
+        commandsInput: this.commandsInput,
+        configInput: this.configInput,
+        keysInput: this.keysInput,
+        titleInput: this.titleInput,
+        unexpectedInput: this.unexpectedInput,
+      })
+    );
+  }
+
+  /** @param {CommandsInput} commandsInput */
+  setCommandsInput(commandsInput) {
+    this.commandsInput = commandsInput;
+  }
+
+  /** @param {CommandsJSON} commandsJSON */
+  setCommandsInputFromJSONAndConfigKeys(commandsJSON) {
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+    invariant(
+      this.keysInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setKeysInput.name,
+      this.setKeysInputFromBuiltinAndConfig.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+
+    this.setCommandsInput(
+      CommandsInput.fromJSONAndConfigKeys(commandsJSON, {
+        configInput: this.configInput,
+        keysInput: this.keysInput,
+      })
+    );
+  }
+
+  /** @param {ConfigInput} configInput */
+  setConfigInput(configInput) {
+    this.configInput = configInput;
+  }
+
+  /** @param {ConfigQueryParams} queryParams */
+  setConfigInputFromQueryParamsAndSupport(queryParams) {
+    invariant(
+      this.supportInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setSupportInput.name,
+      this.setSupportInputFromJSON.name,
+      this.setConfigInputFromQueryParamsAndSupport.name
+    );
+
+    this.setConfigInput(
+      ConfigInput.fromQueryParamsAndSupport(queryParams, {
+        supportInput: this.supportInput,
+      })
+    );
+  }
+
+  /** @param {KeysInput} keysInput */
+  setKeysInput(keysInput) {
+    this.keysInput = keysInput;
+  }
+
+  setKeysInputFromBuiltinAndConfig() {
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+
+    this.setKeysInput(KeysInput.fromBuiltinAndConfig({configInput: this.configInput}));
+  }
+
+  /** @param {PageUriInput} pageUriInput */
+  setPageUriInput(pageUriInput) {
+    this.pageUriInput = pageUriInput;
+  }
+
+  /** @param {string} pageUri */
+  setPageUriInputFromPageUri(pageUri) {
+    this.setPageUriInput(PageUriInput.fromPageUri(pageUri));
+  }
+
+  /** @param {ScriptsInput} scriptsInput */
+  setScriptsInput(scriptsInput) {
+    this.scriptsInput = scriptsInput;
+  }
+
+  /** @param {SetupScripts} scriptsMap */
+  setScriptsInputFromMap(scriptsMap) {
+    this.setScriptsInput(ScriptsInput.fromScriptsMap(scriptsMap));
+  }
+
+  /** @param {SupportInput} supportInput */
+  setSupportInput(supportInput) {
+    this.supportInput = supportInput;
+  }
+
+  /** @param {SupportJSON} supportJSON */
+  setSupportInputFromJSON(supportJSON) {
+    this.setSupportInput(SupportInput.fromJSON(supportJSON));
+  }
+
+  /** @param {TitleInput} titleInput */
+  setTitleInput(titleInput) {
+    this.titleInput = titleInput;
+  }
+
+  /** @param {string} title */
+  setTitleInputFromTitle(title) {
+    this.setTitleInput(TitleInput.fromTitle(title));
+  }
+
+  /** @param {UnexpectedInput} unexpectedInput */
+  setUnexpectedInput(unexpectedInput) {
+    this.unexpectedInput = unexpectedInput;
+  }
+
+  setUnexpectedInputFromBuiltin() {
+    this.setUnexpectedInput(UnexpectedInput.fromBuiltin());
+  }
+
+  /** @returns {import("./aria-at-test-run.mjs").TestRunState} */
+  testRunState() {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.testRunState.name
+    );
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.testRunState.name
+    );
+
+    const errors = [...this.behaviorInput.errors, ...this.commandsInput.errors, ...this.configInput.errors];
+    const test = this.behaviorInput.behavior();
+    const config = this.configInput;
+
+    return {
+      errors,
+      info: {
+        description: test.description,
+        task: test.task,
+        mode: test.mode,
+        modeInstructions: test.modeInstructions,
+        userInstructions: test.specificUserInstruction.split("|"),
+        setupScriptDescription: test.setupScriptDescription,
+      },
+      config: {
+        at: config.at(),
+        displaySubmitButton: config.displaySubmitButton(),
+        renderResultsAfterSubmit: config.renderResultsAfterSubmit(),
+      },
+      currentUserAction: UserActionMap.LOAD_PAGE,
+      openTest: {
+        enabled: true,
+      },
+      commands: test.commands.map(
+        command =>
+          /** @type {import("./aria-at-test-run.mjs").TestRunCommand} */ ({
+            description: command,
+            atOutput: {
+              highlightRequired: false,
+              value: "",
+            },
+            assertions: test.assertions.map(assertion => ({
+              description: assertion.assertion,
+              highlightRequired: false,
+              priority: assertion.priority,
+              result: CommonResultMap.NOT_SET,
+            })),
+            additionalAssertions: test.additionalAssertions.map(assertion => ({
+              description: assertion.assertion,
+              highlightRequired: false,
+              priority: assertion.priority,
+              result: CommonResultMap.NOT_SET,
+            })),
+            unexpected: {
+              highlightRequired: false,
+              hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
+              tabbedBehavior: 0,
+              behaviors: test.unexpectedBehaviors.map(({description, requireExplanation}) => ({
+                description,
+                checked: false,
+                more: requireExplanation ? {highlightRequired: false, value: ""} : null,
+              })),
+            },
+          })
+      ),
+    };
+  }
+
+  testWindowOptions() {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.testWindowOptions.name
+    );
+    invariant(
+      this.pageUriInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setPageUriInput.name,
+      this.setPageUriInputFromPageUri.name,
+      this.testWindowOptions.name
+    );
+    invariant(
+      this.scriptsInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setScriptsInput.name,
+      this.setScriptsInputFromMap.name,
+      this.testWindowOptions.name
+    );
+
+    return {
+      pageUri: this.pageUriInput.pageUri(),
+      setupScriptName: this.behaviorInput.behavior().setupTestPage,
+      scripts: this.scriptsInput.scripts(),
+    };
+  }
+
+  /**
+   * @param {import("./aria-at-test-run.mjs").TestRunState} state
+   * @returns {import("./aria-at-harness.mjs").SubmitResultJSON}
+   */
+  submitResultsJSON(state) {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.submitResultsJSON.name
+    );
+
+    const behavior = this.behaviorInput.behavior();
+
+    /** @type {SubmitResultDetailsJSON} */
+    const details = {
+      name: state.info.description,
+      task: state.info.task,
+      specific_user_instruction: behavior.specificUserInstruction,
+      summary: {
+        1: {
+          pass: countAssertions(({priority, result}) => priority === 1 && result === CommonResultMap.PASS),
+          fail: countAssertions(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS),
+        },
+        2: {
+          pass: countAssertions(({priority, result}) => priority === 2 && result === CommonResultMap.PASS),
+          fail: countAssertions(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS),
+        },
+        unexpectedCount: countUnexpectedBehaviors(({checked}) => checked),
+      },
+      commands: state.commands.map(command => ({
+        command: command.description,
+        output: command.atOutput.value,
+        support: commandSupport(command),
+        assertions: [...command.assertions, ...command.additionalAssertions].map(assertionToAssertion),
+        unexpected_behaviors: command.unexpected.behaviors
+          .filter(({checked}) => checked)
+          .map(({description, more}) => (more ? more.value : description)),
+      })),
+    };
+
+    /** @type {SubmitResultStatusJSON} */
+    const status = state.commands.map(commandSupport).some(support => support === CommandSupportJSONMap.FAILING)
+      ? StatusJSONMap.FAIL
+      : StatusJSONMap.PASS;
+
+    return {
+      test: state.info.description,
+      details,
+      status,
+    };
+
+    function commandSupport(command) {
+      const allAssertions = [...command.assertions, ...command.additionalAssertions];
+      return allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
+        command.unexpected.behaviors.some(({checked}) => checked)
+        ? CommandSupportJSONMap.FAILING
+        : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
+        ? CommandSupportJSONMap.ALL_REQUIRED
+        : CommandSupportJSONMap.FULL;
+    }
+
+    /**
+     * @param {(assertion: TestRunAssertion | TestRunAdditionalAssertion) => boolean} filter
+     * @returns {number}
+     */
+    function countAssertions(filter) {
+      return state.commands.reduce(
+        (carry, command) => carry + [...command.assertions, ...command.additionalAssertions].filter(filter).length,
+        0
+      );
+    }
+
+    /**
+     * @param {(behavior: TestRunUnexpected) => boolean} filter
+     * @returns {number}
+     */
+    function countUnexpectedBehaviors(filter) {
+      return state.commands.reduce((carry, command) => carry + command.unexpected.behaviors.filter(filter).length, 0);
+    }
+
+    /**
+     * @param {TestRunAssertion | TestRunAdditionalAssertion} assertion
+     * @returns {SubmitResultAssertionsJSON}
+     */
+    function assertionToAssertion(assertion) {
+      return assertion.result === CommonResultMap.PASS
+        ? {
+            assertion: assertion.description,
+            priority: assertion.priority.toString(),
+            pass: AssertionPassJSONMap.GOOD_OUTPUT,
+          }
+        : {
+            assertion: assertion.description,
+            priority: assertion.priority.toString(),
+            fail:
+              assertion.result === AssertionResultMap.FAIL_MISSING
+                ? AssertionFailJSONMap.NO_OUTPUT
+                : assertion.result === AssertionResultMap.FAIL_INCORRECT
+                ? AssertionFailJSONMap.INCORRECT_OUTPUT
+                : AssertionFailJSONMap.NO_SUPPORT,
+          };
+    }
+  }
+}
+
+/**
+ * Extended TestRun that can access methods to turn the TestRun["state"] into
+ * the desired output format.
+ */
+export class TestRunExport extends TestRun {
+  /**
+   * @param {TestRunOptions & TestRunExportOptions} options
+   */
+  constructor({resultsJSON, ...parentOptions}) {
+    super(parentOptions);
+
+    this.resultsJSON = resultsJSON;
+  }
+
+  testPageAndResults() {
+    const testPage = this.testPage();
+    if ("results" in testPage) {
+      return {
+        ...testPage,
+        resultsJSON: this.resultsJSON(this.state),
+      };
+    }
+    return {
+      ...testPage,
+      resultsJSON: this.state.currentUserAction === UserActionMap.CLOSE_TEST_WINDOW ? this.resultsJSON(this.state) : null,
+    };
+  }
+}
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsPass
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionPassJSON} pass
+ */
+
+/**
+ * Passing assertion values submitted from the tester result form.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
+ */
+
+const AssertionPassJSONMap = createEnumMap({
+  GOOD_OUTPUT: "Good Output",
+});
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsFail
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionFailJSON} fail
+ */
+
+/**
+ * Failing assertion values from the tester result form as are submitted in the
+ * JSON result object.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
+ */
+
+const AssertionFailJSONMap = createEnumMap({
+  NO_OUTPUT: "No Output",
+  INCORRECT_OUTPUT: "Incorrect Output",
+  NO_SUPPORT: "No Support",
+});
+
+/** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
+
+/**
+ * Command result derived from priority 1 and 2 assertions.
+ *
+ * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
+ * if priority 2 assertions fail.
+ *
+ * In the submitted json object values may contain spaces and are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
+ */
+
+const CommandSupportJSONMap = createEnumMap({
+  FULL: "FULL",
+  FAILING: "FAILING",
+  ALL_REQUIRED: "ALL REQUIRED",
+});
+
+/**
+ * Highest level status submitted from test result.
+ *
+ * In the submitted json object values are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
+ */
+
+const StatusJSONMap = createEnumMap({
+  PASS: "PASS",
+  FAIL: "FAIL",
+});
+
+/**
+ * @param {boolean} test
+ * @param {string} message
+ * @param {any[]} args
+ * @returns {asserts test}
+ */
+function invariant(test, message, ...args) {
+  if (!test) {
+    let index = 0;
+    throw new Error(message.replace(/%%|%\w/g, match => (match[0] !== "%%" ? args[index++] : "%")));
+  }
+}
+
+/** @typedef {ConstructorParameters<typeof TestRun>[0]} TestRunOptions */
+/**
+ * @typedef TestRunExportOptions
+ * @property {(state: TestRunState) => SubmitResultJSON} resultsJSON
+ */
+
+/**
+ * @typedef ATJSON
+ * @property {string} name
+ * @property {string} key
+ */
+
+/**
+ * @typedef SupportJSON
+ * @property {ATJSON[]} ats
+ * @property {object} applies_to
+ * @property {string[]} applies_to.system
+ * @property {object[]} examples
+ * @property {string} examples[].directory
+ * @property {string} examples[].name
+ */
+
+/**
+ * @typedef {([string] | [string, string])[]} CommandATJSON
+ */
+
+/**
+ * @typedef {{[atMode: string]: CommandATJSON}} CommandModeJSON
+ */
+
+/**
+ * @typedef CommandJSON
+ * @property {CommandModeJSON} [reading]
+ * @property {CommandModeJSON} [interaction]
+ */
+
+/**
+ * @typedef {{[commandDescription: string]: CommandJSON}} CommandsJSON
+ */
+
+/**
+ * @typedef {["at" | "showSubmitButton" | "showResults" | string, string][]} ConfigQueryParams
+ */
+
+/** @typedef {"reading" | "interaction"} ATMode */
+
+/**
+ * @typedef BehaviorJSON
+ * @property {string} setup_script_description
+ * @property {string} setupTestPage
+ * @property {string[]} applies_to
+ * @property {ATMode | ATMode[]} mode
+ * @property {string} task
+ * @property {string} specific_user_instruction
+ * @property {[string, string][]} [output_assertions]
+ * @property {{[atKey: string]: [number, string][]}} [additional_assertions]
+ */
+
+/**
+ * @typedef BehaviorAssertion
+ * @property {number} priority
+ * @property {string} assertion
+ */
+
+/**
+ * @typedef BehaviorUnexpectedItem
+ * @property {string} description
+ * @property {boolean} requireExplanation
+ */
+
+/**
+ * @typedef Behavior
+ * @property {string} description
+ * @property {string} task
+ * @property {ATMode} mode
+ * @property {string} modeInstructions
+ * @property {string[]} appliesTo
+ * @property {string} specificUserInstruction
+ * @property {string} setupScriptDescription
+ * @property {string} setupTestPage
+ * @property {string[]} commands
+ * @property {BehaviorAssertion[]} assertions
+ * @property {BehaviorAssertion[]} additionalAssertions
+ * @property {BehaviorUnexpectedItem[]} unexpectedBehaviors
+ */
+
+/** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
+
+/**
+ * @typedef SubmitResultJSON
+ * @property {string} test
+ * @property {SubmitResultDetailsJSON} details
+ * @property {SubmitResultStatusJSON} status
+ */
+
+/**
+ * @typedef SubmitResultSummaryPriorityJSON
+ * @property {number} pass
+ * @property {number} fail
+ */
+
+/**
+ * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
+ */
+
+/**
+ * @typedef SubmitResultSummaryPropsJSON
+ * @property {number} unexpectedCount
+ */
+
+/**
+ * @typedef {SubmitResultSummaryPriorityMapJSON & SubmitResultSummaryPropsJSON} SubmitResultSummaryJSON
+ */
+
+/**
+ * @typedef SubmitResultDetailsJSON
+ * @property {string} name
+ * @property {string} specific_user_instruction
+ * @property {string} task
+ * @property {object[]} commands
+ * @property {string} commands[].command
+ * @property {string} commands[].output
+ * @property {string[]} commands[].unexpected_behaviors
+ * @property {CommandSupportJSON} commands[].support
+ * @property {SubmitResultAssertionsJSON[]} commands[].assertions
+ * @property {SubmitResultSummaryJSON} summary
+ */
+
+/**
+ * @typedef ResultJSONDocument
+ * @property {SubmitResultJSON | null} resultsJSON
+ */
+
+/**
+ * @typedef {TestPageDocument & ResultJSONDocument} TestPageAndResultsDocument
+ */
+
+/**
+ * @typedef {import('./aria-at-test-run.mjs').EnumValues<T>} EnumValues<T>
+ * @template T
+ */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunAssertion} TestRunAssertion */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunCommand} TestRunCommand */
+/** @typedef {import("./aria-at-test-run.mjs").TestRunUnexpectedBehavior} TestRunUnexpected */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestPageDocument} TestPageDocument */

--- a/build/tests/resources/aria-at-test-run.mjs
+++ b/build/tests/resources/aria-at-test-run.mjs
@@ -119,7 +119,7 @@ export function instructionDocument(resultState, hooks) {
   return {
     errors: {
       visible: false,
-      header: "",
+      header: "Test cannot be performed due to error(s)!",
       errors: [],
     },
     instructions: {
@@ -218,9 +218,9 @@ export function instructionDocument(resultState, hooks) {
         change: atOutput => hooks.setCommandOutput({commandIndex, atOutput}),
       },
       assertionsHeader: {
-        descriptionHeader: "",
-        passHeader: "",
-        failHeader: "",
+        descriptionHeader: "Assertion",
+        passHeader: "Success case",
+        failHeader: "Failure cases",
       },
       assertions: [
         ...assertions.map(bind(assertionResult, commandIndex)),
@@ -363,7 +363,7 @@ export function instructionDocument(resultState, hooks) {
             },
           ],
           click: () =>
-            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_INCORRECT}),
         }),
       ],
     });

--- a/build/tests/resources/aria-at-test-window.mjs
+++ b/build/tests/resources/aria-at-test-window.mjs
@@ -1,0 +1,85 @@
+export class TestWindow {
+  /**
+   * @param {object} options
+   * @param {Window | null} [options.window]
+   * @param {string} options.pageUri
+   * @param {string} [options.setupScriptName]
+   * @param {TestWindowHooks} [options.hooks]
+   * @param {SetupScripts} [options.scripts]
+   */
+  constructor({window = null, pageUri, setupScriptName, hooks, scripts = {}}) {
+    /** @type {Window | null} */
+    this.window = window;
+
+    /** @type {string} */
+    this.pageUri = pageUri;
+
+    /** @type {string} */
+    this.setupScriptName = setupScriptName;
+
+    /** @type {TestWindowHooks} */
+    this.hooks = {
+      windowOpened: () => {},
+      windowClosed: () => {},
+      ...hooks,
+    };
+
+    /** @type {SetupScripts} */
+    this.scripts = scripts;
+  }
+
+  open() {
+    this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
+
+    this.hooks.windowOpened();
+
+    // If the window is closed, re-enable open popup button
+    this.window.onunload = () => {
+      window.setTimeout(() => {
+        if (this.window.closed) {
+          this.window = undefined;
+
+          this.hooks.windowClosed();
+        }
+      }, 100);
+    };
+
+    this.prepare();
+  }
+
+  prepare() {
+    if (!this.window) {
+      return;
+    }
+
+    let setupScriptName = this.setupScriptName;
+    if (!setupScriptName) {
+      return;
+    }
+    if (
+      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
+      this.window.document.readyState !== "complete"
+    ) {
+      window.setTimeout(() => {
+        this.prepare();
+      }, 100);
+      return;
+    }
+
+    this.scripts[setupScriptName](this.window.document);
+  }
+
+  close() {
+    if (this.window) {
+      this.window.close();
+    }
+  }
+}
+
+/**
+ * @typedef TestWindowHooks
+ * @property {() => void} windowOpened
+ * @property {() => void} windowClosed
+ */
+
+/** @typedef {import('./aria-at-test-formatter').SetupScripts} SetupScripts */

--- a/build/tests/resources/at-commands.mjs
+++ b/build/tests/resources/at-commands.mjs
@@ -1,6 +1,11 @@
+/** @deprecated See aria-at-test-io-format.mjs */
+
 import * as keys from './keys.mjs';
 
-/** Class for getting AT-specific instructions for a test against a design pattern. */
+/**
+ * Class for getting AT-specific instructions for a test against a design pattern.
+ * @deprecated See aria-at-test-io-format.mjs:CommandsInput
+ */
 export class commandsAPI {
   /**
    * Creates an API to get AT-specific instructions for a design pattern.

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -46,7 +46,9 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
   const resourcesDirectory = path.join(testsDirectory, 'resources');
 
   const ariaAtHarnessFilePath = path.join(resourcesDirectory, 'aria-at-harness.mjs');
+  const ariaAtTestIoFormatFilePath = path.join(resourcesDirectory, 'aria-at-test-io-format.mjs');
   const ariaAtTestRunFilePath = path.join(resourcesDirectory, 'aria-at-test-run.mjs');
+  const ariaAtTestWindowFilePath = path.join(resourcesDirectory, 'aria-at-test-window.mjs');
   const atCommandsFilePath = path.join(resourcesDirectory, 'at-commands.mjs');
   const keysFilePath = path.join(resourcesDirectory, 'keys.mjs');
   const vrenderFilePath = path.join(resourcesDirectory, 'vrender.mjs');
@@ -69,7 +71,9 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
   const supportFileBuildPath = path.join(testsBuildDirectory, 'support.json');
 
   const ariaAtHarnessFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-harness.mjs');
+  const ariaAtTestIoFormatFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-test-io-format.mjs');
   const ariaAtTestRunFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-test-run.mjs');
+  const ariaAtTestWindowFileBuildPath = path.join(resourcesBuildDirectory, 'aria-at-test-window.mjs');
   const atCommandsFileBuildPath = path.join(resourcesBuildDirectory, 'at-commands.mjs');
   const keysFileBuildPath = path.join(resourcesBuildDirectory, 'keys.mjs');
   const vrenderFileBuildPath = path.join(resourcesBuildDirectory, 'vrender.mjs');
@@ -84,7 +88,9 @@ const createExampleTests = ({directory, args = {}}) => new Promise(resolve => {
   fse.copySync(supportFilePath, supportFileBuildPath, {overwrite: true});
 
   fse.copySync(ariaAtHarnessFilePath, ariaAtHarnessFileBuildPath, {overwrite: true});
+  fse.copySync(ariaAtTestIoFormatFilePath, ariaAtTestIoFormatFileBuildPath, {overwrite: true});
   fse.copySync(ariaAtTestRunFilePath, ariaAtTestRunFileBuildPath, {overwrite: true});
+  fse.copySync(ariaAtTestWindowFilePath, ariaAtTestWindowFileBuildPath, {overwrite: true});
   fse.copySync(atCommandsFilePath, atCommandsFileBuildPath, {overwrite: true});
   fse.copySync(keysFilePath, keysFileBuildPath, {overwrite: true});
   fse.copySync(vrenderFilePath, vrenderFileBuildPath, {overwrite: true});

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -274,9 +274,9 @@ function renderVirtualTestPage(doc) {
       ? div(
           section(
             id("errors"),
-            style({display: doc.errors.visible ? "block" : "none"}),
+            style({display: doc.errors && doc.errors.visible ? "block" : "none"}),
             h2("Test cannot be performed due to error(s)!"),
-            ul(...(doc.errors.errors ? doc.errors.errors.map(error => li(error)) : [])),
+            ul(...(doc.errors && doc.errors.errors ? doc.errors.errors.map(error => li(error)) : [])),
             hr()
           ),
           section(id("instructions"), renderVirtualInstructionDocument(doc.instructions)),

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -1,24 +1,7 @@
-import {commandsAPI} from "./at-commands.mjs";
 import {element, fragment, property, attribute, className, style, focus, render} from "./vrender.mjs";
-import {
-  AssertionResultMap,
-  CommonResultMap,
-  createEnumMap,
-  HasUnexpectedBehaviorMap,
-  TestRun,
-  UserActionMap,
-  userCloseWindow,
-  userOpenWindow,
-  WhitespaceStyleMap,
-} from "./aria-at-test-run.mjs";
-
-const UNEXPECTED_BEHAVIORS = [
-  "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
-  "Reading cursor position changed in an unexpected manner",
-  "Screen reader became extremely sluggish",
-  "Screen reader crashed",
-  "Browser crashed",
-];
+import {userCloseWindow, userOpenWindow, WhitespaceStyleMap} from "./aria-at-test-run.mjs";
+import {TestRunExport, TestRunInputOutput} from "./aria-at-test-io-format.mjs";
+import {TestWindow} from "./aria-at-test-window.mjs";
 
 const PAGE_STYLES = `
   table {
@@ -77,94 +60,31 @@ const PAGE_STYLES = `
   }
 `;
 
-/** @type {string[]} */
-const errors = [];
-let showResults = true;
-let showSubmitButton = true;
-
-/** @type {AT} */
-let at;
-/** @type {CommandsAPI} */
-let commapi;
-/** @type {Behavior} */
-let behavior;
-/** @type {TestRunState} */
-let firstState;
+let testRunIO = new TestRunInputOutput();
+testRunIO.setTitleInputFromTitle(document.title);
+testRunIO.setUnexpectedInputFromBuiltin();
+testRunIO.setScriptsInputFromMap(typeof scripts === "object" ? scripts : {});
 
 /**
- * @param {Support} newSupport
- * @param {Commands} newCommandsData
+ * @param {SupportJSON} newSupport
+ * @param {CommandsJSON} newCommandsData
  */
 export function initialize(newSupport, newCommandsData) {
-  commapi = new commandsAPI(newCommandsData, newSupport);
-
-  // Get the AT under test from the URL search params
-  // set the showResults flag from the URL search params
-  let params = new URL(document.location).searchParams;
-  at = newSupport.ats[0];
-  for (const [key, value] of params) {
-    if (key === "at") {
-      let requestedAT = value;
-      if (commapi.isKnownAT(requestedAT)) {
-        at = commapi.isKnownAT(requestedAT);
-      } else {
-        errors.push(
-          `Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`
-        );
-      }
-    }
-    if (key === "showResults") {
-      if (value === "true") {
-        showResults = true;
-      } else if (value === "false") {
-        showResults = false;
-      }
-    }
-    if (key === "showSubmitButton") {
-      if (value === "true") {
-        showSubmitButton = true;
-      } else if (value === "false") {
-        showSubmitButton = false;
-      }
-    }
-  }
+  testRunIO.setSupportInputFromJSON(newSupport);
+  testRunIO.setConfigInputFromQueryParamsAndSupport(Array.from(new URL(document.location).searchParams));
+  testRunIO.setKeysInputFromBuiltinAndConfig();
+  testRunIO.setCommandsInputFromJSONAndConfigKeys(newCommandsData);
 }
 
 /**
  * @param {BehaviorJSON} atBehavior
  */
 export function verifyATBehavior(atBehavior) {
-  // This is temporary until transition is complete from multiple modes to one mode
-  let mode = typeof atBehavior.mode === "string" ? atBehavior.mode : atBehavior.mode[0];
-
-  /** @type {Behavior} */
-  behavior = {
-    description: document.title,
-    task: atBehavior.task,
-    mode,
-    modeInstructions: commapi.getModeInstructions(mode, at),
-    appliesTo: atBehavior.applies_to,
-    specificUserInstruction: atBehavior.specific_user_instruction,
-    setupScriptDescription: atBehavior.setup_script_description,
-    setupTestPage: atBehavior.setupTestPage,
-    commands: commapi.getATCommands(mode, atBehavior.task, at),
-    outputAssertions: atBehavior.output_assertions ? atBehavior.output_assertions : [],
-    additionalAssertions: atBehavior.additional_assertions ? atBehavior.additional_assertions[at.key] || [] : [],
-    unexpectedBehaviors: [
-      ...UNEXPECTED_BEHAVIORS.map(content => ({content})),
-      {content: "Other", requireExplanation: true},
-    ],
-  };
-
-  if (!firstState && behavior.commands.length) {
-    firstState = initializeTestRunState({
-      errors: errors.length ? errors : null,
-      test: behavior,
-      config: {at, displaySubmitButton: showSubmitButton, renderResultsAfterSubmit: showResults},
-    });
-  } else {
+  if (testRunIO.behaviorInput !== null) {
     throw new Error("Test files should only contain one verifyATBehavior call.");
   }
+
+  testRunIO.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected(atBehavior);
 }
 
 export function displayTestPageAndInstructions(testPage) {
@@ -175,23 +95,19 @@ export function displayTestPageAndInstructions(testPage) {
     return;
   }
 
+  testRunIO.setPageUriInputFromPageUri(testPage);
+
   document.querySelector("html").setAttribute("lang", "en");
   var style = document.createElement("style");
   style.innerHTML = PAGE_STYLES;
   document.head.appendChild(style);
 
-  displayInstructionsForBehaviorTest(testPage, behavior);
+  displayInstructionsForBehaviorTest();
 }
 
-/**
- * @param {string} testPage
- * @param {Behavior} behavior
- */
-function displayInstructionsForBehaviorTest(testPage, behavior) {
+function displayInstructionsForBehaviorTest() {
   const windowManager = new TestWindow({
-    pageUri: testPage,
-    setupScriptName: behavior.setupTestPage,
-    scripts: typeof scripts === "object" ? scripts : {},
+    ...testRunIO.testWindowOptions(),
     hooks: {
       windowOpened() {
         app.dispatch(userOpenWindow());
@@ -206,7 +122,6 @@ function displayInstructionsForBehaviorTest(testPage, behavior) {
   windowManager.prepare();
 
   const app = new TestRunExport({
-    behavior,
     hooks: {
       openTestPage() {
         windowManager.open();
@@ -214,9 +129,10 @@ function displayInstructionsForBehaviorTest(testPage, behavior) {
       closeTestPage() {
         windowManager.close();
       },
-      postResults: () => postResults(app),
+      postResults: () => postResults(testRunIO.submitResultsJSON(app.state)),
     },
-    state: firstState,
+    state: testRunIO.testRunState(),
+    resultsJSON: state => testRunIO.submitResultsJSON(state),
   });
   app.observe(() => {
     render(document.body, renderVirtualTestPage(app.testPageAndResults()));
@@ -259,205 +175,23 @@ function validateMessage(message, type) {
 }
 
 /**
- * @param {TestRunExport} app
+ * @param {resultsJSON} resultsJSON
  */
-function postResults(app) {
+function postResults(resultsJSON) {
   // send message to parent if test is loaded in iFrame
   if (window.parent && window.parent.postMessage) {
     window.parent.postMessage(
       {
         type: "results",
-        data: app.resultsJSON(),
+        data: resultsJSON,
       },
       "*"
     );
   }
 }
 
-/** @typedef {ConstructorParameters<typeof TestRun>[0]} TestRunOptions */
-/**
- * @typedef TestRunExportOptions
- * @property {Behavior} behavior
- */
-
-class TestRunExport extends TestRun {
-  /**
-   * @param {TestRunOptions & TestRunExportOptions} options
-   */
-  constructor({behavior, ...parentOptions}) {
-    super(parentOptions);
-
-    this.behavior = behavior;
-  }
-
-  testPageAndResults() {
-    const testPage = this.testPage();
-    if ("results" in testPage) {
-      return {
-        ...testPage,
-        resultsJSON: this.resultsJSON(),
-      };
-    }
-    return {
-      ...testPage,
-      resultsJSON: this.state.currentUserAction === UserActionMap.CLOSE_TEST_WINDOW ? this.resultsJSON() : null,
-    };
-  }
-
-  resultsJSON() {
-    return toSubmitResultJSON(this.state, this.behavior);
-  }
-}
-
-class TestWindow {
-  /**
-   * @param {object} options
-   * @param {Window | null} [options.window]
-   * @param {string} options.pageUri
-   * @param {string} [options.setupScriptName]
-   * @param {TestWindowHooks} [options.hooks]
-   * @param {SetupScripts} [options.scripts]
-   */
-  constructor({window = null, pageUri, setupScriptName, hooks, scripts = {}}) {
-    /** @type {Window | null} */
-    this.window = window;
-
-    /** @type {string} */
-    this.pageUri = pageUri;
-
-    /** @type {string} */
-    this.setupScriptName = setupScriptName;
-
-    /** @type {TestWindowHooks} */
-    this.hooks = {
-      windowOpened: () => {},
-      windowClosed: () => {},
-      ...hooks,
-    };
-
-    /** @type {SetupScripts} */
-    this.scripts = scripts;
-  }
-
-  open() {
-    this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
-
-    this.hooks.windowOpened();
-
-    // If the window is closed, re-enable open popup button
-    this.window.onunload = () => {
-      window.setTimeout(() => {
-        if (this.window.closed) {
-          this.window = undefined;
-
-          this.hooks.windowClosed();
-        }
-      }, 100);
-    };
-
-    this.prepare();
-  }
-
-  prepare() {
-    if (!this.window) {
-      return;
-    }
-
-    let setupScriptName = this.setupScriptName;
-    if (!setupScriptName) {
-      return;
-    }
-    if (
-      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
-      this.window.document.readyState !== "complete"
-    ) {
-      window.setTimeout(() => {
-        this.prepare();
-      }, 100);
-      return;
-    }
-
-    this.scripts[setupScriptName](this.window.document);
-  }
-
-  close() {
-    if (this.window) {
-      this.window.close();
-    }
-  }
-}
-
 function bind(fn, ...args) {
   return (...moreArgs) => fn(...args, ...moreArgs);
-}
-
-/**
- * @param {object} options
- * @param {string[] | null} [options.errors]
- * @param {Behavior} options.test
- * @param {object} options.config
- * @param {AT} options.config.at
- * @param {boolean} [options.config.displaySubmitButton]
- * @param {boolean} [options.config.renderResultsAfterSubmit]
- * @returns {TestRunState}
- */
-function initializeTestRunState({
-  errors = null,
-  test,
-  config: {at, displaySubmitButton = true, renderResultsAfterSubmit = true},
-}) {
-  return {
-    errors,
-    info: {
-      description: test.description,
-      task: test.task,
-      mode: test.mode,
-      modeInstructions: test.modeInstructions,
-      userInstructions: test.specificUserInstruction.split("|"),
-      setupScriptDescription: test.setupScriptDescription,
-    },
-    config: {
-      at,
-      displaySubmitButton,
-      renderResultsAfterSubmit,
-    },
-    currentUserAction: UserActionMap.LOAD_PAGE,
-    openTest: {
-      enabled: true,
-    },
-    commands: test.commands.map(
-      command =>
-        /** @type {TestRunCommand} */ ({
-          description: command,
-          atOutput: {
-            highlightRequired: false,
-            value: "",
-          },
-          assertions: test.outputAssertions.map(assertion => ({
-            description: assertion[1],
-            highlightRequired: false,
-            priority: Number(assertion[0]),
-            result: CommonResultMap.NOT_SET,
-          })),
-          additionalAssertions: test.additionalAssertions.map(assertion => ({
-            description: assertion[1],
-            highlightRequired: false,
-            priority: Number(assertion[0]),
-            result: CommonResultMap.NOT_SET,
-          })),
-          unexpected: {
-            highlightRequired: false,
-            hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
-            tabbedBehavior: 0,
-            behaviors: test.unexpectedBehaviors.map(({content: description, requireExplanation}) => ({
-              description,
-              checked: false,
-              more: requireExplanation ? {highlightRequired: false, value: ""} : null,
-            })),
-          },
-        })
-    ),
-  };
 }
 
 const a = bind(element, "a");
@@ -790,350 +524,26 @@ function renderVirtualResultsTable(results) {
   }
 }
 
-/**
- * @typedef SubmitResultDetailsCommandsAssertionsPass
- * @property {string} assertion
- * @property {string} priority
- * @property {AssertionPassJSON} pass
- */
+/** @typedef {import('./aria-at-test-io-format.js').SupportJSON} SupportJSON */
+/** @typedef {import('./aria-at-test-io-format.js').CommandsJSON} CommandsJSON */
+/** @typedef {import('./aria-at-test-io-format.js').BehaviorJSON} BehaviorJSON */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
+
+/** @typedef {import('./aria-at-test-run.mjs').Description} Description */
+
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocument} InstructionDocument */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentInstructions} InstructionDocumentInstructions */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentInstructionsAssertions} InstructionDocumentInstructionsAssertions */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsHeader} InstructionDocumentResultsHeader */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsCommand} InstructionDocumentResultsCommand */
+/** @typedef {import('./aria-at-test-run.mjs').InstructionDocumentResultsCommandsUnexpected} InstructionDocumentResultsCommandsUnexpected */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentResultsCommandsAssertion} InstructionDocumentResultsCommandsAssertion */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentAssertionChoice} InstructionDocumentAssertionChoice */
+/** @typedef {import("./aria-at-test-run.mjs").InstructionDocumentInstructionsInstructions} InstructionDocumentInstructionsInstructions */
+
+/** @typedef {import('./aria-at-test-run.mjs').ResultsTableDocument} ResultsTableDocument */
 
 /**
- * Passing assertion values submitted from the tester result form.
- *
- * In the submitted json object the values contain spaces and are title cased.
- * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
+ * @typedef {import('./aria-at-test-io-format.js').TestPageAndResultsDocument} TestPageAndResultsDocument
  */
-
-const AssertionPassJSONMap = createEnumMap({
-  GOOD_OUTPUT: "Good Output",
-});
-
-/**
- * @typedef SubmitResultDetailsCommandsAssertionsFail
- * @property {string} assertion
- * @property {string} priority
- * @property {AssertionFailJSON} fail
- */
-
-/**
- * Failing assertion values from the tester result form as are submitted in the
- * JSON result object.
- *
- * In the submitted json object the values contain spaces and are title cased.
- * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
- */
-
-const AssertionFailJSONMap = createEnumMap({
-  NO_OUTPUT: "No Output",
-  INCORRECT_OUTPUT: "Incorrect Output",
-  NO_SUPPORT: "No Support",
-});
-
-/** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
-
-/**
- * Command result derived from priority 1 and 2 assertions.
- *
- * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
- * if priority 2 assertions fail.
- *
- * In the submitted json object values may contain spaces and are in ALL CAPS.
- *
- * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
- */
-
-const CommandSupportJSONMap = createEnumMap({
-  FULL: "FULL",
-  FAILING: "FAILING",
-  ALL_REQUIRED: "ALL REQUIRED",
-});
-
-/**
- * Highest level status submitted from test result.
- *
- * In the submitted json object values are in ALL CAPS.
- *
- * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
- */
-
-const StatusJSONMap = createEnumMap({
-  PASS: "PASS",
-  FAIL: "FAIL",
-});
-
-/**
- * @param {TestRunState} state
- * @param {Behavior} behavior
- * @returns {SubmitResultJSON}
- */
-function toSubmitResultJSON(state, behavior) {
-  /** @type {SubmitResultDetailsJSON} */
-  const details = {
-    name: state.info.description,
-    task: state.info.task,
-    specific_user_instruction: behavior.specificUserInstruction,
-    summary: {
-      1: {
-        pass: countAssertions(({priority, result}) => priority === 1 && result === CommonResultMap.PASS),
-        fail: countAssertions(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS),
-      },
-      2: {
-        pass: countAssertions(({priority, result}) => priority === 2 && result === CommonResultMap.PASS),
-        fail: countAssertions(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS),
-      },
-      unexpectedCount: countUnexpectedBehaviors(({checked}) => checked),
-    },
-    commands: state.commands.map(command => ({
-      command: command.description,
-      output: command.atOutput.value,
-      support: commandSupport(command),
-      assertions: [...command.assertions, ...command.additionalAssertions].map(assertionToAssertion),
-      unexpected_behaviors: command.unexpected.behaviors
-        .filter(({checked}) => checked)
-        .map(({description, more}) => (more ? more.value : description)),
-    })),
-  };
-  /** @type {SubmitResultStatusJSON} */
-  const status = state.commands.map(commandSupport).some(support => support === CommandSupportJSONMap.FAILING)
-    ? StatusJSONMap.FAIL
-    : StatusJSONMap.PASS;
-  return {
-    test: state.info.description,
-    details,
-    status,
-  };
-
-  function commandSupport(command) {
-    const allAssertions = [...command.assertions, ...command.additionalAssertions];
-    return allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
-      command.unexpected.behaviors.some(({checked}) => checked)
-      ? CommandSupportJSONMap.FAILING
-      : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
-      ? CommandSupportJSONMap.ALL_REQUIRED
-      : CommandSupportJSONMap.FULL;
-  }
-
-  /**
-   * @param {(assertion: TestRunAssertion | TestRunAdditionalAssertion) => boolean} filter
-   * @returns {number}
-   */
-  function countAssertions(filter) {
-    return state.commands.reduce(
-      (carry, command) => carry + [...command.assertions, ...command.additionalAssertions].filter(filter).length,
-      0
-    );
-  }
-
-  /**
-   * @param {(behavior: TestRunUnexpected) => boolean} filter
-   * @returns {number}
-   */
-  function countUnexpectedBehaviors(filter) {
-    return state.commands.reduce((carry, command) => carry + command.unexpected.behaviors.filter(filter).length, 0);
-  }
-
-  /**
-   * @param {TestRunAssertion | TestRunAdditionalAssertion} assertion
-   * @returns {SubmitResultAssertionsJSON}
-   */
-  function assertionToAssertion(assertion) {
-    return assertion.result === CommonResultMap.PASS
-      ? {
-          assertion: assertion.description,
-          priority: assertion.priority.toString(),
-          pass: AssertionPassJSONMap.GOOD_OUTPUT,
-        }
-      : {
-          assertion: assertion.description,
-          priority: assertion.priority.toString(),
-          fail:
-            assertion.result === AssertionResultMap.FAIL_MISSING
-              ? AssertionFailJSONMap.NO_OUTPUT
-              : assertion.result === AssertionResultMap.FAIL_INCORRECT
-              ? AssertionFailJSONMap.INCORRECT_OUTPUT
-              : AssertionFailJSONMap.NO_SUPPORT,
-        };
-  }
-}
-
-/**
- * @typedef AT
- * @property {string} name
- * @property {string} key
- */
-
-/**
- * @typedef Support
- * @property {AT[]} ats
- * @property {{system: string[]}} applies_to
- * @property {{directory: string, name: string}[]} examples
- */
-
-/**
- * @typedef {{[mode in ATMode]: {[atName: string]: string;};}} CommandsAPI_ModeInstructions
- */
-
-/**
- * @typedef {([string] | [string, string])[]} CommandAT
- */
-
-/**
- * @typedef {{[atMode: string]: CommandAT}} CommandMode
- */
-
-/**
- * @typedef Command
- * @property {CommandMode} [reading]
- * @property {CommandMode} [interaction]
- */
-
-/**
- * @typedef {{[commandDescription: string]: Command}} Commands
- */
-
-/**
- * @callback CommandsAPI_getATCommands
- * @param {ATMode} mode
- * @param {string} task
- * @param {AT} assistiveTech
- * @returns {string[]}
- */
-
-/** @typedef {"reading" | "interaction"} ATMode */
-
-/**
- * @callback CommandsAPI_getModeInstructions
- * @param {ATMode} mode
- * @param {AT} assistiveTech
- * @returns {string}
- */
-
-/**
- * @callback CommandsAPI_isKnownAT
- * @param {string} assistiveTech
- * @returns {AT}
- */
-
-/**
- * @typedef CommandsAPI
- * @property {Commands} AT_COMMAND_MAP
- * @property {CommandsAPI_ModeInstructions} MODE_INSTRUCTIONS
- * @property {Support} support
- * @property {CommandsAPI_getATCommands} getATCommands
- * @property {CommandsAPI_getModeInstructions} getModeInstructions
- * @property {CommandsAPI_isKnownAT} isKnownAT
- */
-
-/**
- * @typedef BehaviorJSON
- * @property {string} setup_script_description
- * @property {string} setupTestPage
- * @property {string[]} applies_to
- * @property {ATMode | ATMode[]} mode
- * @property {string} task
- * @property {string} specific_user_instruction
- * @property {[string, string][]} [output_assertions]
- * @property {{[atKey: string]: [number, string][]}} [additional_assertions]
- */
-
-/**
- * @typedef Behavior
- * @property {string} description
- * @property {string} task
- * @property {ATMode} mode
- * @property {string} modeInstructions
- * @property {string[]} appliesTo
- * @property {string} specificUserInstruction
- * @property {string} setupScriptDescription
- * @property {string} setupTestPage
- * @property {string[]} commands
- * @property {[string, string][]} outputAssertions
- * @property {[number, string][]} additionalAssertions
- * @property {object[]} unexpectedBehaviors
- * @property {string} unexpectedBehaviors[].content
- * @property {boolean} [unexpectedBehaviors[].requireExplanation]
- */
-
-/**
- * @typedef SubmitResultJSON
- * @property {string} test
- * @property {SubmitResultDetailsJSON} details
- * @property {SubmitResultStatusJSON} status
- */
-
-/**
- * @typedef SubmitResultSummaryPriorityJSON
- * @property {number} pass
- * @property {number} fail
- */
-
-/**
- * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
- */
-
-/**
- * @typedef SubmitResultSummaryPropsJSON
- * @property {number} unexpectedCount
- */
-
-/**
- * @typedef {SubmitResultSummaryPriorityMapJSON & SubmitResultSummaryPropsJSON} SubmitResultSummaryJSON
- */
-
-/**
- * @typedef SubmitResultDetailsJSON
- * @property {string} name
- * @property {string} specific_user_instruction
- * @property {string} task
- * @property {object[]} commands
- * @property {string} commands[].command
- * @property {string} commands[].output
- * @property {string[]} commands[].unexpected_behaviors
- * @property {CommandSupportJSON} commands[].support
- * @property {SubmitResultAssertionsJSON[]} commands[].assertions
- * @property {SubmitResultSummaryJSON} summary
- */
-
-/**
- * @typedef TestWindowHooks
- * @property {() => void} windowOpened
- * @property {() => void} windowClosed
- */
-
-/** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
-
-/**
- * @typedef ResultJSONDocument
- * @property {SubmitResultJSON | null} resultsJSON
- */
-
-/**
- * @typedef {TestPageDocument & ResultJSONDocument} TestPageAndResultsDocument
- */
-
-/**
- * @typedef {import('./aria-at-test-run.js').EnumValues<T>} EnumValues<T>
- * @template T
- */
-
-/** @typedef {import('./aria-at-test-run.js').TestRunState} TestRunState */
-/** @typedef {import('./aria-at-test-run.js').TestRunAssertion} TestRunAssertion */
-/** @typedef {import('./aria-at-test-run.js').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
-/** @typedef {import('./aria-at-test-run.js').TestRunCommand} TestRunCommand */
-/** @typedef {import("./aria-at-test-run.js").TestRunUnexpectedBehavior} TestRunUnexpected */
-
-/** @typedef {import('./aria-at-test-run.js').Description} Description */
-
-/** @typedef {import('./aria-at-test-run.js').TestPageDocument} TestPageDocument */
-
-/** @typedef {import('./aria-at-test-run.js').InstructionDocument} InstructionDocument */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructions} InstructionDocumentInstructions */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentInstructionsAssertions} InstructionDocumentInstructionsAssertions */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsHeader} InstructionDocumentResultsHeader */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommand} InstructionDocumentResultsCommand */
-/** @typedef {import('./aria-at-test-run.js').InstructionDocumentResultsCommandsUnexpected} InstructionDocumentResultsCommandsUnexpected */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentResultsCommandsAssertion} InstructionDocumentResultsCommandsAssertion */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentAssertionChoice} InstructionDocumentAssertionChoice */
-/** @typedef {import("./aria-at-test-run.js").InstructionDocumentInstructionsInstructions} InstructionDocumentInstructionsInstructions */
-
-/** @typedef {import('./aria-at-test-run.js').ResultsTableDocument} ResultsTableDocument */

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -274,9 +274,9 @@ function renderVirtualTestPage(doc) {
       ? div(
           section(
             id("errors"),
-            style({display: doc.errors ? "block" : "none"}),
+            style({display: doc.errors.visible ? "block" : "none"}),
             h2("Test cannot be performed due to error(s)!"),
-            ul(...(doc.errors ? doc.errors.map(error => li(error)) : [])),
+            ul(...(doc.errors.errors ? doc.errors.errors.map(error => li(error)) : [])),
             hr()
           ),
           section(id("instructions"), renderVirtualInstructionDocument(doc.instructions)),
@@ -524,9 +524,9 @@ function renderVirtualResultsTable(results) {
   }
 }
 
-/** @typedef {import('./aria-at-test-io-format.js').SupportJSON} SupportJSON */
-/** @typedef {import('./aria-at-test-io-format.js').CommandsJSON} CommandsJSON */
-/** @typedef {import('./aria-at-test-io-format.js').BehaviorJSON} BehaviorJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').SupportJSON} SupportJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').CommandsJSON} CommandsJSON */
+/** @typedef {import('./aria-at-test-io-format.mjs').BehaviorJSON} BehaviorJSON */
 
 /** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
 
@@ -545,5 +545,5 @@ function renderVirtualResultsTable(results) {
 /** @typedef {import('./aria-at-test-run.mjs').ResultsTableDocument} ResultsTableDocument */
 
 /**
- * @typedef {import('./aria-at-test-io-format.js').TestPageAndResultsDocument} TestPageAndResultsDocument
+ * @typedef {import('./aria-at-test-io-format.mjs').TestPageAndResultsDocument} TestPageAndResultsDocument
  */

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -23,7 +23,7 @@ class KeysInput {
    * @param {string} value.origin
    * @param {{[KEY_ID: string]: string}} value.keys
    * @param {ATJSON} value.at
-   * @param {{[atMode in ATMode]: {[atKey: string]: string}}} value.modeInstructions
+   * @param {{[atMode in ATMode]: string}} value.modeInstructions
    * @private
    */
   constructor(value) {
@@ -49,9 +49,8 @@ class KeysInput {
    * @param {ATMode} atMode
    */
   modeInstructions(atMode) {
-    const atKey = this._value.at.key;
-    if (this._value.modeInstructions[atMode] && this._value.modeInstructions[atMode][atKey]) {
-      return this._value.modeInstructions[atMode][atKey];
+    if (this._value.modeInstructions[atMode]) {
+      return this._value.modeInstructions[atMode];
     }
     return "";
   }
@@ -62,22 +61,28 @@ class KeysInput {
    */
   static fromBuiltinAndConfig({configInput}) {
     const keys = keysModule;
+    const atKey = configInput.at().key;
+
+    invariant(
+      ['jaws', 'nvda', 'voiceover_macos'].includes(atKey),
+      '%s is one of "jaws", "nvda", or "voiceover_macos"', atKey
+    );
 
     return new KeysInput({
       origin: "resources/keys.mjs",
       keys,
-      at: configInput.at(),
+      at: atKey,
       modeInstructions: {
         reading: {
           jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
           nvda: `Insure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
           voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
-        },
+        }[atKey],
         interaction: {
           jaws: `Verify the PC Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn off the Virtual Cursor by pressing ${keys.INS_Z}.`,
           nvda: `If NVDA did not make the focus mode sound when the test page loaded, press ${keys.INS_SPACE} to turn focus mode on.`,
           voiceover_macos: `Toggle Quick Nav OFF by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
-        },
+        }[atKey],
       },
     });
   }

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1,0 +1,1099 @@
+import {
+  HasUnexpectedBehaviorMap,
+  createEnumMap,
+  TestRun,
+  AssertionResultMap,
+  UserActionMap,
+  CommonResultMap,
+} from "./aria-at-test-run.mjs";
+import * as keysModule from "./keys.mjs";
+
+const UNEXPECTED_BEHAVIORS = [
+  "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
+  "Reading cursor position changed in an unexpected manner",
+  "Screen reader became extremely sluggish",
+  "Screen reader crashed",
+  "Browser crashed",
+];
+
+/** Depends on ConfigInput. */
+class KeysInput {
+  /**
+   * @param {object} value
+   * @param {string} value.origin
+   * @param {{[KEY_ID: string]: string}} value.keys
+   * @param {ATJSON} value.at
+   * @param {{[atMode in ATMode]: {[atKey: string]: string}}} value.modeInstructions
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  origin() {
+    return this._value.origin;
+  }
+
+  /**
+   * @param {string} keyId
+   * @returns {string}
+   */
+  keysForCommand(keyId) {
+    return this._value.keys[keyId];
+  }
+
+  /**
+   * @param {ATMode} atMode
+   */
+  modeInstructions(atMode) {
+    const atKey = this._value.at.key;
+    if (this._value.modeInstructions[atMode] && this._value.modeInstructions[atMode][atKey]) {
+      return this._value.modeInstructions[atMode][atKey];
+    }
+    return "";
+  }
+
+  /**
+   * @param {object} data
+   * @param {ConfigInput} data.configInput
+   */
+  static fromBuiltinAndConfig({configInput}) {
+    const keys = keysModule;
+
+    return new KeysInput({
+      origin: "resources/keys.mjs",
+      keys,
+      at: configInput.at(),
+      modeInstructions: {
+        reading: {
+          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          nvda: `Insure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
+          voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
+        },
+        interaction: {
+          jaws: `Verify the PC Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn off the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          nvda: `If NVDA did not make the focus mode sound when the test page loaded, press ${keys.INS_SPACE} to turn focus mode on.`,
+          voiceover_macos: `Toggle Quick Nav OFF by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
+        },
+      },
+    });
+  }
+}
+
+class SupportInput {
+  /**
+   * @param {SupportJSON} value
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  defaultAT() {
+    return this._value.ats[0];
+  }
+
+  /**
+   * @param {string} atKey
+   * @returns {ATJSON | undefined}
+   */
+  findAT(atKey) {
+    const lowercaseATKey = atKey.toLowerCase();
+    return this._value.ats.find(({key}) => key === lowercaseATKey);
+  }
+
+  /**
+   * @param {SupportJSON} json
+   */
+  static fromJSON(json) {
+    return new SupportInput(json);
+  }
+}
+
+/** Depends on ConfigInput and KeysInput. */
+class CommandsInput {
+  /**
+   * @param {object} value
+   * @param {CommandsJSON} value.commands
+   * @param {ATJSON} value.at
+   * @param {KeysInput} keysInput
+   * @private
+   */
+  constructor(value, keysInput) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+
+    /** @private */
+    this._keysInput = keysInput;
+  }
+
+  /**
+   * @param {string} task
+   * @param {ATMode} atMode
+   * @returns {string[]}
+   */
+  getCommands(task, atMode) {
+    const assistiveTech = this._value.at;
+
+    if (!this._value.commands[task]) {
+      throw new Error(`Task "${task}" does not exist, please add to at-commands or correct your spelling.`);
+    } else if (!this._value.commands[task][atMode]) {
+      throw new Error(
+        `Mode "${atMode}" instructions for task "${task}" does not exist, please add to at-commands or correct your spelling.`
+      );
+    }
+
+    let commandsData = this._value.commands[task][atMode][assistiveTech.key] || [];
+    let commands = [];
+
+    for (let c of commandsData) {
+      let innerCommands = [];
+      let commandSequence = c[0].split(",");
+      for (let command of commandSequence) {
+        command = this._keysInput.keysForCommand(command);
+        if (typeof command === "undefined") {
+          throw new Error(
+            `Key instruction identifier "${c}" for AT "${assistiveTech.name}", mode "${atMode}", task "${task}" is not an available identified. Update you commands.json file to the correct identifier or add your identifier to resources/keys.mjs.`
+          );
+        }
+
+        let furtherInstruction = c[1];
+        command = furtherInstruction ? `${command} ${furtherInstruction}` : command;
+        innerCommands.push(command);
+      }
+      commands.push(innerCommands.join(", then "));
+    }
+
+    return commands;
+  }
+
+  /**
+   * @param {CommandsJSON} json
+   * @param {object} data
+   * @param {ConfigInput} data.configInput
+   * @param {KeysInput} data.keysInput
+   */
+  static fromJSONAndConfigKeys(json, {configInput, keysInput}) {
+    return new CommandsInput({commands: json, at: configInput.at()}, keysInput);
+  }
+}
+
+/**
+ * Depends on SupportInput.
+ */
+class ConfigInput {
+  /**
+   * @param {string[]} errors
+   * @param {object} value
+   * @param {ATJSON} value.at
+   * @param {boolean} value.displaySubmitButton
+   * @param {boolean} value.renderResultsAfterSubmit
+   * @private
+   */
+  constructor(errors, value) {
+    this.errors = errors;
+
+    /** @private */
+    this._value = value;
+  }
+
+  at() {
+    return this._value.at;
+  }
+
+  displaySubmitButton() {
+    return this._value.displaySubmitButton;
+  }
+
+  renderResultsAfterSubmit() {
+    return this._value.renderResultsAfterSubmit;
+  }
+
+  /**
+   * @param {ConfigQueryParams} queryParams
+   * @param {object} data
+   * @param {SupportInput} data.supportInput
+   */
+  static fromQueryParamsAndSupport(queryParams, {supportInput}) {
+    const errors = [];
+
+    let at = supportInput.defaultAT();
+    let displaySubmitButton = true;
+    let renderResultsAfterSubmit = true;
+
+    for (const [key, value] of queryParams) {
+      if (key === "at") {
+        const requestedAT = value;
+        const knownAt = supportInput.findAT(requestedAT);
+        if (knownAt) {
+          at = knownAt;
+        } else {
+          errors.push(
+            `Harness does not have commands for the requested assistive technology ('${requestedAT}'), showing commands for assistive technology '${at.name}' instead. To test '${requestedAT}', please contribute command mappings to this project.`
+          );
+        }
+      } else if (key === "showResults") {
+        displaySubmitButton = decodeBooleanParam(value, displaySubmitButton);
+      } else if (key === "showSubmitButton") {
+        renderResultsAfterSubmit = decodeBooleanParam(value, renderResultsAfterSubmit);
+      }
+    }
+
+    return new ConfigInput(errors, {
+      at,
+      displaySubmitButton,
+      renderResultsAfterSubmit,
+    });
+
+    /**
+     * @param {string} param
+     * @param {boolean} defaultValue
+     * @returns {boolean}
+     */
+    function decodeBooleanParam(param, defaultValue) {
+      if (param === "true") {
+        return true;
+      } else if (param === "false") {
+        return false;
+      }
+      return defaultValue;
+    }
+  }
+}
+
+class ScriptsInput {
+  /**
+   * @param {object} value
+   * @param {SetupScripts} value.scripts
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  scripts() {
+    return this._value.scripts;
+  }
+
+  /**
+   * @param {SetupScripts} scripts
+   */
+  static fromScriptsMap(scripts) {
+    return new ScriptsInput({scripts});
+  }
+}
+
+class UnexpectedInput {
+  /**
+   * @param {object} value
+   * @param {BehaviorUnexpectedItem[]} value.behaviors
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    this._value = value;
+  }
+
+  behaviors() {
+    return this._value.behaviors;
+  }
+
+  static fromBuiltin() {
+    return new UnexpectedInput({
+      behaviors: [
+        ...UNEXPECTED_BEHAVIORS.map(description => ({description, requireExplanation: false})),
+        {description: "Other", requireExplanation: true},
+      ],
+    });
+  }
+}
+
+class TitleInput {
+  /**
+   * @param {object} value
+   * @param {string} value.title
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  title() {
+    return this._value.title;
+  }
+
+  /** @param {string} title */
+  static fromTitle(title) {
+    return new TitleInput({
+      title,
+    });
+  }
+}
+
+/** Depends on CommandsInput, ConfigInput, KeysInput, TitleInput, and UnexpectedInput. */
+class BehaviorInput {
+  /**
+   * @param {object} value
+   * @param {Behavior} value.behavior
+   * @private
+   */
+  constructor(value) {
+    this.errors = [];
+
+    /** @private */
+    this._value = value;
+  }
+
+  behavior() {
+    return this._value.behavior;
+  }
+
+  /**
+   * @param {BehaviorJSON} json
+   * @param {object} data
+   * @param {KeysInput} data.keysInput
+   * @param {CommandsInput} data.commandsInput
+   * @param {ConfigInput} data.configInput
+   * @param {UnexpectedInput} data.unexpectedInput
+   * @param {TitleInput} data.titleInput
+   */
+  static fromJSONCommandsConfigKeysTitleUnexpected(
+    json,
+    {commandsInput, configInput, keysInput, titleInput, unexpectedInput}
+  ) {
+    const mode = Array.isArray(json.mode) ? json.mode[0] : json.mode;
+    const at = configInput.at();
+
+    return new BehaviorInput({
+      behavior: {
+        description: titleInput.title(),
+        task: json.task,
+        mode,
+        modeInstructions: keysInput.modeInstructions(mode),
+        appliesTo: json.applies_to,
+        specificUserInstruction: json.specific_user_instruction,
+        setupScriptDescription: json.setup_script_description,
+        setupTestPage: json.setupTestPage,
+        commands: commandsInput.getCommands(json.task, mode),
+        assertions: (json.output_assertions ? json.output_assertions : []).map(assertionTuple => ({
+          priority: Number(assertionTuple[0]),
+          assertion: assertionTuple[1],
+        })),
+        additionalAssertions: (json.additional_assertions ? json.additional_assertions[at.key] || [] : []).map(
+          assertionTuple => ({
+            priority: Number(assertionTuple[0]),
+            assertion: assertionTuple[1],
+          })
+        ),
+        unexpectedBehaviors: unexpectedInput.behaviors(),
+      },
+    });
+  }
+}
+
+class PageUriInput {
+  /**
+   * @param {object} value
+   * @param {string} value.pageUri
+   * @private
+   */
+  constructor(value) {
+    this._errors = [];
+    this._value = value;
+  }
+
+  pageUri() {
+    return this._value.pageUri;
+  }
+
+  /**
+   * @param {string} pageUri
+   */
+  static fromPageUri(pageUri) {
+    return new PageUriInput({pageUri});
+  }
+}
+
+export class TestRunInputOutput {
+  constructor() {
+    /** @type {BehaviorInput} */
+    this.behaviorInput = null;
+    /** @type {CommandsInput} */
+    this.commandsInput = null;
+    /** @type {ConfigInput} */
+    this.configInput = null;
+    /** @type {KeysInput} */
+    this.keysInput = null;
+    /** @type {PageUriInput} */
+    this.pageUriInput = null;
+    /** @type {ScriptsInput} */
+    this.scriptsInput = null;
+    /** @type {SupportInput} */
+    this.supportInput = null;
+    /** @type {TitleInput} */
+    this.titleInput = null;
+    /** @type {UnexpectedInput} */
+    this.unexpectedInput = null;
+  }
+
+  /** @param {BehaviorInput} behaviorInput */
+  setBehaviorInput(behaviorInput) {
+    this.behaviorInput = behaviorInput;
+  }
+
+  /** @param {BehaviorJSON} behaviorJSON */
+  setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected(behaviorJSON) {
+    invariant(
+      this.commandsInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setCommandsInput.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.keysInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setKeysInput.name,
+      this.setKeysInputFromBuiltinAndConfig.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.titleInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setTitleInput.name,
+      this.setTitleInputFromTitle.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+    invariant(
+      this.unexpectedInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setUnexpectedInput.name,
+      this.setUnexpectedInputFromBuiltin.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name
+    );
+
+    this.setBehaviorInput(
+      BehaviorInput.fromJSONCommandsConfigKeysTitleUnexpected(behaviorJSON, {
+        commandsInput: this.commandsInput,
+        configInput: this.configInput,
+        keysInput: this.keysInput,
+        titleInput: this.titleInput,
+        unexpectedInput: this.unexpectedInput,
+      })
+    );
+  }
+
+  /** @param {CommandsInput} commandsInput */
+  setCommandsInput(commandsInput) {
+    this.commandsInput = commandsInput;
+  }
+
+  /** @param {CommandsJSON} commandsJSON */
+  setCommandsInputFromJSONAndConfigKeys(commandsJSON) {
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+    invariant(
+      this.keysInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setKeysInput.name,
+      this.setKeysInputFromBuiltinAndConfig.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+
+    this.setCommandsInput(
+      CommandsInput.fromJSONAndConfigKeys(commandsJSON, {
+        configInput: this.configInput,
+        keysInput: this.keysInput,
+      })
+    );
+  }
+
+  /** @param {ConfigInput} configInput */
+  setConfigInput(configInput) {
+    this.configInput = configInput;
+  }
+
+  /** @param {ConfigQueryParams} queryParams */
+  setConfigInputFromQueryParamsAndSupport(queryParams) {
+    invariant(
+      this.supportInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setSupportInput.name,
+      this.setSupportInputFromJSON.name,
+      this.setConfigInputFromQueryParamsAndSupport.name
+    );
+
+    this.setConfigInput(
+      ConfigInput.fromQueryParamsAndSupport(queryParams, {
+        supportInput: this.supportInput,
+      })
+    );
+  }
+
+  /** @param {KeysInput} keysInput */
+  setKeysInput(keysInput) {
+    this.keysInput = keysInput;
+  }
+
+  setKeysInputFromBuiltinAndConfig() {
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.setCommandsInputFromJSONAndConfigKeys.name
+    );
+
+    this.setKeysInput(KeysInput.fromBuiltinAndConfig({configInput: this.configInput}));
+  }
+
+  /** @param {PageUriInput} pageUriInput */
+  setPageUriInput(pageUriInput) {
+    this.pageUriInput = pageUriInput;
+  }
+
+  /** @param {string} pageUri */
+  setPageUriInputFromPageUri(pageUri) {
+    this.setPageUriInput(PageUriInput.fromPageUri(pageUri));
+  }
+
+  /** @param {ScriptsInput} scriptsInput */
+  setScriptsInput(scriptsInput) {
+    this.scriptsInput = scriptsInput;
+  }
+
+  /** @param {SetupScripts} scriptsMap */
+  setScriptsInputFromMap(scriptsMap) {
+    this.setScriptsInput(ScriptsInput.fromScriptsMap(scriptsMap));
+  }
+
+  /** @param {SupportInput} supportInput */
+  setSupportInput(supportInput) {
+    this.supportInput = supportInput;
+  }
+
+  /** @param {SupportJSON} supportJSON */
+  setSupportInputFromJSON(supportJSON) {
+    this.setSupportInput(SupportInput.fromJSON(supportJSON));
+  }
+
+  /** @param {TitleInput} titleInput */
+  setTitleInput(titleInput) {
+    this.titleInput = titleInput;
+  }
+
+  /** @param {string} title */
+  setTitleInputFromTitle(title) {
+    this.setTitleInput(TitleInput.fromTitle(title));
+  }
+
+  /** @param {UnexpectedInput} unexpectedInput */
+  setUnexpectedInput(unexpectedInput) {
+    this.unexpectedInput = unexpectedInput;
+  }
+
+  setUnexpectedInputFromBuiltin() {
+    this.setUnexpectedInput(UnexpectedInput.fromBuiltin());
+  }
+
+  /** @returns {import("./aria-at-test-run.mjs").TestRunState} */
+  testRunState() {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.testRunState.name
+    );
+    invariant(
+      this.configInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setConfigInput.name,
+      this.setConfigInputFromQueryParamsAndSupport.name,
+      this.testRunState.name
+    );
+
+    const errors = [...this.behaviorInput.errors, ...this.commandsInput.errors, ...this.configInput.errors];
+    const test = this.behaviorInput.behavior();
+    const config = this.configInput;
+
+    return {
+      errors,
+      info: {
+        description: test.description,
+        task: test.task,
+        mode: test.mode,
+        modeInstructions: test.modeInstructions,
+        userInstructions: test.specificUserInstruction.split("|"),
+        setupScriptDescription: test.setupScriptDescription,
+      },
+      config: {
+        at: config.at(),
+        displaySubmitButton: config.displaySubmitButton(),
+        renderResultsAfterSubmit: config.renderResultsAfterSubmit(),
+      },
+      currentUserAction: UserActionMap.LOAD_PAGE,
+      openTest: {
+        enabled: true,
+      },
+      commands: test.commands.map(
+        command =>
+          /** @type {import("./aria-at-test-run.mjs").TestRunCommand} */ ({
+            description: command,
+            atOutput: {
+              highlightRequired: false,
+              value: "",
+            },
+            assertions: test.assertions.map(assertion => ({
+              description: assertion.assertion,
+              highlightRequired: false,
+              priority: assertion.priority,
+              result: CommonResultMap.NOT_SET,
+            })),
+            additionalAssertions: test.additionalAssertions.map(assertion => ({
+              description: assertion.assertion,
+              highlightRequired: false,
+              priority: assertion.priority,
+              result: CommonResultMap.NOT_SET,
+            })),
+            unexpected: {
+              highlightRequired: false,
+              hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
+              tabbedBehavior: 0,
+              behaviors: test.unexpectedBehaviors.map(({description, requireExplanation}) => ({
+                description,
+                checked: false,
+                more: requireExplanation ? {highlightRequired: false, value: ""} : null,
+              })),
+            },
+          })
+      ),
+    };
+  }
+
+  testWindowOptions() {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.testWindowOptions.name
+    );
+    invariant(
+      this.pageUriInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setPageUriInput.name,
+      this.setPageUriInputFromPageUri.name,
+      this.testWindowOptions.name
+    );
+    invariant(
+      this.scriptsInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setScriptsInput.name,
+      this.setScriptsInputFromMap.name,
+      this.testWindowOptions.name
+    );
+
+    return {
+      pageUri: this.pageUriInput.pageUri(),
+      setupScriptName: this.behaviorInput.behavior().setupTestPage,
+      scripts: this.scriptsInput.scripts(),
+    };
+  }
+
+  /**
+   * @param {import("./aria-at-test-run.mjs").TestRunState} state
+   * @returns {import("./aria-at-harness.mjs").SubmitResultJSON}
+   */
+  submitResultsJSON(state) {
+    invariant(
+      this.behaviorInput !== null,
+      "Call %s or %s before calling %s.",
+      this.setBehaviorInput.name,
+      this.setBehaviorInputFromJSONAndCommandsConfigKeysTitleUnexpected.name,
+      this.submitResultsJSON.name
+    );
+
+    const behavior = this.behaviorInput.behavior();
+
+    /** @type {SubmitResultDetailsJSON} */
+    const details = {
+      name: state.info.description,
+      task: state.info.task,
+      specific_user_instruction: behavior.specificUserInstruction,
+      summary: {
+        1: {
+          pass: countAssertions(({priority, result}) => priority === 1 && result === CommonResultMap.PASS),
+          fail: countAssertions(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS),
+        },
+        2: {
+          pass: countAssertions(({priority, result}) => priority === 2 && result === CommonResultMap.PASS),
+          fail: countAssertions(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS),
+        },
+        unexpectedCount: countUnexpectedBehaviors(({checked}) => checked),
+      },
+      commands: state.commands.map(command => ({
+        command: command.description,
+        output: command.atOutput.value,
+        support: commandSupport(command),
+        assertions: [...command.assertions, ...command.additionalAssertions].map(assertionToAssertion),
+        unexpected_behaviors: command.unexpected.behaviors
+          .filter(({checked}) => checked)
+          .map(({description, more}) => (more ? more.value : description)),
+      })),
+    };
+
+    /** @type {SubmitResultStatusJSON} */
+    const status = state.commands.map(commandSupport).some(support => support === CommandSupportJSONMap.FAILING)
+      ? StatusJSONMap.FAIL
+      : StatusJSONMap.PASS;
+
+    return {
+      test: state.info.description,
+      details,
+      status,
+    };
+
+    function commandSupport(command) {
+      const allAssertions = [...command.assertions, ...command.additionalAssertions];
+      return allAssertions.some(({priority, result}) => priority === 1 && result !== CommonResultMap.PASS) ||
+        command.unexpected.behaviors.some(({checked}) => checked)
+        ? CommandSupportJSONMap.FAILING
+        : allAssertions.some(({priority, result}) => priority === 2 && result !== CommonResultMap.PASS)
+        ? CommandSupportJSONMap.ALL_REQUIRED
+        : CommandSupportJSONMap.FULL;
+    }
+
+    /**
+     * @param {(assertion: TestRunAssertion | TestRunAdditionalAssertion) => boolean} filter
+     * @returns {number}
+     */
+    function countAssertions(filter) {
+      return state.commands.reduce(
+        (carry, command) => carry + [...command.assertions, ...command.additionalAssertions].filter(filter).length,
+        0
+      );
+    }
+
+    /**
+     * @param {(behavior: TestRunUnexpected) => boolean} filter
+     * @returns {number}
+     */
+    function countUnexpectedBehaviors(filter) {
+      return state.commands.reduce((carry, command) => carry + command.unexpected.behaviors.filter(filter).length, 0);
+    }
+
+    /**
+     * @param {TestRunAssertion | TestRunAdditionalAssertion} assertion
+     * @returns {SubmitResultAssertionsJSON}
+     */
+    function assertionToAssertion(assertion) {
+      return assertion.result === CommonResultMap.PASS
+        ? {
+            assertion: assertion.description,
+            priority: assertion.priority.toString(),
+            pass: AssertionPassJSONMap.GOOD_OUTPUT,
+          }
+        : {
+            assertion: assertion.description,
+            priority: assertion.priority.toString(),
+            fail:
+              assertion.result === AssertionResultMap.FAIL_MISSING
+                ? AssertionFailJSONMap.NO_OUTPUT
+                : assertion.result === AssertionResultMap.FAIL_INCORRECT
+                ? AssertionFailJSONMap.INCORRECT_OUTPUT
+                : AssertionFailJSONMap.NO_SUPPORT,
+          };
+    }
+  }
+}
+
+/**
+ * Extended TestRun that can access methods to turn the TestRun["state"] into
+ * the desired output format.
+ */
+export class TestRunExport extends TestRun {
+  /**
+   * @param {TestRunOptions & TestRunExportOptions} options
+   */
+  constructor({resultsJSON, ...parentOptions}) {
+    super(parentOptions);
+
+    this.resultsJSON = resultsJSON;
+  }
+
+  testPageAndResults() {
+    const testPage = this.testPage();
+    if ("results" in testPage) {
+      return {
+        ...testPage,
+        resultsJSON: this.resultsJSON(this.state),
+      };
+    }
+    return {
+      ...testPage,
+      resultsJSON: this.state.currentUserAction === UserActionMap.CLOSE_TEST_WINDOW ? this.resultsJSON(this.state) : null,
+    };
+  }
+}
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsPass
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionPassJSON} pass
+ */
+
+/**
+ * Passing assertion values submitted from the tester result form.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionPassJSONMap>} AssertionPassJSON
+ */
+
+const AssertionPassJSONMap = createEnumMap({
+  GOOD_OUTPUT: "Good Output",
+});
+
+/**
+ * @typedef SubmitResultDetailsCommandsAssertionsFail
+ * @property {string} assertion
+ * @property {string} priority
+ * @property {AssertionFailJSON} fail
+ */
+
+/**
+ * Failing assertion values from the tester result form as are submitted in the
+ * JSON result object.
+ *
+ * In the submitted json object the values contain spaces and are title cased.
+ * @typedef {EnumValues<typeof AssertionFailJSONMap>} AssertionFailJSON
+ */
+
+const AssertionFailJSONMap = createEnumMap({
+  NO_OUTPUT: "No Output",
+  INCORRECT_OUTPUT: "Incorrect Output",
+  NO_SUPPORT: "No Support",
+});
+
+/** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
+
+/**
+ * Command result derived from priority 1 and 2 assertions.
+ *
+ * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
+ * if priority 2 assertions fail.
+ *
+ * In the submitted json object values may contain spaces and are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof CommandSupportJSONMap>} CommandSupportJSON
+ */
+
+const CommandSupportJSONMap = createEnumMap({
+  FULL: "FULL",
+  FAILING: "FAILING",
+  ALL_REQUIRED: "ALL REQUIRED",
+});
+
+/**
+ * Highest level status submitted from test result.
+ *
+ * In the submitted json object values are in ALL CAPS.
+ *
+ * @typedef {EnumValues<typeof StatusJSONMap>} SubmitResultStatusJSON
+ */
+
+const StatusJSONMap = createEnumMap({
+  PASS: "PASS",
+  FAIL: "FAIL",
+});
+
+/**
+ * @param {boolean} test
+ * @param {string} message
+ * @param {any[]} args
+ * @returns {asserts test}
+ */
+function invariant(test, message, ...args) {
+  if (!test) {
+    let index = 0;
+    throw new Error(message.replace(/%%|%\w/g, match => (match[0] !== "%%" ? args[index++] : "%")));
+  }
+}
+
+/** @typedef {ConstructorParameters<typeof TestRun>[0]} TestRunOptions */
+/**
+ * @typedef TestRunExportOptions
+ * @property {(state: TestRunState) => SubmitResultJSON} resultsJSON
+ */
+
+/**
+ * @typedef ATJSON
+ * @property {string} name
+ * @property {string} key
+ */
+
+/**
+ * @typedef SupportJSON
+ * @property {ATJSON[]} ats
+ * @property {object} applies_to
+ * @property {string[]} applies_to.system
+ * @property {object[]} examples
+ * @property {string} examples[].directory
+ * @property {string} examples[].name
+ */
+
+/**
+ * @typedef {([string] | [string, string])[]} CommandATJSON
+ */
+
+/**
+ * @typedef {{[atMode: string]: CommandATJSON}} CommandModeJSON
+ */
+
+/**
+ * @typedef CommandJSON
+ * @property {CommandModeJSON} [reading]
+ * @property {CommandModeJSON} [interaction]
+ */
+
+/**
+ * @typedef {{[commandDescription: string]: CommandJSON}} CommandsJSON
+ */
+
+/**
+ * @typedef {["at" | "showSubmitButton" | "showResults" | string, string][]} ConfigQueryParams
+ */
+
+/** @typedef {"reading" | "interaction"} ATMode */
+
+/**
+ * @typedef BehaviorJSON
+ * @property {string} setup_script_description
+ * @property {string} setupTestPage
+ * @property {string[]} applies_to
+ * @property {ATMode | ATMode[]} mode
+ * @property {string} task
+ * @property {string} specific_user_instruction
+ * @property {[string, string][]} [output_assertions]
+ * @property {{[atKey: string]: [number, string][]}} [additional_assertions]
+ */
+
+/**
+ * @typedef BehaviorAssertion
+ * @property {number} priority
+ * @property {string} assertion
+ */
+
+/**
+ * @typedef BehaviorUnexpectedItem
+ * @property {string} description
+ * @property {boolean} requireExplanation
+ */
+
+/**
+ * @typedef Behavior
+ * @property {string} description
+ * @property {string} task
+ * @property {ATMode} mode
+ * @property {string} modeInstructions
+ * @property {string[]} appliesTo
+ * @property {string} specificUserInstruction
+ * @property {string} setupScriptDescription
+ * @property {string} setupTestPage
+ * @property {string[]} commands
+ * @property {BehaviorAssertion[]} assertions
+ * @property {BehaviorAssertion[]} additionalAssertions
+ * @property {BehaviorUnexpectedItem[]} unexpectedBehaviors
+ */
+
+/** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
+
+/**
+ * @typedef SubmitResultJSON
+ * @property {string} test
+ * @property {SubmitResultDetailsJSON} details
+ * @property {SubmitResultStatusJSON} status
+ */
+
+/**
+ * @typedef SubmitResultSummaryPriorityJSON
+ * @property {number} pass
+ * @property {number} fail
+ */
+
+/**
+ * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
+ */
+
+/**
+ * @typedef SubmitResultSummaryPropsJSON
+ * @property {number} unexpectedCount
+ */
+
+/**
+ * @typedef {SubmitResultSummaryPriorityMapJSON & SubmitResultSummaryPropsJSON} SubmitResultSummaryJSON
+ */
+
+/**
+ * @typedef SubmitResultDetailsJSON
+ * @property {string} name
+ * @property {string} specific_user_instruction
+ * @property {string} task
+ * @property {object[]} commands
+ * @property {string} commands[].command
+ * @property {string} commands[].output
+ * @property {string[]} commands[].unexpected_behaviors
+ * @property {CommandSupportJSON} commands[].support
+ * @property {SubmitResultAssertionsJSON[]} commands[].assertions
+ * @property {SubmitResultSummaryJSON} summary
+ */
+
+/**
+ * @typedef ResultJSONDocument
+ * @property {SubmitResultJSON | null} resultsJSON
+ */
+
+/**
+ * @typedef {TestPageDocument & ResultJSONDocument} TestPageAndResultsDocument
+ */
+
+/**
+ * @typedef {import('./aria-at-test-run.mjs').EnumValues<T>} EnumValues<T>
+ * @template T
+ */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestRunState} TestRunState */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunAssertion} TestRunAssertion */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
+/** @typedef {import('./aria-at-test-run.mjs').TestRunCommand} TestRunCommand */
+/** @typedef {import("./aria-at-test-run.mjs").TestRunUnexpectedBehavior} TestRunUnexpected */
+
+/** @typedef {import('./aria-at-test-run.mjs').TestPageDocument} TestPageDocument */

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -119,7 +119,7 @@ export function instructionDocument(resultState, hooks) {
   return {
     errors: {
       visible: false,
-      header: "",
+      header: "Test cannot be performed due to error(s)!",
       errors: [],
     },
     instructions: {
@@ -218,9 +218,9 @@ export function instructionDocument(resultState, hooks) {
         change: atOutput => hooks.setCommandOutput({commandIndex, atOutput}),
       },
       assertionsHeader: {
-        descriptionHeader: "",
-        passHeader: "",
-        failHeader: "",
+        descriptionHeader: "Assertion",
+        passHeader: "Success case",
+        failHeader: "Failure cases",
       },
       assertions: [
         ...assertions.map(bind(assertionResult, commandIndex)),
@@ -363,7 +363,7 @@ export function instructionDocument(resultState, hooks) {
             },
           ],
           click: () =>
-            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_MISSING}),
+            hooks.setCommandAssertion({commandIndex, assertionIndex, result: AssertionResultMap.FAIL_INCORRECT}),
         }),
       ],
     });

--- a/tests/resources/aria-at-test-window.mjs
+++ b/tests/resources/aria-at-test-window.mjs
@@ -1,0 +1,85 @@
+export class TestWindow {
+  /**
+   * @param {object} options
+   * @param {Window | null} [options.window]
+   * @param {string} options.pageUri
+   * @param {string} [options.setupScriptName]
+   * @param {TestWindowHooks} [options.hooks]
+   * @param {SetupScripts} [options.scripts]
+   */
+  constructor({window = null, pageUri, setupScriptName, hooks, scripts = {}}) {
+    /** @type {Window | null} */
+    this.window = window;
+
+    /** @type {string} */
+    this.pageUri = pageUri;
+
+    /** @type {string} */
+    this.setupScriptName = setupScriptName;
+
+    /** @type {TestWindowHooks} */
+    this.hooks = {
+      windowOpened: () => {},
+      windowClosed: () => {},
+      ...hooks,
+    };
+
+    /** @type {SetupScripts} */
+    this.scripts = scripts;
+  }
+
+  open() {
+    this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
+
+    this.hooks.windowOpened();
+
+    // If the window is closed, re-enable open popup button
+    this.window.onunload = () => {
+      window.setTimeout(() => {
+        if (this.window.closed) {
+          this.window = undefined;
+
+          this.hooks.windowClosed();
+        }
+      }, 100);
+    };
+
+    this.prepare();
+  }
+
+  prepare() {
+    if (!this.window) {
+      return;
+    }
+
+    let setupScriptName = this.setupScriptName;
+    if (!setupScriptName) {
+      return;
+    }
+    if (
+      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
+      this.window.document.readyState !== "complete"
+    ) {
+      window.setTimeout(() => {
+        this.prepare();
+      }, 100);
+      return;
+    }
+
+    this.scripts[setupScriptName](this.window.document);
+  }
+
+  close() {
+    if (this.window) {
+      this.window.close();
+    }
+  }
+}
+
+/**
+ * @typedef TestWindowHooks
+ * @property {() => void} windowOpened
+ * @property {() => void} windowClosed
+ */
+
+/** @typedef {import('./aria-at-test-formatter').SetupScripts} SetupScripts */

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -1,6 +1,11 @@
+/** @deprecated See aria-at-test-io.mjs */
+
 import * as keys from './keys.mjs';
 
-/** Class for getting AT-specific instructions for a test against a design pattern. */
+/**
+ * Class for getting AT-specific instructions for a test against a design pattern.
+ * @deprecated See aria-at-test-io.mjs:CommandsInput
+ */
 export class commandsAPI {
   /**
    * Creates an API to get AT-specific instructions for a design pattern.

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -1,10 +1,10 @@
-/** @deprecated See aria-at-test-io.mjs */
+/** @deprecated See aria-at-test-io-format.mjs */
 
 import * as keys from './keys.mjs';
 
 /**
  * Class for getting AT-specific instructions for a test against a design pattern.
- * @deprecated See aria-at-test-io.mjs:CommandsInput
+ * @deprecated See aria-at-test-io-format.mjs:CommandsInput
  */
 export class commandsAPI {
   /**


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/mzgoddard-harness-io-formatting/build/index.html)

- Add `TestRunInputOutput` class to gather various test information in a test html file.
- Move classes out of `aria-at-harness` so they can be used by dependents of `aria-at`.

## TestRunInputOutput Summary

The main change in this PR adds the `TestRunInputOutput` class. It takes `Input` helpers instances to produce the state for a `TestRun` instance and options for a `TestWindow` instance. Each `Input` type has a public interface representing some current information processed currently at runtime.

This PR includes static methods on those inputs that process currently available information in the test html files for that public interface. This design is intended to provide a means to iterate the input data format for a test. The current data has a diverse set of format and is collected in many distinct methods, making it difficult to use and understand.

After this PR we will add new implementations of the `Input` types and process improved data formats while maintaining backwards compatibility with the existing formats.

## New Files

- `aria-at-test-io-format.mjs`
  - `class KeysInput`
  - `class SupportInput`
  - `class CommandsInput`
  - `class ConfigInput`
  - `class ScriptsInput`
  - `class UnexpectedInput`
  - `class TitleInput`
  - `class BehaviorInput`
  - `class PageUriInput`
  - `class TestRunInputOutput`
  - `class TextRunExport`
- `aria-at-test-window.mjs`
  - `class TestWindow`

## Inputs

`TestRunInputOutput` currently consumes 9 `Input` types which can be broken into two groups: standalone and dependent. Standalone inputs can be processed on their own. Dependent inputs require one or more other inputs to be able to process their information.

- **`TitleInput`**, a **standalone** input. The title is the title of the test and originally appears in `tests.csv`. In this PR it is sourced from a test html file's title element.
- **`PageUriInput`**, a **standalone** input. The page uri is the reference page loaded in the test window and originally appears in `references.csv`. In this PR it is provided as an argument to one of the `aria-at-harness` functions.
- **`UnexpectedInput`**, a **standalone** input. The set of unexpected behaviors listed in the instruction document. In this PR it is builtin `aria-at-test-io-format`.
- **`ScriptsInput`**, a **standalone** input. The set of executable scripts currently used to setup the reference page after it is loaded in a test window. In this PR it is fetched with the global scope member `scripts` if it exists.
- **`SupportInput`**, a **standalone** input. The support information provided by `tests/support.json`.
- **`ConfigInput `**, a **dependent** input. The configuration sets things like which at a test is being performed with for tests that are defined for multiple ATs. In this PR the config comes from the page's url query parameters and depends on `SupportInput`.
- **`KeysInput`**, a **dependent** input. The keys are a map of key ids to keystrokes a user will perform and some other key related data. In this PR this keys comes from the keys module and depends on `ConfigInput`. Importantly keys does not depend on `SupportInput`. The keys implementation in this PR could be provided a `ConfigInput` that does not need `SupportInput` to be instantiated.
- **`CommandsInput`**, a **dependent** input. `CommandsInput` represents the information currently found in `commands.json`. In this PR it depends on `ConfigInput` and `KeysInput` to process the information provided by `commands.json`.
- **`BehaviorInput`**, a **dependent** input. `BehaviorInput` represents the information currently found in a `test.json` file. In this PR it depends on `CommandsInput`, `ConfigInput`, `KeysInput`, `TitleInput`, and `UnexpectedInput` to process the information in a `test.json` object.

## Processed Outputs

When `TestRunInputOutput` has the right inputs provided it has some methods that can be called to provide data in a format need to render test instructions, record test results, open a test window, and create the test result submission object.

- `testWindowOptions()` depends on `BehaviorInput`, `PageUriInput`, and `ScriptsInput`. It returns the options for a `TestWindow` instance.
- `testRunState()` depends on `BehaviorInput` and `ConfigInput`. It returns an initial state for `TestRun` instances.
- `submitResultsJSON(state)` depends on `BehaviorInput`. It takes a current state from `TestRun` instances, and returns the json object submitted for a aria-at test.