### PR TITLE
Add title reference field to each test plan

### DIFF
--- a/tests/checkbox-tri-state/data/references.csv
+++ b/tests/checkbox-tri-state/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+title,Checkbox Example (Tri State)
 reference,reference/checkbox-tri-state.html
 example,https://w3c.github.io/aria-practices/examples/checkbox/checkbox-2/checkbox-2.html
 checkbox,https://w3c.github.io/aria/#checkbox

--- a/tests/combobox-autocomplete-both-updated/data/references.csv
+++ b/tests/combobox-autocomplete-both-updated/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+title,Combobox with Both List and Inline Autocomplete Example
 reference,reference/2020-12-11_16649/combobox-autocomplete-both.html
 designPattern,https://w3c.github.io/aria-practices/#combobox
 example,https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html

--- a/tests/combobox-select-only/data/references.csv
+++ b/tests/combobox-select-only/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+title,Select Only Combobox Example
 reference,reference/combobox-select-only.html
 example,https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html
 combobox,https://w3c.github.io/aria-practices/#combobox

--- a/tests/command-button/data/references.csv
+++ b/tests/command-button/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Command Button Example
 reference,reference/2021-3-29_132754/button.html
 designPattern,https://w3c.github.io/aria-practices/#button
 example,https://w3c.github.io/aria-practices/examples/button/button.html

--- a/tests/disclosure-faq/data/references.csv
+++ b/tests/disclosure-faq/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+title,Disclosure of Answers to Frequently Asked Questions Example
 reference,reference/2020-12-3_11559/disclosure-faq.html
 designPattern,https://w3c.github.io/aria-practices/#disclosure
 example,https://w3c.github.io/aria-practices/examples/disclosure/disclosure-faq.html

--- a/tests/disclosure-navigation/data/references.csv
+++ b/tests/disclosure-navigation/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+title,Disclosure Navigation Menu Example
 reference,reference/disclosure-navigation.html
 example,https://w3c.github.io/aria-practices/examples/disclosure/disclosure-navigation.html
 button,https://w3c.github.io/aria/#button

--- a/tests/menu-button-actions-active-descendant/data/references.csv
+++ b/tests/menu-button-actions-active-descendant/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Action Menu Button Example Using aria-activedescendant
 reference,reference/2021-1-14_171136/menu-button-actions-active-descendant.html
 designPattern,https://w3c.github.io/aria-practices/#menubutton
 example,https://w3c.github.io/aria-practices/examples/menu-button/menu-button-actions-active-descendant.html

--- a/tests/menu-button-actions/data/references.csv
+++ b/tests/menu-button-actions/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Action Menu Button Example
 reference,reference/2021-1-14_12348/menu-button-actions.html
 designPattern,https://w3c.github.io/aria-practices/#menubutton
 example,https://w3c.github.io/aria-practices/examples/menu-button/menu-button-actions.html

--- a/tests/minimal-data-grid/data/references.csv
+++ b/tests/minimal-data-grid/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Data Grid Example
 reference,reference/2021-3-8_151542/dataGrids.html
 designPattern,https://w3c.github.io/aria-practices/#grid
 example,https://w3c.github.io/aria-practices/examples/grid/dataGrids.html

--- a/tests/modal-dialog/data/references.csv
+++ b/tests/modal-dialog/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,James Scholes
 authorEmail,james@pac.bz
+action,Modal Dialog Example
 reference,reference/2020-12-17_13353/dialog.html
 designPattern,https://w3c.github.io/aria-practices/#dialog_modal
 example,https://w3c.github.io/aria-practices/examples/dialog-modal/dialog.html

--- a/tests/radiogroup-aria-activedescendant/data/references.csv
+++ b/tests/radiogroup-aria-activedescendant/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Radio Group Example Using aria-activedescendant
 reference,reference/2021-3-17_161413/radio-activedescendant.html
 designPattern,https://w3c.github.io/aria-practices/#radiobutton
 example,https://w3c.github.io/aria-practices/examples/radio/radio-activedescendant.html

--- a/tests/radiogroup-roving-tabindex/data/references.csv
+++ b/tests/radiogroup-roving-tabindex/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Radio Group Example Using Roving tabindex
 reference,reference/2021-3-15_144141/radio.html
 designPattern,https://w3c.github.io/aria-practices/#radiobutton
 example,https://w3c.github.io/aria-practices/examples/radio/radio.html

--- a/tests/tabs-manual-activation/data/references.csv
+++ b/tests/tabs-manual-activation/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Tabs with Manual Activation
 reference,reference/2021-2-15_124757/tabs.html
 designPattern,https://w3c.github.io/aria-practices/#tabpanel
 example,https://w3c.github.io/aria-practices/examples/tabs/tabs-2/tabs.html

--- a/tests/toggle-button/data/references.csv
+++ b/tests/toggle-button/data/references.csv
@@ -1,6 +1,7 @@
 refId,value
 author,Isabel Del Castillo
 authorEmail,isa.delcastillo5@gmail.com
+title,Toggle Button with aria-pressed
 reference,reference/2021-3-29_145942/button.html
 designPattern,https://w3c.github.io/aria-practices/#button
 example,https://w3c.github.io/aria-practices/examples/button/button.html


### PR DESCRIPTION
#473 move titles for each test plan from support.json into their references.csv.

This PR adds a tittle to test plans that did not have one.