### PR TITLE
 add Setup Test Page button into test window

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -40,7 +40,7 @@
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -48,7 +48,7 @@
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -56,7 +56,7 @@
             <td><a href="./tests/combobox-autocomplete-both-updated/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both-updated.html">Review</a></td>
             <td>76</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -64,7 +64,7 @@
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -72,7 +72,7 @@
             <td><a href="./tests/command-button/index.html">Index</a></td>
             <td><a href="./review/command-button.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -80,7 +80,7 @@
             <td><a href="./tests/disclosure-faq/index.html">Index</a></td>
             <td><a href="./review/disclosure-faq.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -88,7 +88,7 @@
             <td><a href="./tests/disclosure-navigation/index.html">Index</a></td>
             <td><a href="./review/disclosure-navigation.html">Review</a></td>
             <td>46</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -96,7 +96,7 @@
             <td><a href="./tests/menu-button-actions/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -104,7 +104,7 @@
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -112,7 +112,7 @@
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -120,7 +120,7 @@
             <td><a href="./tests/minimal-data-grid/index.html">Index</a></td>
             <td><a href="./review/minimal-data-grid.html">Review</a></td>
             <td>55</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -128,7 +128,7 @@
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -136,7 +136,7 @@
             <td><a href="./tests/radiogroup-aria-activedescendant/index.html">Index</a></td>
             <td><a href="./review/radiogroup-aria-activedescendant.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -144,7 +144,7 @@
             <td><a href="./tests/radiogroup-roving-tabindex/index.html">Index</a></td>
             <td><a href="./review/radiogroup-roving-tabindex.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -152,7 +152,7 @@
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
           <tr>
@@ -160,7 +160,7 @@
             <td><a href="./tests/toggle-button/index.html">Index</a></td>
             <td><a href="./review/toggle-button.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/e6938ed" target="_blank">e6938ed fixup! lint and fix js files
+            <td><a href="https://github.com/w3c/aria-at/commit/753c7ae" target="_blank">753c7ae insert setup button reference page on DOMContentLoaded
 </a></td>
           </tr>
     </table>

