### PR TITLE
Support comma separated key sequences in test generation

### DIFF
--- a/lib/data/command-tuples-at-mode-task-lookup.js
+++ b/lib/data/command-tuples-at-mode-task-lookup.js
@@ -1,0 +1,34 @@
+/// <reference path="../../types/aria-at-validated.js" />
+/// <reference path="../../types/aria-at-file.js" />
+
+'use strict';
+
+/**
+ * Create command lookup object and file.
+ * @param {AriaATValidated.Command[]} commands
+ * @returns {AriaATFile.CommandTuplesATModeTaskLookup}
+ */
+function createCommandTuplesATModeTaskLookup(commands) {
+  const data = commands.reduce((carry, command) => {
+    const commandTask = carry[command.task] || {};
+    const commandTaskMode = commandTask[command.target.mode] || {};
+    const commandTaskModeAT = commandTaskMode[command.target.at.key] || [];
+    const commandTuples = command.commands.map(({ id, extraInstruction }) =>
+      extraInstruction ? [id, extraInstruction] : [id]
+    );
+    return {
+      ...carry,
+      [command.task]: {
+        ...commandTask,
+        [command.target.mode]: {
+          ...commandTaskMode,
+          [command.target.at.key]: [...commandTaskModeAT, ...commandTuples],
+        },
+      },
+    };
+  }, {});
+
+  return data;
+}
+
+exports.createCommandTuplesATModeTaskLookup = createCommandTuplesATModeTaskLookup;

--- a/lib/data/parse-command-csv-row.js
+++ b/lib/data/parse-command-csv-row.js
@@ -1,0 +1,50 @@
+/// <reference path="../../types/aria-at-csv.js" />
+/// <reference path="../../types/aria-at-parsed.js" />
+
+'use strict';
+
+/**
+ * @param {AriaATCSV.Command} commandRow
+ * @returns {AriaATParsed.Command}
+ */
+function parseCommandCSVRow(commandRow) {
+  return {
+    testId: Number(commandRow.testId),
+    task: commandRow.task.replace(/[';]/g, '').trim().toLowerCase(),
+    target: {
+      at: {
+        key: commandRow.at.trim().toLowerCase(),
+        raw: commandRow.at,
+      },
+      mode: commandRow.mode.trim().toLowerCase(),
+    },
+    commands: [
+      commandRow.commandA,
+      commandRow.commandB,
+      commandRow.commandC,
+      commandRow.commandD,
+      commandRow.commandE,
+      commandRow.commandF,
+    ]
+      .filter(Boolean)
+      .map(command => {
+        const paranIndex = command.indexOf('(');
+        if (paranIndex >= 0) {
+          return {
+            id: command.substring(0, paranIndex).trim(),
+            extraInstruction: command.substring(paranIndex).trim(),
+          };
+        }
+        return {
+          id: command.trim(),
+        };
+      })
+      .map(({ id, ...rest }) => ({
+        id,
+        keypresses: id.split(',').map(id => ({ id })),
+        ...rest,
+      })),
+  };
+}
+
+exports.parseCommandCSVRow = parseCommandCSVRow;

--- a/types/aria-at-file.js
+++ b/types/aria-at-file.js
@@ -25,29 +25,27 @@
 
 /**
  * 1 or 2 member tuples of strings.
- * @typedef {string[]} AriaATFile.CommandAT
+ * @typedef {string[]} AriaATFile.CommandExtraInstructionTuple
  */
 
 /**
- * @typedef {Object<string, AriaATFile.CommandAT[]>} AriaATFile.CommandMode
+ * @typedef {Object<string, AriaATFile.CommandExtraInstructionTuple[]>} AriaATFile.CommandTuplesATLookup
  */
 
-/** @typedef {"reading" | "interaction"} AriaATFile.ATMode */
-
 /**
- * @typedef AriaATFile.Command
- * @property {AriaATFile.CommandMode} [reading]
- * @property {AriaATFile.CommandMode} [interaction]
+ * @typedef {Object<string, AriaATFile.CommandTuplesATLookup>} AriaATFile.CommandTuplesATModeLookup
  */
 
 /**
  * An object with keys that have sentence-long descriptions of their value.
- * @typedef {Object<string, AriaATFile.Command>} AriaATFile.CommandStore
+ * @typedef {Object<string, AriaATFile.CommandTuplesATModeLookup>} AriaATFile.CommandTuplesATModeTaskLookup
  */
 
 /**
  * @typedef {number | string} AriaATFile.StringNumber
  */
+
+/** @typedef {"reading" | "interaction"} AriaATFile.ATMode */
 
 /**
  * @typedef AriaATFile.Behavior
@@ -78,7 +76,7 @@
  * @property {object} target
  * @property {object} target.at
  * @property {string} target.at.key
- * @property {string} target.at.raw
+ * @property {string} target.at.raw original test plan file assistive tech id
  * @property {string} target.at.name
  * @property {string} target.mode
  * @property {string} target.referencePage
@@ -90,8 +88,11 @@
  * @property {string} target.setupScript.jsonpPath load with `<script src="...">`
  * @property {object[]} commands
  * @property {string} commands[].id
- * @property {string} commands[].keystroke
- * @property {string} [commands[].extraInstruction]
+ * @property {string} commands[].keystroke human-readable sequence of key and key chord presses
+ * @property {object[]} commands[].keypresses
+ * @property {string} commands[].keypresses[].id
+ * @property {string} commands[].keypresses[].keystroke single human-readable key or key chord press
+ * @property {string} [commands[].extraInstruction] human-readable additional instruction to follow
  * @property {object[]} assertions[]
  * @property {1 | 2} assertions[].priority
  * @property {string} assertions[].expectation

--- a/types/aria-at-parsed.js
+++ b/types/aria-at-parsed.js
@@ -18,6 +18,8 @@
  * @property {string} target.mode
  * @property {object[]} commands
  * @property {string} commands[].id
+ * @property {object[]} commands[].keypresses
+ * @property {string} commands[].keypresses[].id
  * @property {string} [commands[].extraInstruction]
  */
 

--- a/types/aria-at-validated.js
+++ b/types/aria-at-validated.js
@@ -15,6 +15,9 @@
  * @property {object[]} commands
  * @property {string} commands[].id
  * @property {string} commands[].keystroke
+ * @property {object[]} commands[].keypresses
+ * @property {string} commands[].keypresses[].id
+ * @property {string} commands[].keypresses[].keystroke
  * @property {string} [commands[].extraInstruction]
  */
 


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/bocoup/comma-separated-command-sequences/build/index.html)

- types:
  - Add `keypresses` member to `AriaATParsed.Command`, `AriaATValidated.Command` and `AriaATFile.CollectedTest` types
  - Clarify in `AriaATFile.CollectedTest` that `keystroke` members are human readable
  - Rename command tuple nesting types in `AriaATFile` to reflect that they are deeper and deeper maps around `AriaATFile.CommandExtraInstructionTuple`
- `create-example-tests.js`:
  - Replace `createATCommandFile` with `createCommandTuplesATModeTaskLookup`
  - call `emitFile` with the output of `createCommandTuplesATModeTaskLookup`
- `lib/data`: Extract command csv row and tuple lookup functions from `create-example-tests.js` into relevant independent files