--- a/build/review/checkbox-tri-state.html
+++ b/build/review/checkbox-tri-state.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +712,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -807,7 +794,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -883,7 +870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -959,7 +946,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1010,7 +997,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1061,7 +1048,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1132,7 +1119,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1203,7 +1190,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1250,7 +1237,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1322,7 +1309,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1381,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1429,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1520,7 +1507,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1598,7 +1585,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1648,7 +1635,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1720,7 +1707,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1792,7 +1779,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1839,7 +1826,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1917,7 +1904,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1991,7 +1978,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2065,7 +2052,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2139,7 +2126,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2186,7 +2173,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox.html
+++ b/build/review/checkbox.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -716,7 +703,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -782,7 +769,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -828,7 +815,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -911,7 +898,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -987,7 +974,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1038,7 +1025,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1101,7 +1088,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1162,7 +1149,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1204,7 +1191,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1282,7 +1269,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1360,7 +1347,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1410,7 +1397,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1488,7 +1475,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1566,7 +1553,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1616,7 +1603,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1680,7 +1667,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1744,7 +1731,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1788,7 +1775,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1857,7 +1844,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1903,7 +1890,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1980,7 +1967,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2049,7 +2036,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2099,7 +2086,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2168,7 +2155,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2237,7 +2224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-autocomplete-both-updated.html
+++ b/build/review/combobox-autocomplete-both-updated.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-01-navigate-forwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -732,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-02-navigate-backwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -821,7 +808,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-03-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -902,7 +889,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-04-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -983,7 +970,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-05-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1037,7 +1024,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-06-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1091,7 +1078,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-07-read-information-about-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1174,7 +1161,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-08-read-information-about-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1255,7 +1242,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-09-read-information-about-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1308,7 +1295,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-10-navigate-forwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1401,7 +1388,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-11-navigate-backwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1494,7 +1481,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-12-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1579,7 +1566,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-13-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1664,7 +1651,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-14-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1720,7 +1707,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-15-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1776,7 +1763,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-16-read-information-about-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1863,7 +1850,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-17-read-information-about-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1948,7 +1935,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-18-read-information-about-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2003,7 +1990,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-19-open-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2076,7 +2063,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-20-open-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2149,7 +2136,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-21-open-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2196,7 +2183,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-22-open-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2269,7 +2256,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-23-open-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2342,7 +2329,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-24-open-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2389,7 +2376,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-25-open-empty-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2464,7 +2451,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-26-open-an-empty-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2512,7 +2499,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-27-open-a-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2587,7 +2574,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-28-open-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2635,7 +2622,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-29-read-information-about-empty-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2718,7 +2705,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-30-read-information-about-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2799,7 +2786,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-31-read-information-about-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2852,7 +2839,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-32-read-information-about-filled-in-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2939,7 +2926,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-33-read-information-about-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3024,7 +3011,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-34-read-information-about-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3079,7 +3066,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-35-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3151,7 +3138,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-36-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3197,7 +3184,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-37-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3269,7 +3256,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-38-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3315,7 +3302,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-39-close-empty-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3386,7 +3373,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-40-close-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3459,7 +3446,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-41-close-empty-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3506,7 +3493,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-42-close-filled-in-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3577,7 +3564,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-43-close-filled-in-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3650,7 +3637,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-44-close-filled-in-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3697,7 +3684,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-45-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3784,7 +3771,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-46-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3840,7 +3827,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-47-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3925,7 +3912,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-48-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3980,7 +3967,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-49-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4067,7 +4054,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-50-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4123,7 +4110,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-51-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4210,7 +4197,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-52-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4266,7 +4253,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-53-navigate-from-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4351,7 +4338,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-54-navigate-from-an-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4406,7 +4393,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-55-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4491,7 +4478,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-56-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4546,7 +4533,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-57-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4631,7 +4618,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-58-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4686,7 +4673,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-59-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4771,7 +4758,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-60-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4826,7 +4813,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-61-navigate-to-next-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4913,7 +4900,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-62-navigate-to-next-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4970,7 +4957,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-63-navigate-to-previous-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5057,7 +5044,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-64-navigate-to-previous-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5114,7 +5101,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-65-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5198,7 +5185,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-66-read-information-about-a-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5253,7 +5240,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-67-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=jaws">jaws</a></li>
@@ -5338,7 +5325,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-68-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=jaws">jaws</a></li>
@@ -5423,7 +5410,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-69-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5477,7 +5464,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-70-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5531,7 +5518,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-71-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5616,7 +5603,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-72-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5701,7 +5688,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-73-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5755,7 +5742,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-74-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5809,7 +5796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-75-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5895,7 +5882,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-76-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-select-only.html
+++ b/build/review/combobox-select-only.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -728,7 +715,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -813,7 +800,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -892,7 +879,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -971,7 +958,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1024,7 +1011,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1077,7 +1064,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1158,7 +1145,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1237,7 +1224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1289,7 +1276,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1376,7 +1363,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1471,7 +1458,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1532,7 +1519,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1619,7 +1606,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1675,7 +1662,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1762,7 +1749,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1818,7 +1805,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -1905,7 +1892,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1961,7 +1948,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2045,7 +2032,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2100,7 +2087,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2178,7 +2165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2256,7 +2243,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2308,7 +2295,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2360,7 +2347,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2438,7 +2425,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2488,7 +2475,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2566,7 +2553,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2644,7 +2631,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2694,7 +2681,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2744,7 +2731,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2822,7 +2809,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2900,7 +2887,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2950,7 +2937,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3000,7 +2987,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3083,7 +3070,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3137,7 +3124,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3216,7 +3203,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/command-button.html
+++ b/build/review/command-button.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-01-navigate-forwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +709,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-02-navigate-backwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -801,7 +788,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-03-navigate-forwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -874,7 +861,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-04-navigate-backwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -947,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-05-navigate-forwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -996,7 +983,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-06-navigate-backwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1045,7 +1032,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-07-read-information-about-button-reading.html?at=jaws">jaws</a></li>
@@ -1120,7 +1107,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-08-read-information-about-button-interaction.html?at=jaws">jaws</a></li>
@@ -1195,7 +1182,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-09-read-information-about-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-faq.html
+++ b/build/review/disclosure-faq.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -724,7 +711,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -805,7 +792,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +867,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -955,7 +942,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1005,7 +992,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1055,7 +1042,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1136,7 +1123,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1217,7 +1204,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1292,7 +1279,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1367,7 +1354,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1417,7 +1404,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1467,7 +1454,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1544,7 +1531,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1619,7 +1606,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1668,7 +1655,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1745,7 +1732,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1820,7 +1807,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1869,7 +1856,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1942,7 +1929,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2015,7 +2002,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2063,7 +2050,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2136,7 +2123,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2209,7 +2196,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2257,7 +2244,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-25-navigate-from-expanded-disclosure-button-to-text-of-question-answer-reading.html?at=jaws">jaws</a></li>
@@ -2328,7 +2315,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-26-navigate-from-expanded-disclosure-button-to-text-of-question-answer-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-navigation.html
+++ b/build/review/disclosure-navigation.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -724,7 +711,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -805,7 +792,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -880,7 +867,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -961,7 +948,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1011,7 +998,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1061,7 +1048,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1142,7 +1129,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1223,7 +1210,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1298,7 +1285,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1379,7 +1366,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1428,7 +1415,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1478,7 +1465,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1555,7 +1542,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1630,7 +1617,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1679,7 +1666,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1756,7 +1743,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1831,7 +1818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1880,7 +1867,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1953,7 +1940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2026,7 +2013,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2074,7 +2061,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2147,7 +2134,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2220,7 +2207,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2268,7 +2255,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-25-navigate-from-expanded-disclosure-button-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2349,7 +2336,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-26-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -2427,7 +2414,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-27-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2478,7 +2465,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-28-navigate-from-expanded-disclosure-button-to-current-page-link-reading.html?at=jaws">jaws</a></li>
@@ -2562,7 +2549,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-29-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=jaws">jaws</a></li>
@@ -2643,7 +2630,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-30-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2696,7 +2683,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-31-navigate-from-dropdown-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2771,7 +2758,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-32-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2846,7 +2833,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-33-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2894,7 +2881,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-34-navigate-forwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2971,7 +2958,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-35-navigate-backwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3048,7 +3035,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-36-navigate-forwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3124,7 +3111,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-37-navigate-backwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3200,7 +3187,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-38-navigate-forwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3250,7 +3237,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-39-navigate-backwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3300,7 +3287,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-40-navigate-to-first-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3372,7 +3359,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-41-navigate-to-last-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3444,7 +3431,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-42-navigate-to-first-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3490,7 +3477,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-43-navigate-to-last-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3536,7 +3523,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-44-activate-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3612,7 +3599,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-45-activate-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3688,7 +3675,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-46-activate-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions-active-descendant.html
+++ b/build/review/menu-button-actions-active-descendant.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +709,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -801,7 +788,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -874,7 +861,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -947,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -996,7 +983,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1045,7 +1032,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1120,7 +1107,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1195,7 +1182,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1243,7 +1230,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1329,7 +1316,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1417,7 +1404,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1473,7 +1460,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1557,7 +1544,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1611,7 +1598,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1691,7 +1678,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1742,7 +1729,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1822,7 +1809,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1873,7 +1860,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1953,7 +1940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2004,7 +1991,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2082,7 +2069,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2132,7 +2119,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2205,7 +2192,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2253,7 +2240,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2326,7 +2313,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions.html
+++ b/build/review/menu-button-actions.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -722,7 +709,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -801,7 +788,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -874,7 +861,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -947,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -996,7 +983,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1045,7 +1032,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1120,7 +1107,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1195,7 +1182,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1243,7 +1230,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1328,7 +1315,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1415,7 +1402,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1471,7 +1458,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1554,7 +1541,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1607,7 +1594,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1686,7 +1673,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1736,7 +1723,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1815,7 +1802,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1865,7 +1852,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1944,7 +1931,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1994,7 +1981,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2071,7 +2058,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2120,7 +2107,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2193,7 +2180,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2241,7 +2228,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2314,7 +2301,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menubar-editor.html
+++ b/build/review/menubar-editor.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -724,7 +711,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -787,7 +774,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -868,7 +855,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -947,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -998,7 +985,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1067,7 +1054,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1133,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1197,7 +1184,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1276,7 +1263,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1326,7 +1313,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1406,7 +1393,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1458,7 +1445,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1536,7 +1523,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1586,7 +1573,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1664,7 +1651,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1715,7 +1702,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1793,7 +1780,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1844,7 +1831,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1924,7 +1911,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1976,7 +1963,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2062,7 +2049,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2117,7 +2104,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -2191,7 +2178,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -2275,7 +2262,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2329,7 +2316,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2413,7 +2400,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2497,7 +2484,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2551,7 +2538,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2635,7 +2622,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2719,7 +2706,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2773,7 +2760,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2857,7 +2844,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2941,7 +2928,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2995,7 +2982,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3079,7 +3066,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3163,7 +3150,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3217,7 +3204,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3299,7 +3286,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3381,7 +3368,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/minimal-data-grid.html
+++ b/build/review/minimal-data-grid.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-01-navigate-forwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -727,7 +714,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-02-navigate-backwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -809,7 +796,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-03-navigate-forwards-to-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -862,7 +849,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-04-navigate-into-end-of-grid-reading.html?at=jaws">jaws</a></li>
@@ -947,7 +934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-05-navigate-into-end-of-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1000,7 +987,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-06-move-focus-forwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1084,7 +1071,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-07-move-focus-backwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1168,7 +1155,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-08-move-focus-forwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1252,7 +1239,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-09-move-focus-backwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1336,7 +1323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-10-move-focus-forwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1389,7 +1376,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-11-move-focus-backwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1429,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-12-read-information-about-grid-cell-reading.html?at=jaws">jaws</a></li>
@@ -1518,7 +1505,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-13-read-information-about-grid-cell-interaction.html?at=jaws">jaws</a></li>
@@ -1594,7 +1581,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-14-read-information-about-grid-cell-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1642,7 +1629,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-15-read-information-about-grid-cell-containing-link-reading.html?at=jaws">jaws</a></li>
@@ -1720,7 +1707,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-16-read-information-about-grid-cell-containing-link-interaction.html?at=jaws">jaws</a></li>
@@ -1798,7 +1785,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-17-read-information-about-grid-cell-containing-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1847,7 +1834,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-18-navigate-to-next-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -1921,7 +1908,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-19-navigate-to-next-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1995,7 +1982,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-20-navigate-to-next-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2044,7 +2031,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-21-navigate-to-previous-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2118,7 +2105,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-22-navigate-to-previous-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2192,7 +2179,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-23-navigate-to-previous-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2241,7 +2228,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-24-navigate-to-next-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2320,7 +2307,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-25-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2397,7 +2384,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-26-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2448,7 +2435,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-27-navigate-to-previous-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2527,7 +2514,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-28-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2603,7 +2590,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-29-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2654,7 +2641,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-30-navigate-to-next-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2728,7 +2715,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-31-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2802,7 +2789,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-32-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2851,7 +2838,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-33-navigate-to-previous-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2925,7 +2912,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-34-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2999,7 +2986,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-35-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3049,7 +3036,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-36-navigate-to-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3123,7 +3110,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-37-navigate-to-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3197,7 +3184,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-38-navigate-to-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3245,7 +3232,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-39-navigate-to-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3319,7 +3306,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-40-navigate-to-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3393,7 +3380,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-41-navigate-to-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3441,7 +3428,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-42-navigate-to-cell-containing-link-on-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3517,7 +3504,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-43-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3593,7 +3580,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-44-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3642,7 +3629,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-45-navigate-to-cell-containing-link-on-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3718,7 +3705,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-46-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3794,7 +3781,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-47-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3843,7 +3830,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-48-navigate-to-first-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3917,7 +3904,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-49-navigate-to-first-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3964,7 +3951,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-50-navigate-to-last-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4038,7 +4025,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-51-navigate-to-last-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4085,7 +4072,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-52-navigate-to-first-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4159,7 +4146,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-53-navigate-to-first-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4206,7 +4193,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-54-navigate-to-last-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4280,7 +4267,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-55-navigate-to-last-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/modal-dialog.html
+++ b/build/review/modal-dialog.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -723,7 +710,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -803,7 +790,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -855,7 +842,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -927,7 +914,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -999,7 +986,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1045,7 +1032,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1119,7 +1106,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1193,7 +1180,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1241,7 +1228,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1313,7 +1300,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1359,7 +1346,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1431,7 +1418,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1477,7 +1464,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1551,7 +1538,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1598,7 +1585,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1670,7 +1657,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1716,7 +1703,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1799,7 +1786,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1882,7 +1869,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1936,7 +1923,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -2014,7 +2001,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2092,7 +2079,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2142,7 +2129,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -2222,7 +2209,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -2302,7 +2289,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2354,7 +2341,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2435,7 +2422,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2516,7 +2503,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-aria-activedescendant.html
+++ b/build/review/radiogroup-aria-activedescendant.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -734,7 +721,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -791,7 +778,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -882,7 +869,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -939,7 +926,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1030,7 +1017,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1087,7 +1074,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1178,7 +1165,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1235,7 +1222,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1322,7 +1309,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1378,7 +1365,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1465,7 +1452,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1521,7 +1508,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1608,7 +1595,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1664,7 +1651,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1751,7 +1738,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1807,7 +1794,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1889,7 +1876,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1969,7 +1956,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2021,7 +2008,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2103,7 +2090,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2183,7 +2170,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2235,7 +2222,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2318,7 +2305,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2401,7 +2388,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2454,7 +2441,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2537,7 +2524,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2620,7 +2607,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2673,7 +2660,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2756,7 +2743,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2810,7 +2797,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2893,7 +2880,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2947,7 +2934,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3030,7 +3017,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3083,7 +3070,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3166,7 +3153,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3219,7 +3206,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3290,7 +3277,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3361,7 +3348,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-roving-tabindex.html
+++ b/build/review/radiogroup-roving-tabindex.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -733,7 +720,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -789,7 +776,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -879,7 +866,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -935,7 +922,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1025,7 +1012,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1081,7 +1068,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1171,7 +1158,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1227,7 +1214,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1313,7 +1300,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1368,7 +1355,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1454,7 +1441,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1509,7 +1496,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1595,7 +1582,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1650,7 +1637,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1736,7 +1723,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1791,7 +1778,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -1873,7 +1860,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -1953,7 +1940,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2005,7 +1992,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2087,7 +2074,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2167,7 +2154,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2219,7 +2206,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2301,7 +2288,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2383,7 +2370,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2435,7 +2422,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2517,7 +2504,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2599,7 +2586,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2651,7 +2638,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2733,7 +2720,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2786,7 +2773,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2868,7 +2855,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2921,7 +2908,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3003,7 +2990,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3055,7 +3042,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3137,7 +3124,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3189,7 +3176,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3260,7 +3247,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3331,7 +3318,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/tabs-manual-activation.html
+++ b/build/review/tabs-manual-activation.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -732,7 +719,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -821,7 +808,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -908,7 +895,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -995,7 +982,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1053,7 +1040,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1111,7 +1098,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1194,7 +1181,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1277,7 +1264,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1330,7 +1317,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1408,7 +1395,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1486,7 +1473,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1536,7 +1523,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1617,7 +1604,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1698,7 +1685,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1750,7 +1737,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1831,7 +1818,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1883,7 +1870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1961,7 +1948,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2011,7 +1998,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2087,7 +2074,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2163,7 +2150,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2213,7 +2200,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2263,7 +2250,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2336,7 +2323,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2409,7 +2396,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2457,7 +2444,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2538,7 +2525,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2619,7 +2606,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/toggle-button.html
+++ b/build/review/toggle-button.html
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,21 +56,10 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
-
-        if (setupScriptName) {
-          var scripts = {
-            	checkFirstCheckbox: function(testPageDocument){
+      var scripts = {
+        	checkFirstCheckbox: function(testPageDocument){
 	// Set aria-checked on first checkbox
 	testPageDocument.querySelector('[role="checkbox"]').setAttribute('aria-checked', 'true');
 },	moveFocusAndCheckFirstCheckbox: function(testPageDocument){
@@ -600,30 +591,26 @@
 	button.querySelector('use').setAttribute('xlink:href', '#icon-sound');
 	button.focus();
 }
-          };
+      };
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>
@@ -643,7 +630,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-01-navigate-forwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -725,7 +712,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-02-navigate-backwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -807,7 +794,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-03-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -883,7 +870,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-04-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -959,7 +946,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-05-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1010,7 +997,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-06-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1061,7 +1048,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-07-navigate-forwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1143,7 +1130,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-08-navigate-backwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1225,7 +1212,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-09-navigate-forwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1301,7 +1288,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-10-navigate-backwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1377,7 +1364,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-11-navigate-forwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1428,7 +1415,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-12-navigate-backwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1479,7 +1466,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-13-read-information-about-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1557,7 +1544,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-14-read-information-about-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1635,7 +1622,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-15-read-information-about-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1685,7 +1672,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-16-read-information-about-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1763,7 +1750,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-17-read-information-about-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1841,7 +1828,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-18-read-information-about-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1891,7 +1878,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-19-operate-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1965,7 +1952,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-20-operate-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2039,7 +2026,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-21-operate-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2089,7 +2076,7 @@
       <ul>
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-22-operate-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2163,7 +2150,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-23-operate-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2237,7 +2224,7 @@
       <ul>
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Wed Sep 22 11:24:22 2021 -0400</li>
+        <li>Last edited: Wed Sep 15 11:10:38 2021 -0400</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-24-operate-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/tests/resources/aria-at-test-window.mjs
+++ b/build/tests/resources/aria-at-test-window.mjs
@@ -28,45 +28,93 @@ export class TestWindow {
     this.scripts = scripts;
   }
 
+  windowOnBeforeUnload() {
+    window.setTimeout(() => {
+      if (this.window.closed) {
+        this.window = undefined;
+      }
+
+      /** Re-enable open popup button. If the window was reloaded it may be 100ms  */
+      this.hooks.windowClosed();
+    }, 100);
+  }
+
+  windowOnDOMContentLoaded() {
+    if (this.window) {
+      this.prepare();
+    }
+  }
+
+  /**
+   * @param {Window} testPageWindow
+   */
+  injectSetupResetButton(testPageWindow) {
+    const {scripts, setupScriptName} = this;
+    const setupScriptPresent = Boolean(setupScriptName && scripts[setupScriptName]);
+
+    /** @type {'setup' | 'post-setup'} */
+    let runSetupOrRelad = setupScriptPresent ? 'setup' : 'post-setup';
+
+    const buttonDiv = testPageWindow.document.createElement('div');
+    buttonDiv.innerHTML = `
+      <div style="position: relative; left: 0; right: 0; height: 2rem;">
+        <button autofocus style="height: 100%; width: 100%;"${setupScriptPresent ? '' : ' disabled'}>Run Test Setup</button>
+      </div>
+    `;
+    const buttonButton = buttonDiv.querySelector('button');
+
+    buttonButton.onclick = function() {
+      try {
+        if (runSetupOrRelad === 'setup') {
+          runSetupOrRelad = 'post-setup';
+          buttonButton.disabled = true;
+
+          if (setupScriptName) {
+            scripts[setupScriptName](testPageWindow.document);
+          }
+        }
+      } catch (error) {
+        window.console.error(error);
+        throw error;
+      }
+    };
+
+    const bodyElement = testPageWindow.document.body;
+    const mainElement = bodyElement.getElementsByTagName('main')[0] || bodyElement;
+
+    mainElement.appendChild(buttonDiv.children[0]);
+  }
+
   open() {
+    if (this.window) {
+      this.window.close();
+    }
+
     this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
 
     this.hooks.windowOpened();
 
-    // If the window is closed, re-enable open popup button
-    this.window.onunload = () => {
-      window.setTimeout(() => {
-        if (this.window.closed) {
-          this.window = undefined;
-
-          this.hooks.windowClosed();
-        }
-      }, 100);
-    };
-
-    this.prepare();
+    // Prepare the window once we can modify it.
+    this.window.addEventListener('DOMContentLoaded', this.windowOnDOMContentLoaded.bind(this));
   }
 
-  prepare() {
+  async prepare() {
     if (!this.window) {
       return;
     }
 
-    let setupScriptName = this.setupScriptName;
-    if (!setupScriptName) {
-      return;
-    }
-    if (
-      this.window.location.origin !== window.location.origin || // make sure the origin is the same, and prevent this from firing on an 'about' page
-      this.window.document.readyState !== "complete"
+    // Re-enable open button when unloaded by closing the window or reloading it.
+    this.window.onbeforeunload = this.windowOnBeforeUnload.bind(this);
+
+    // Make sure the origin is the same, and prevent this from firing on an 'about' page.
+    while (
+      this.window.location.origin !== window.location.origin ||
+      this.window.document.readyState !== "complete" && this.window.document.readyState !== "interactive"
     ) {
-      window.setTimeout(() => {
-        this.prepare();
-      }, 100);
-      return;
+      await new Promise(resolve => window.setTimeout(resolve, 100));
     }
 
-    this.scripts[setupScriptName](this.window.document);
+    this.injectSetupResetButton(this.window);
   }
 
   close() {

--- a/scripts/review-template.mustache
+++ b/scripts/review-template.mustache
@@ -18,8 +18,10 @@
       }
 
     </style>
-    <script>
-      const filterATs = function(button) {
+    <script type="module">
+      import {TestWindow} from '../tests/resources/aria-at-test-window.mjs';
+
+      window.filterATs = function(button) {
         const val = button.value;
 
         if (val === 'all') {
@@ -54,45 +56,30 @@
 
           }
         }
-      }
+      };
 
-      function executeScriptInTestPage(setupScriptName, testPageWindow) {
-        if (testPageWindow.location.origin !== window.location.origin // make sure the origin is the same, and prevent this from firing on an 'about' page
-            || testPageWindow.document.readyState !== 'complete'
-        ) {
-          window.setTimeout(() => {
-            executeScriptInTestPage(setupScriptName, testPageWindow);
-          }, 100);
-          return;
-        }
+      var scripts = {
+        {{{setupScripts}}}
+      };
 
-        if (setupScriptName) {
-          var scripts = {
-            {{{setupScripts}}}
-          };
+      window.openTestPage = function(testPageUri, testNumber, setupScriptName) {
+        var openTestPageElement = document.getElementById('open-test-page-' + testNumber);
 
-          scripts[setupScriptName](testPageWindow.document);
-        }
-      }
-
-      function openTestPage(testPageUri, testNumber, setupScriptName) {
-        testPageWindow = window.open(testPageUri, '_blank', 'toolbar=0,location=0,menubar=0,width=400,height=400');
-
-        document.getElementById('open-test-page-' + testNumber).disabled = true;
-
-        // If the window is closed, re-enable open popup button
-        testPageWindow.onunload = function(event) {
-          window.setTimeout(() => {
-            if (testPageWindow.closed) {
-              testPageWindow = undefined;
-              document.getElementById('open-test-page-' + testNumber).disabled = false;
+        var testWindow = new TestWindow({
+          pageUri: testPageUri,
+          setupScriptName,
+          scripts,
+          hooks: {
+            windowOpened() {
+              openTestPageElement.disabled = true;
+            },
+            windowClosed() {
+              openTestPageElement.disabled = false;
             }
-          }, 100);
-
-        };
-
-        executeScriptInTestPage(setupScriptName, testPageWindow);
-      }
+          }
+        });
+        testWindow.open();
+      };
     </script>
   </head>
   <body>

--- a/tests/resources/aria-at-test-window.mjs
+++ b/tests/resources/aria-at-test-window.mjs
@@ -28,46 +28,50 @@ export class TestWindow {
     this.scripts = scripts;
   }
 
-  /** If the window is closed, re-enable open popup button. */
   windowOnBeforeUnload() {
     window.setTimeout(() => {
       if (this.window.closed) {
         this.window = undefined;
-
-        this.hooks.windowClosed();
-      } else {
-        // If the window is open (after a location.reload()) rerun the setupTestPage script.
-        this.prepare();
       }
+
+      /** Re-enable open popup button. If the window was reloaded it may be 100ms  */
+      this.hooks.windowClosed();
     }, 100);
   }
 
+  windowOnDOMContentLoaded() {
+    if (this.window) {
+      this.prepare();
+    }
+  }
+
+  /**
+   * @param {Window} testPageWindow
+   */
   injectSetupResetButton(testPageWindow) {
+    const {scripts, setupScriptName} = this;
+    const setupScriptPresent = Boolean(setupScriptName && scripts[setupScriptName]);
+
+    /** @type {'setup' | 'post-setup'} */
+    let runSetupOrRelad = setupScriptPresent ? 'setup' : 'post-setup';
+
     const buttonDiv = testPageWindow.document.createElement('div');
     buttonDiv.innerHTML = `
       <div style="position: relative; left: 0; right: 0; height: 2rem;">
-        <button style="height: 100%; width: 100%;">Run Test Setup</button>
+        <button autofocus style="height: 100%; width: 100%;"${setupScriptPresent ? '' : ' disabled'}>Run Test Setup</button>
       </div>
     `;
     const buttonButton = buttonDiv.querySelector('button');
 
-    /** @type {'setup' | 'reload'} */
-    let runSetupOrRelad = 'setup';
-
-    const setupScriptName = this.setupScriptName;
-
     buttonButton.onclick = function() {
       try {
         if (runSetupOrRelad === 'setup') {
-          runSetupOrRelad = 'reload';
-          buttonButton.innerText = 'Reload Test';
+          runSetupOrRelad = 'post-setup';
+          buttonButton.disabled = true;
 
           if (setupScriptName) {
-            scripts[behavior.setupScriptName](testPageWindow.document);
+            scripts[setupScriptName](testPageWindow.document);
           }
-        } else {
-          testPageWindow.location.reload();
-          buttonButton.disabled = true;
         }
       } catch (error) {
         window.console.error(error);
@@ -75,32 +79,39 @@ export class TestWindow {
       }
     };
 
-    testPageWindow.document.body.insertBefore(buttonDiv.children[0], testPageWindow.document.body.children[0]);
+    const bodyElement = testPageWindow.document.body;
+    const mainElement = bodyElement.getElementsByTagName('main')[0] || bodyElement;
+
+    mainElement.appendChild(buttonDiv.children[0]);
   }
 
   open() {
+    if (this.window) {
+      this.window.close();
+    }
+
     this.window = window.open(this.pageUri, "_blank", "toolbar=0,location=0,menubar=0,width=400,height=400");
 
     this.hooks.windowOpened();
 
-    // If the window is closed, re-enable open popup button
-    this.window.onbeforeunload = this.windowOnBeforeUnload.bind(this);
+    // Prepare the window once we can modify it.
+    this.window.addEventListener('DOMContentLoaded', this.windowOnDOMContentLoaded.bind(this));
   }
 
-  prepare() {
+  async prepare() {
     if (!this.window) {
       return;
     }
 
-    // make sure the origin is the same, and prevent this from firing on an 'about' page
-    if (
+    // Re-enable open button when unloaded by closing the window or reloading it.
+    this.window.onbeforeunload = this.windowOnBeforeUnload.bind(this);
+
+    // Make sure the origin is the same, and prevent this from firing on an 'about' page.
+    while (
       this.window.location.origin !== window.location.origin ||
-      this.window.document.readyState !== "complete"
+      this.window.document.readyState !== "complete" && this.window.document.readyState !== "interactive"
     ) {
-      window.setTimeout(() => {
-        this.prepare();
-      }, 100);
-      return;
+      await new Promise(resolve => window.setTimeout(resolve, 100));
     }
 
     this.injectSetupResetButton(this.window);


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/mzgoddard-reset-test/build/index.html)

Close #450

This is same work in PR #450. This PR replaces that one so that our github workflow can run as expected.

> This change injects a button at the bottom of the test page in the window opened by activating the `Open Test Page` button.
>
> The button has the text `Setup Test Page` and the autofocus attribute. Clicking it will run a test setup script if this test has one and then disables itself. If there is no setup script the button will disabled at the start.
