### PR TITLE
Provide warning if UTF-8 byte order mark found when processing CSVs

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -21,11 +21,6 @@
         padding: .5em;
       }
 
-      tr:not(:first-of-type) th {
-        padding: .5em;
-        text-align: left;
-      }
-
     </style>
   </head>
   <body>
@@ -37,247 +32,247 @@
         <th>Pattern</th>
         <th>Index Page</th>
         <th>Review Page</th>
-        <th>Number of Tests</th>
+        <th># of Tests</th>
         <th>Commit of Last Change</th>
       </tr>
           <tr>
-            <th>alert</th>
+            <td>alert</td>
             <td><a href="./tests/alert/index.html">Index</a></td>
             <td><a href="./review/alert.html">Review</a></td>
             <td>3</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>banner</th>
+            <td>banner</td>
             <td><a href="./tests/banner/index.html">Index</a></td>
             <td><a href="./review/banner.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>breadcrumb</th>
+            <td>breadcrumb</td>
             <td><a href="./tests/breadcrumb/index.html">Index</a></td>
             <td><a href="./review/breadcrumb.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>checkbox</th>
+            <td>checkbox</td>
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>checkbox-tri-state</th>
+            <td>checkbox-tri-state</td>
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>combobox-autocomplete-both-updated</th>
+            <td>combobox-autocomplete-both-updated</td>
             <td><a href="./tests/combobox-autocomplete-both-updated/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both-updated.html">Review</a></td>
             <td>76</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>combobox-select-only</th>
+            <td>combobox-select-only</td>
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>command-button</th>
+            <td>command-button</td>
             <td><a href="./tests/command-button/index.html">Index</a></td>
             <td><a href="./review/command-button.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>complementary</th>
+            <td>complementary</td>
             <td><a href="./tests/complementary/index.html">Index</a></td>
             <td><a href="./review/complementary.html">Review</a></td>
             <td>20</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>contentinfo</th>
+            <td>contentinfo</td>
             <td><a href="./tests/contentinfo/index.html">Index</a></td>
             <td><a href="./review/contentinfo.html">Review</a></td>
             <td>16</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>datepicker-spin-button</th>
+            <td>datepicker-spin-button</td>
             <td><a href="./tests/datepicker-spin-button/index.html">Index</a></td>
             <td><a href="./review/datepicker-spin-button.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>disclosure-faq</th>
+            <td>disclosure-faq</td>
             <td><a href="./tests/disclosure-faq/index.html">Index</a></td>
             <td><a href="./review/disclosure-faq.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>disclosure-navigation</th>
+            <td>disclosure-navigation</td>
             <td><a href="./tests/disclosure-navigation/index.html">Index</a></td>
             <td><a href="./review/disclosure-navigation.html">Review</a></td>
             <td>46</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>form</th>
+            <td>form</td>
             <td><a href="./tests/form/index.html">Index</a></td>
             <td><a href="./review/form.html">Review</a></td>
             <td>20</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>horizontal-slider</th>
+            <td>horizontal-slider</td>
             <td><a href="./tests/horizontal-slider/index.html">Index</a></td>
             <td><a href="./review/horizontal-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>main</th>
+            <td>main</td>
             <td><a href="./tests/main/index.html">Index</a></td>
             <td><a href="./review/main.html">Review</a></td>
             <td>16</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>menu-button-actions</th>
+            <td>menu-button-actions</td>
             <td><a href="./tests/menu-button-actions/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>menu-button-actions-active-descendant</th>
+            <td>menu-button-actions-active-descendant</td>
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>menubar-editor</th>
+            <td>menubar-editor</td>
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>meter</th>
+            <td>meter</td>
             <td><a href="./tests/meter/index.html">Index</a></td>
             <td><a href="./review/meter.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>minimal-data-grid</th>
+            <td>minimal-data-grid</td>
             <td><a href="./tests/minimal-data-grid/index.html">Index</a></td>
             <td><a href="./review/minimal-data-grid.html">Review</a></td>
             <td>55</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>modal-dialog</th>
+            <td>modal-dialog</td>
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>radiogroup-aria-activedescendant</th>
+            <td>radiogroup-aria-activedescendant</td>
             <td><a href="./tests/radiogroup-aria-activedescendant/index.html">Index</a></td>
             <td><a href="./review/radiogroup-aria-activedescendant.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>radiogroup-roving-tabindex</th>
+            <td>radiogroup-roving-tabindex</td>
             <td><a href="./tests/radiogroup-roving-tabindex/index.html">Index</a></td>
             <td><a href="./review/radiogroup-roving-tabindex.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>rating-slider</th>
+            <td>rating-slider</td>
             <td><a href="./tests/rating-slider/index.html">Index</a></td>
             <td><a href="./review/rating-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>seek-slider</th>
+            <td>seek-slider</td>
             <td><a href="./tests/seek-slider/index.html">Index</a></td>
             <td><a href="./review/seek-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>switch</th>
+            <td>switch</td>
             <td><a href="./tests/switch/index.html">Index</a></td>
             <td><a href="./review/switch.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>tabs-manual-activation</th>
+            <td>tabs-manual-activation</td>
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>toggle-button</th>
+            <td>toggle-button</td>
             <td><a href="./tests/toggle-button/index.html">Index</a></td>
             <td><a href="./review/toggle-button.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
           <tr>
-            <th>vertical-temperature-slider</th>
+            <td>vertical-temperature-slider</td>
             <td><a href="./tests/vertical-temperature-slider/index.html">Index</a></td>
             <td><a href="./review/vertical-temperature-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6473381" target="_blank">6473381 Generate test and review files automatically
+            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
 </a></td>
           </tr>
     </table>

--- a/build/index.html
+++ b/build/index.html
@@ -21,6 +21,11 @@
         padding: .5em;
       }
 
+      tr:not(:first-of-type) th {
+        padding: .5em;
+        text-align: left;
+      }
+
     </style>
   </head>
   <body>
@@ -32,247 +37,247 @@
         <th>Pattern</th>
         <th>Index Page</th>
         <th>Review Page</th>
-        <th># of Tests</th>
+        <th>Number of Tests</th>
         <th>Commit of Last Change</th>
       </tr>
           <tr>
-            <td>alert</td>
+            <th>alert</th>
             <td><a href="./tests/alert/index.html">Index</a></td>
             <td><a href="./review/alert.html">Review</a></td>
             <td>3</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>banner</td>
+            <th>banner</th>
             <td><a href="./tests/banner/index.html">Index</a></td>
             <td><a href="./review/banner.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>breadcrumb</td>
+            <th>breadcrumb</th>
             <td><a href="./tests/breadcrumb/index.html">Index</a></td>
             <td><a href="./review/breadcrumb.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>checkbox</td>
+            <th>checkbox</th>
             <td><a href="./tests/checkbox/index.html">Index</a></td>
             <td><a href="./review/checkbox.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>checkbox-tri-state</td>
+            <th>checkbox-tri-state</th>
             <td><a href="./tests/checkbox-tri-state/index.html">Index</a></td>
             <td><a href="./review/checkbox-tri-state.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>combobox-autocomplete-both-updated</td>
+            <th>combobox-autocomplete-both-updated</th>
             <td><a href="./tests/combobox-autocomplete-both-updated/index.html">Index</a></td>
             <td><a href="./review/combobox-autocomplete-both-updated.html">Review</a></td>
             <td>76</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>combobox-select-only</td>
+            <th>combobox-select-only</th>
             <td><a href="./tests/combobox-select-only/index.html">Index</a></td>
             <td><a href="./review/combobox-select-only.html">Review</a></td>
             <td>38</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>command-button</td>
+            <th>command-button</th>
             <td><a href="./tests/command-button/index.html">Index</a></td>
             <td><a href="./review/command-button.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>complementary</td>
+            <th>complementary</th>
             <td><a href="./tests/complementary/index.html">Index</a></td>
             <td><a href="./review/complementary.html">Review</a></td>
             <td>20</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>contentinfo</td>
+            <th>contentinfo</th>
             <td><a href="./tests/contentinfo/index.html">Index</a></td>
             <td><a href="./review/contentinfo.html">Review</a></td>
             <td>16</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>datepicker-spin-button</td>
+            <th>datepicker-spin-button</th>
             <td><a href="./tests/datepicker-spin-button/index.html">Index</a></td>
             <td><a href="./review/datepicker-spin-button.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>disclosure-faq</td>
+            <th>disclosure-faq</th>
             <td><a href="./tests/disclosure-faq/index.html">Index</a></td>
             <td><a href="./review/disclosure-faq.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>disclosure-navigation</td>
+            <th>disclosure-navigation</th>
             <td><a href="./tests/disclosure-navigation/index.html">Index</a></td>
             <td><a href="./review/disclosure-navigation.html">Review</a></td>
             <td>46</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>form</td>
+            <th>form</th>
             <td><a href="./tests/form/index.html">Index</a></td>
             <td><a href="./review/form.html">Review</a></td>
             <td>20</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>horizontal-slider</td>
+            <th>horizontal-slider</th>
             <td><a href="./tests/horizontal-slider/index.html">Index</a></td>
             <td><a href="./review/horizontal-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>main</td>
+            <th>main</th>
             <td><a href="./tests/main/index.html">Index</a></td>
             <td><a href="./review/main.html">Review</a></td>
             <td>16</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>menu-button-actions</td>
+            <th>menu-button-actions</th>
             <td><a href="./tests/menu-button-actions/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>menu-button-actions-active-descendant</td>
+            <th>menu-button-actions-active-descendant</th>
             <td><a href="./tests/menu-button-actions-active-descendant/index.html">Index</a></td>
             <td><a href="./review/menu-button-actions-active-descendant.html">Review</a></td>
             <td>26</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>menubar-editor</td>
+            <th>menubar-editor</th>
             <td><a href="./tests/menubar-editor/index.html">Index</a></td>
             <td><a href="./review/menubar-editor.html">Review</a></td>
             <td>40</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>meter</td>
+            <th>meter</th>
             <td><a href="./tests/meter/index.html">Index</a></td>
             <td><a href="./review/meter.html">Review</a></td>
             <td>9</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>minimal-data-grid</td>
+            <th>minimal-data-grid</th>
             <td><a href="./tests/minimal-data-grid/index.html">Index</a></td>
             <td><a href="./review/minimal-data-grid.html">Review</a></td>
             <td>55</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>modal-dialog</td>
+            <th>modal-dialog</th>
             <td><a href="./tests/modal-dialog/index.html">Index</a></td>
             <td><a href="./review/modal-dialog.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>radiogroup-aria-activedescendant</td>
+            <th>radiogroup-aria-activedescendant</th>
             <td><a href="./tests/radiogroup-aria-activedescendant/index.html">Index</a></td>
             <td><a href="./review/radiogroup-aria-activedescendant.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>radiogroup-roving-tabindex</td>
+            <th>radiogroup-roving-tabindex</th>
             <td><a href="./tests/radiogroup-roving-tabindex/index.html">Index</a></td>
             <td><a href="./review/radiogroup-roving-tabindex.html">Review</a></td>
             <td>39</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>rating-slider</td>
+            <th>rating-slider</th>
             <td><a href="./tests/rating-slider/index.html">Index</a></td>
             <td><a href="./review/rating-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>seek-slider</td>
+            <th>seek-slider</th>
             <td><a href="./tests/seek-slider/index.html">Index</a></td>
             <td><a href="./review/seek-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>switch</td>
+            <th>switch</th>
             <td><a href="./tests/switch/index.html">Index</a></td>
             <td><a href="./review/switch.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>tabs-manual-activation</td>
+            <th>tabs-manual-activation</th>
             <td><a href="./tests/tabs-manual-activation/index.html">Index</a></td>
             <td><a href="./review/tabs-manual-activation.html">Review</a></td>
             <td>29</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>toggle-button</td>
+            <th>toggle-button</th>
             <td><a href="./tests/toggle-button/index.html">Index</a></td>
             <td><a href="./review/toggle-button.html">Review</a></td>
             <td>24</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
           <tr>
-            <td>vertical-temperature-slider</td>
+            <th>vertical-temperature-slider</th>
             <td><a href="./tests/vertical-temperature-slider/index.html">Index</a></td>
             <td><a href="./review/vertical-temperature-slider.html">Review</a></td>
             <td>21</td>
-            <td><a href="https://github.com/w3c/aria-at/commit/91fbc90" target="_blank">91fbc90 lint fix
+            <td><a href="https://github.com/w3c/aria-at/commit/1e4e4e6" target="_blank">1e4e4e6 Generate test and review files automatically
 </a></td>
           </tr>
     </table>

--- a/build/review/alert.html
+++ b/build/review/alert.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-01-trigger-alert-reading.html?at=jaws">jaws</a></li>
@@ -917,7 +917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-02-trigger-alert-interaction.html?at=jaws">jaws</a></li>
@@ -992,7 +992,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-03-trigger-alert-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/alert.html
+++ b/build/review/alert.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-01-trigger-alert-reading.html?at=jaws">jaws</a></li>
@@ -917,7 +917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-02-trigger-alert-interaction.html?at=jaws">jaws</a></li>
@@ -992,7 +992,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/alert/test-03-trigger-alert-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/banner.html
+++ b/build/review/banner.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -999,7 +999,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1048,7 +1048,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1128,7 +1128,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1203,7 +1203,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1330,7 +1330,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1405,7 +1405,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1454,7 +1454,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1532,7 +1532,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1607,7 +1607,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1656,7 +1656,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1741,7 +1741,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1822,7 +1822,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1958,7 +1958,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -2036,7 +2036,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2088,7 +2088,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2163,7 +2163,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2211,7 +2211,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2334,7 +2334,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2413,7 +2413,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2462,7 +2462,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2541,7 +2541,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/banner.html
+++ b/build/review/banner.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -999,7 +999,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1048,7 +1048,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1128,7 +1128,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1203,7 +1203,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1330,7 +1330,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1405,7 +1405,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1454,7 +1454,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1532,7 +1532,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1607,7 +1607,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1656,7 +1656,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1741,7 +1741,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1822,7 +1822,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1958,7 +1958,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -2036,7 +2036,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2088,7 +2088,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2163,7 +2163,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2211,7 +2211,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2334,7 +2334,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2413,7 +2413,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2462,7 +2462,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2541,7 +2541,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/breadcrumb.html
+++ b/build/review/breadcrumb.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-01-navigate-to-first-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-02-navigate-to-last-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -1023,7 +1023,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-03-navigate-to-first-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1104,7 +1104,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-04-navigate-to-last-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1188,7 +1188,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-05-navigate-to-first-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-06-navigate-to-last-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1294,7 +1294,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-07-read-information-about-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -1372,7 +1372,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-08-read-information-about-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1450,7 +1450,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-09-read-information-about-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/breadcrumb.html
+++ b/build/review/breadcrumb.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-01-navigate-to-first-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-02-navigate-to-last-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -1023,7 +1023,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-03-navigate-to-first-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1104,7 +1104,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-04-navigate-to-last-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1188,7 +1188,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-05-navigate-to-first-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1240,7 +1240,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-06-navigate-to-last-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1294,7 +1294,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-07-read-information-about-breadcrumb-link-reading.html?at=jaws">jaws</a></li>
@@ -1372,7 +1372,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-08-read-information-about-breadcrumb-link-interaction.html?at=jaws">jaws</a></li>
@@ -1450,7 +1450,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/breadcrumb/test-09-read-information-about-breadcrumb-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox-tri-state.html
+++ b/build/review/checkbox-tri-state.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1006,7 +1006,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1082,7 +1082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1158,7 +1158,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1209,7 +1209,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1331,7 +1331,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1449,7 +1449,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1521,7 +1521,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1593,7 +1593,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1641,7 +1641,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1719,7 +1719,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1797,7 +1797,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1847,7 +1847,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1991,7 +1991,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2038,7 +2038,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2116,7 +2116,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2190,7 +2190,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2264,7 +2264,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2338,7 +2338,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2385,7 +2385,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox-tri-state.html
+++ b/build/review/checkbox-tri-state.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-01-navigate-forwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-02-navigate-backwards-to-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1006,7 +1006,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-03-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1082,7 +1082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-04-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1158,7 +1158,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-05-navigate-forwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1209,7 +1209,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-06-navigate-backwards-to-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-07-operate-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1331,7 +1331,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-08-operate-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-09-operate-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1449,7 +1449,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-10-operate-unchecked-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1521,7 +1521,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-11-operate-unchecked-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1593,7 +1593,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-12-operate-unchecked-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1641,7 +1641,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-13-read-partially-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1719,7 +1719,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-14-read-partially-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1797,7 +1797,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-15-read-partially-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1847,7 +1847,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1991,7 +1991,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2038,7 +2038,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-19-navigate-forwards-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2116,7 +2116,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-20-navigate-backwards-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2190,7 +2190,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-21-navigate-forwards-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2264,7 +2264,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-22-navigate-backwards-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2338,7 +2338,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-23-navigate-forwards-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2385,7 +2385,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox-tri-state/test-24-navigate-backwards-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox.html
+++ b/build/review/checkbox.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -915,7 +915,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -981,7 +981,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1027,7 +1027,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1186,7 +1186,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1237,7 +1237,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1300,7 +1300,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1361,7 +1361,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1403,7 +1403,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1481,7 +1481,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1559,7 +1559,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1609,7 +1609,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1687,7 +1687,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1765,7 +1765,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1815,7 +1815,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1879,7 +1879,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1943,7 +1943,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1987,7 +1987,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2056,7 +2056,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2102,7 +2102,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2179,7 +2179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2248,7 +2248,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2298,7 +2298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2367,7 +2367,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2436,7 +2436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/checkbox.html
+++ b/build/review/checkbox.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-01-navigate-to-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -915,7 +915,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-02-navigate-to-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -981,7 +981,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-03-navigate-to-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1027,7 +1027,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-04-navigate-to-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-05-navigate-to-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1186,7 +1186,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-06-navigate-to-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1237,7 +1237,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-07-operate-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1300,7 +1300,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-08-operate-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1361,7 +1361,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-09-operate-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1403,7 +1403,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-10-read-unchecked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1481,7 +1481,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-11-read-unchecked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1559,7 +1559,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-12-read-unchecked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1609,7 +1609,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-13-read-checked-checkbox-reading.html?at=jaws">jaws</a></li>
@@ -1687,7 +1687,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-14-read-checked-checkbox-interaction.html?at=jaws">jaws</a></li>
@@ -1765,7 +1765,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-15-read-checked-checkbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1815,7 +1815,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-16-read-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -1879,7 +1879,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-17-read-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -1943,7 +1943,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-18-read-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1987,7 +1987,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-19-navigate-sequentially-through-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2056,7 +2056,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-20-navigate-sequentially-through-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2102,7 +2102,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-21-navigate-into-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2179,7 +2179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-22-navigate-into-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2248,7 +2248,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-23-navigate-into-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2298,7 +2298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-24-navigate-out-of-checkbox-group-reading.html?at=jaws">jaws</a></li>
@@ -2367,7 +2367,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-25-navigate-out-of-checkbox-group-interaction.html?at=jaws">jaws</a></li>
@@ -2436,7 +2436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/checkbox/test-26-navigate-out-of-checkbox-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-autocomplete-both-updated.html
+++ b/build/review/combobox-autocomplete-both-updated.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-01-navigate-forwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-02-navigate-backwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1020,7 +1020,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-03-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-04-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1182,7 +1182,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-05-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1236,7 +1236,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-06-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1290,7 +1290,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-07-read-information-about-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1373,7 +1373,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-08-read-information-about-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1454,7 +1454,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-09-read-information-about-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1507,7 +1507,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-10-navigate-forwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1600,7 +1600,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-11-navigate-backwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1693,7 +1693,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-12-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1778,7 +1778,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-13-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-14-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-15-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1975,7 +1975,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-16-read-information-about-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2062,7 +2062,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-17-read-information-about-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2147,7 +2147,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-18-read-information-about-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2202,7 +2202,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-19-open-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2275,7 +2275,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-20-open-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2348,7 +2348,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-21-open-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2395,7 +2395,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-22-open-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2468,7 +2468,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-23-open-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2541,7 +2541,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-24-open-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2588,7 +2588,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-25-open-empty-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2663,7 +2663,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-26-open-an-empty-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2711,7 +2711,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-27-open-a-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2786,7 +2786,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-28-open-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2834,7 +2834,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-29-read-information-about-empty-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2917,7 +2917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-30-read-information-about-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2998,7 +2998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-31-read-information-about-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3051,7 +3051,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-32-read-information-about-filled-in-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3138,7 +3138,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-33-read-information-about-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3223,7 +3223,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-34-read-information-about-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3278,7 +3278,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-35-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3350,7 +3350,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-36-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3396,7 +3396,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-37-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3468,7 +3468,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-38-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3514,7 +3514,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-39-close-empty-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3585,7 +3585,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-40-close-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3658,7 +3658,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-41-close-empty-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3705,7 +3705,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-42-close-filled-in-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3776,7 +3776,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-43-close-filled-in-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3849,7 +3849,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-44-close-filled-in-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3896,7 +3896,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-45-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3983,7 +3983,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-46-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4039,7 +4039,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-47-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4124,7 +4124,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-48-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4179,7 +4179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-49-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4266,7 +4266,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-50-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4322,7 +4322,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-51-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4409,7 +4409,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-52-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4465,7 +4465,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-53-navigate-from-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4550,7 +4550,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-54-navigate-from-an-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4605,7 +4605,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-55-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4690,7 +4690,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-56-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4745,7 +4745,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-57-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4830,7 +4830,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-58-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4885,7 +4885,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-59-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4970,7 +4970,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-60-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5025,7 +5025,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-61-navigate-to-next-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5112,7 +5112,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-62-navigate-to-next-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5169,7 +5169,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-63-navigate-to-previous-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5256,7 +5256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-64-navigate-to-previous-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5313,7 +5313,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-65-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5397,7 +5397,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-66-read-information-about-a-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5452,7 +5452,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-67-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=jaws">jaws</a></li>
@@ -5537,7 +5537,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-68-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=jaws">jaws</a></li>
@@ -5622,7 +5622,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-69-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5676,7 +5676,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-70-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5730,7 +5730,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-71-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5815,7 +5815,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-72-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5900,7 +5900,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-73-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5954,7 +5954,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-74-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -6008,7 +6008,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-75-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -6094,7 +6094,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-76-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-autocomplete-both-updated.html
+++ b/build/review/combobox-autocomplete-both-updated.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-01-navigate-forwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-02-navigate-backwards-to-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1020,7 +1020,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-03-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-04-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1182,7 +1182,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-05-navigate-forwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1236,7 +1236,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-06-navigate-backwards-to-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1290,7 +1290,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-07-read-information-about-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1373,7 +1373,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-08-read-information-about-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1454,7 +1454,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-09-read-information-about-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1507,7 +1507,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-10-navigate-forwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1600,7 +1600,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-11-navigate-backwards-to-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1693,7 +1693,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-12-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1778,7 +1778,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-13-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-14-navigate-forwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-15-navigate-backwards-to-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1975,7 +1975,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-16-read-information-about-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2062,7 +2062,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-17-read-information-about-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2147,7 +2147,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-18-read-information-about-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2202,7 +2202,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-19-open-empty-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2275,7 +2275,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-20-open-empty-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2348,7 +2348,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-21-open-empty-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2395,7 +2395,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-22-open-filled-in-collapsed-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2468,7 +2468,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-23-open-filled-in-collapsed-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2541,7 +2541,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-24-open-filled-in-collapsed-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2588,7 +2588,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-25-open-empty-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2663,7 +2663,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-26-open-an-empty-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2711,7 +2711,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-27-open-a-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2786,7 +2786,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-28-open-filled-in-collapsed-combobox-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2834,7 +2834,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-29-read-information-about-empty-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -2917,7 +2917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-30-read-information-about-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -2998,7 +2998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-31-read-information-about-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3051,7 +3051,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-32-read-information-about-filled-in-expanded-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3138,7 +3138,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-33-read-information-about-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3223,7 +3223,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-34-read-information-about-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3278,7 +3278,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-35-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3350,7 +3350,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-36-narrow-down-matching-options-in-empty-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3396,7 +3396,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-37-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3468,7 +3468,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-38-narrow-down-matching-options-in-filled-in-expanded-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3514,7 +3514,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-39-close-empty-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3585,7 +3585,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-40-close-empty-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3658,7 +3658,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-41-close-empty-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3705,7 +3705,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-42-close-filled-in-combobox-reading.html?at=jaws">jaws</a></li>
@@ -3776,7 +3776,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-43-close-filled-in-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -3849,7 +3849,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-44-close-filled-in-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3896,7 +3896,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-45-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3983,7 +3983,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-46-navigate-from-empty-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4039,7 +4039,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-47-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4124,7 +4124,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-48-navigate-from-empty-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4179,7 +4179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-49-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4266,7 +4266,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-50-navigate-from-filled-in-collapsed-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4322,7 +4322,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-51-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4409,7 +4409,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-52-navigate-from-filled-in-collapsed-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4465,7 +4465,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-53-navigate-from-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4550,7 +4550,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-54-navigate-from-an-empty-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4605,7 +4605,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-55-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4690,7 +4690,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-56-navigate-from-empty-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4745,7 +4745,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-57-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4830,7 +4830,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-58-navigate-from-filled-in-expanded-combobox-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4885,7 +4885,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-59-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -4970,7 +4970,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-60-navigate-from-filled-in-expanded-combobox-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5025,7 +5025,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-61-navigate-to-next-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5112,7 +5112,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-62-navigate-to-next-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5169,7 +5169,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-63-navigate-to-previous-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5256,7 +5256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-64-navigate-to-previous-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5313,7 +5313,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-65-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -5397,7 +5397,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-66-read-information-about-a-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5452,7 +5452,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-67-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=jaws">jaws</a></li>
@@ -5537,7 +5537,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-68-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=jaws">jaws</a></li>
@@ -5622,7 +5622,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-69-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-right-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5676,7 +5676,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-70-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-left-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5730,7 +5730,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-71-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5815,7 +5815,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-72-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=jaws">jaws</a></li>
@@ -5900,7 +5900,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-73-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-end-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -5954,7 +5954,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-74-navigate-out-of-listbox-popup-by-moving-editing-cursor-to-beginning-of-textbox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -6008,7 +6008,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-75-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -6094,7 +6094,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-autocomplete-both-updated/test-76-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-select-only.html
+++ b/build/review/combobox-select-only.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -927,7 +927,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1012,7 +1012,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1091,7 +1091,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1170,7 +1170,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1223,7 +1223,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1276,7 +1276,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1357,7 +1357,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1436,7 +1436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1488,7 +1488,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1575,7 +1575,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1670,7 +1670,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1731,7 +1731,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1818,7 +1818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1874,7 +1874,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1961,7 +1961,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2017,7 +2017,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -2104,7 +2104,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2160,7 +2160,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2244,7 +2244,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2299,7 +2299,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2377,7 +2377,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2455,7 +2455,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2507,7 +2507,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2559,7 +2559,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2637,7 +2637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2687,7 +2687,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2765,7 +2765,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2843,7 +2843,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2893,7 +2893,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2943,7 +2943,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3021,7 +3021,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3099,7 +3099,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3149,7 +3149,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3199,7 +3199,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3282,7 +3282,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3336,7 +3336,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3415,7 +3415,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/combobox-select-only.html
+++ b/build/review/combobox-select-only.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-01-navigate-forwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -927,7 +927,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-02-navigate-backwards-to-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1012,7 +1012,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-03-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1091,7 +1091,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-04-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1170,7 +1170,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-05-navigate-forwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1223,7 +1223,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-06-navigate-backwards-to-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1276,7 +1276,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-07-read-information-about-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1357,7 +1357,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-08-read-information-about-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1436,7 +1436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-09-read-information-about-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1488,7 +1488,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-10-open-collapsed-select-only-combobox-reading.html?at=jaws">jaws</a></li>
@@ -1575,7 +1575,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-11-open-collapsed-select-only-combobox-interaction.html?at=jaws">jaws</a></li>
@@ -1670,7 +1670,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-12-open-collapsed-select-only-combobox-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1731,7 +1731,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-13-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=jaws">jaws</a></li>
@@ -1818,7 +1818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-14-open-collapsed-select-only-combobox-to-first-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1874,7 +1874,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-15-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=jaws">jaws</a></li>
@@ -1961,7 +1961,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-16-open-collapsed-select-only-combobox-to-specific-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2017,7 +2017,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-17-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=jaws">jaws</a></li>
@@ -2104,7 +2104,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-18-open-collapsed-select-only-combobox-to-last-option-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2160,7 +2160,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-19-read-information-about-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2244,7 +2244,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-20-read-information-about-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2299,7 +2299,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-21-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2377,7 +2377,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-22-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2455,7 +2455,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-23-navigate-forwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2507,7 +2507,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-24-navigate-backwards-to-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2559,7 +2559,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-25-navigate-to-specific-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2637,7 +2637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-26-navigate-to-specific-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2687,7 +2687,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-27-navigate-to-first-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2765,7 +2765,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-28-navigate-to-last-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -2843,7 +2843,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-29-navigate-to-first-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2893,7 +2893,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-30-navigate-to-last-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2943,7 +2943,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-31-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3021,7 +3021,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-32-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3099,7 +3099,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-33-navigate-forwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3149,7 +3149,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-34-navigate-backwards-by-ten-options-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3199,7 +3199,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-35-select-option-in-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3282,7 +3282,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-36-select-option-in-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3336,7 +3336,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-37-close-listbox-popup-interaction.html?at=jaws">jaws</a></li>
@@ -3415,7 +3415,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/combobox-select-only/test-38-close-listbox-popup-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/command-button.html
+++ b/build/review/command-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-01-navigate-forwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-02-navigate-backwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-03-navigate-forwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-04-navigate-backwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-05-navigate-forwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-06-navigate-backwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-07-read-information-about-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-08-read-information-about-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-09-read-information-about-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/command-button.html
+++ b/build/review/command-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-01-navigate-forwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-02-navigate-backwards-to-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-03-navigate-forwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-04-navigate-backwards-to-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-05-navigate-forwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-06-navigate-backwards-to-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-07-read-information-about-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-08-read-information-about-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/command-button/test-09-read-information-about-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/complementary.html
+++ b/build/review/complementary.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-01-navigate-forwards-into-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -926,7 +926,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-02-navigate-forwards-into-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1003,7 +1003,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-03-navigate-forwards-into-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1053,7 +1053,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-04-navigate-backwards-into-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1135,7 +1135,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-05-navigate-backwards-into-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1212,7 +1212,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-06-navigate-backwards-into-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1262,7 +1262,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-07-navigate-forwards-out-of-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1344,7 +1344,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-08-navigate-forwards-out-of-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1421,7 +1421,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-09-navigate-forwards-out-of-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1471,7 +1471,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-10-navigate-backwards-out-of-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1553,7 +1553,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-11-navigate-backwards-out-of-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1630,7 +1630,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-12-navigate-backwards-out-of-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1680,7 +1680,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-13-navigate-forwards-to-a-heading-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1761,7 +1761,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-14-navigate-forwards-to-a-heading-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1811,7 +1811,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-15-navigate-backwards-to-a-heading-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1892,7 +1892,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-16-navigate-backwards-to-a-heading-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1942,7 +1942,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-17-navigate-forwards-to-a-list-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2023,7 +2023,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-18-navigate-forwards-to-a-list-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2073,7 +2073,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-19-navigate-backwards-to-a-list-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-20-navigate-backwards-to-a-list-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/complementary.html
+++ b/build/review/complementary.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-01-navigate-forwards-into-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -926,7 +926,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-02-navigate-forwards-into-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1003,7 +1003,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-03-navigate-forwards-into-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1053,7 +1053,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-04-navigate-backwards-into-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1135,7 +1135,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-05-navigate-backwards-into-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1212,7 +1212,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-06-navigate-backwards-into-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1262,7 +1262,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-07-navigate-forwards-out-of-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1344,7 +1344,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-08-navigate-forwards-out-of-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1421,7 +1421,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-09-navigate-forwards-out-of-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1471,7 +1471,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-10-navigate-backwards-out-of-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1553,7 +1553,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-11-navigate-backwards-out-of-a-complementary-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1630,7 +1630,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-12-navigate-backwards-out-of-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1680,7 +1680,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-13-navigate-forwards-to-a-heading-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1761,7 +1761,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-14-navigate-forwards-to-a-heading-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1811,7 +1811,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-15-navigate-backwards-to-a-heading-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1892,7 +1892,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-16-navigate-backwards-to-a-heading-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1942,7 +1942,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-17-navigate-forwards-to-a-list-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2023,7 +2023,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-18-navigate-forwards-to-a-list-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2073,7 +2073,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-19-navigate-backwards-to-a-list-inside-a-complementary-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/complementary/test-20-navigate-backwards-to-a-list-inside-a-complementary-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/contentinfo.html
+++ b/build/review/contentinfo.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-01-navigate-forwards-into-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-02-navigate-forwards-into-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -999,7 +999,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-03-navigate-forwards-into-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1048,7 +1048,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-04-navigate-backwards-into-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1128,7 +1128,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-05-navigate-backwards-into-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1203,7 +1203,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-06-navigate-backwards-into-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-07-navigate-forwards-out-of-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1332,7 +1332,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-08-navigate-forwards-out-of-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1407,7 +1407,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-09-navigate-forwards-out-of-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1456,7 +1456,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-10-navigate-backwards-out-of-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1536,7 +1536,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-11-navigate-backwards-out-of-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1611,7 +1611,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-12-navigate-backwards-out-of-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1660,7 +1660,7 @@
       <ul class="jaws">
         <li>Mode: reading</li>
         <li>Applies to: jaws</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-13-navigate-forwards-to-a-paragraph-inside-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1707,7 +1707,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-14-navigate-forwards-to-a-paragraph-inside-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1754,7 +1754,7 @@
       <ul class="jaws">
         <li>Mode: reading</li>
         <li>Applies to: jaws</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-15-navigate-backwards-to-a-paragraph-inside-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1801,7 +1801,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-16-navigate-backwards-to-a-paragraph-inside-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/contentinfo.html
+++ b/build/review/contentinfo.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-01-navigate-forwards-into-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-02-navigate-forwards-into-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -999,7 +999,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-03-navigate-forwards-into-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1048,7 +1048,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-04-navigate-backwards-into-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1128,7 +1128,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-05-navigate-backwards-into-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1203,7 +1203,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-06-navigate-backwards-into-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-07-navigate-forwards-out-of-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1332,7 +1332,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-08-navigate-forwards-out-of-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1407,7 +1407,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-09-navigate-forwards-out-of-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1456,7 +1456,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-10-navigate-backwards-out-of-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1536,7 +1536,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-11-navigate-backwards-out-of-a-contentinfo-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1611,7 +1611,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-12-navigate-backwards-out-of-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1660,7 +1660,7 @@
       <ul class="jaws">
         <li>Mode: reading</li>
         <li>Applies to: jaws</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-13-navigate-forwards-to-a-paragraph-inside-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1707,7 +1707,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-14-navigate-forwards-to-a-paragraph-inside-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1754,7 +1754,7 @@
       <ul class="jaws">
         <li>Mode: reading</li>
         <li>Applies to: jaws</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-15-navigate-backwards-to-a-paragraph-inside-a-contentinfo-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1801,7 +1801,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/contentinfo/test-16-navigate-backwards-to-a-paragraph-inside-a-contentinfo-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/datepicker-spin-button.html
+++ b/build/review/datepicker-spin-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-01-navigate-forwards-to-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -928,7 +928,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-02-navigate-backwards-to-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -1014,7 +1014,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-03-navigate-forwards-to-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1098,7 +1098,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-04-navigate-backwards-to-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1182,7 +1182,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-05-navigate-forwards-to-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1238,7 +1238,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-06-navigate-backwards-to-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1294,7 +1294,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-07-read-information-about-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -1375,7 +1375,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-08-read-information-about-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1456,7 +1456,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-09-read-information-about-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1509,7 +1509,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-10-decrement-spin-button-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1581,7 +1581,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-11-decrement-spin-button-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-12-increment-spin-button-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1700,7 +1700,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-13-increment-spin-button-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1747,7 +1747,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-14-decrement-spin-button-by-five-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1819,7 +1819,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-15-decrement-spin-button-by-five-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1866,7 +1866,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-16-increment-spin-button-by-five-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1938,7 +1938,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-17-increment-spin-button-by-five-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1985,7 +1985,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-18-decrement-spin-button-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2058,7 +2058,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-19-decrement-spin-button-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2106,7 +2106,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-20-increment-spin-button-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2178,7 +2178,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-21-increment-spin-button-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/datepicker-spin-button.html
+++ b/build/review/datepicker-spin-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-01-navigate-forwards-to-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -928,7 +928,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-02-navigate-backwards-to-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -1014,7 +1014,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-03-navigate-forwards-to-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1098,7 +1098,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-04-navigate-backwards-to-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1182,7 +1182,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-05-navigate-forwards-to-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1238,7 +1238,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-06-navigate-backwards-to-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1294,7 +1294,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-07-read-information-about-spin-button-reading.html?at=jaws">jaws</a></li>
@@ -1375,7 +1375,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-08-read-information-about-spin-button-interaction.html?at=jaws">jaws</a></li>
@@ -1456,7 +1456,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-09-read-information-about-spin-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1509,7 +1509,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-10-decrement-spin-button-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1581,7 +1581,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-11-decrement-spin-button-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-12-increment-spin-button-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1700,7 +1700,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-13-increment-spin-button-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1747,7 +1747,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-14-decrement-spin-button-by-five-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1819,7 +1819,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-15-decrement-spin-button-by-five-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1866,7 +1866,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-16-increment-spin-button-by-five-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1938,7 +1938,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-17-increment-spin-button-by-five-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1985,7 +1985,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-18-decrement-spin-button-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2058,7 +2058,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-19-decrement-spin-button-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2106,7 +2106,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-20-increment-spin-button-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2178,7 +2178,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/datepicker-spin-button/test-21-increment-spin-button-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-faq.html
+++ b/build/review/disclosure-faq.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1004,7 +1004,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1079,7 +1079,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1154,7 +1154,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1204,7 +1204,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1254,7 +1254,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1335,7 +1335,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1416,7 +1416,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1491,7 +1491,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1566,7 +1566,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1616,7 +1616,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1666,7 +1666,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1743,7 +1743,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1818,7 +1818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1867,7 +1867,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1944,7 +1944,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2019,7 +2019,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2068,7 +2068,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2141,7 +2141,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2214,7 +2214,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2262,7 +2262,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2335,7 +2335,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2408,7 +2408,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2456,7 +2456,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-25-navigate-from-expanded-disclosure-button-to-text-of-question-answer-reading.html?at=jaws">jaws</a></li>
@@ -2527,7 +2527,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-26-navigate-from-expanded-disclosure-button-to-text-of-question-answer-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-faq.html
+++ b/build/review/disclosure-faq.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1004,7 +1004,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1079,7 +1079,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1154,7 +1154,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1204,7 +1204,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1254,7 +1254,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1335,7 +1335,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1416,7 +1416,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1491,7 +1491,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1566,7 +1566,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1616,7 +1616,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1666,7 +1666,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1743,7 +1743,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1818,7 +1818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1867,7 +1867,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1944,7 +1944,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2019,7 +2019,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2068,7 +2068,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2141,7 +2141,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2214,7 +2214,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2262,7 +2262,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2335,7 +2335,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2408,7 +2408,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2456,7 +2456,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-25-navigate-from-expanded-disclosure-button-to-text-of-question-answer-reading.html?at=jaws">jaws</a></li>
@@ -2527,7 +2527,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-faq/test-26-navigate-from-expanded-disclosure-button-to-text-of-question-answer-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-navigation.html
+++ b/build/review/disclosure-navigation.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1004,7 +1004,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1079,7 +1079,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1160,7 +1160,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1210,7 +1210,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1341,7 +1341,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1422,7 +1422,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1497,7 +1497,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1572,7 +1572,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1621,7 +1621,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1671,7 +1671,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1748,7 +1748,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1823,7 +1823,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1872,7 +1872,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1949,7 +1949,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2024,7 +2024,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2073,7 +2073,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2146,7 +2146,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2219,7 +2219,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2267,7 +2267,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2340,7 +2340,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2413,7 +2413,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2461,7 +2461,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-25-navigate-from-expanded-disclosure-button-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2542,7 +2542,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-26-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -2620,7 +2620,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-27-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2671,7 +2671,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-28-navigate-from-expanded-disclosure-button-to-current-page-link-reading.html?at=jaws">jaws</a></li>
@@ -2755,7 +2755,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-29-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=jaws">jaws</a></li>
@@ -2836,7 +2836,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-30-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2889,7 +2889,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-31-navigate-from-dropdown-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2964,7 +2964,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-32-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -3039,7 +3039,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-33-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3087,7 +3087,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-34-navigate-forwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3164,7 +3164,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-35-navigate-backwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3241,7 +3241,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-36-navigate-forwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3317,7 +3317,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-37-navigate-backwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3393,7 +3393,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-38-navigate-forwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3443,7 +3443,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-39-navigate-backwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3493,7 +3493,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-40-navigate-to-first-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3565,7 +3565,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-41-navigate-to-last-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3637,7 +3637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-42-navigate-to-first-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3683,7 +3683,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-43-navigate-to-last-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3729,7 +3729,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-44-activate-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3805,7 +3805,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-45-activate-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3879,7 +3879,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-46-activate-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/disclosure-navigation.html
+++ b/build/review/disclosure-navigation.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-01-navigate-forwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-02-navigate-backwards-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1004,7 +1004,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-03-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1079,7 +1079,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-04-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1160,7 +1160,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-05-navigate-forwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1210,7 +1210,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-06-navigate-backwards-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-07-navigate-forwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1341,7 +1341,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-08-navigate-backwards-to-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1422,7 +1422,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-09-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1497,7 +1497,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-10-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1572,7 +1572,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-11-navigate-forwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1621,7 +1621,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-12-navigate-backwards-to-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1671,7 +1671,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-13-read-information-about-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1748,7 +1748,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-14-read-information-about-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -1823,7 +1823,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-15-read-information-about-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1872,7 +1872,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-16-read-information-about-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -1949,7 +1949,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-17-read-information-about-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2024,7 +2024,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-18-read-information-about-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2073,7 +2073,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-19-operate-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2146,7 +2146,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-20-operate-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2219,7 +2219,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-21-operate-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2267,7 +2267,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-22-operate-expanded-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2340,7 +2340,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-23-operate-expanded-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -2413,7 +2413,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-24-operate-expanded-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2461,7 +2461,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-25-navigate-from-expanded-disclosure-button-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -2542,7 +2542,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-26-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -2620,7 +2620,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-27-navigate-from-expanded-disclosure-button-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2671,7 +2671,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-28-navigate-from-expanded-disclosure-button-to-current-page-link-reading.html?at=jaws">jaws</a></li>
@@ -2755,7 +2755,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-29-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=jaws">jaws</a></li>
@@ -2836,7 +2836,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-30-navigate-from-expanded-disclosure-button-to-current-page-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2889,7 +2889,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-31-navigate-from-dropdown-to-collapsed-disclosure-button-reading.html?at=jaws">jaws</a></li>
@@ -2964,7 +2964,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-32-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=jaws">jaws</a></li>
@@ -3039,7 +3039,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-33-navigate-from-dropdown-to-collapsed-disclosure-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3087,7 +3087,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-34-navigate-forwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3164,7 +3164,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-35-navigate-backwards-to-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3241,7 +3241,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-36-navigate-forwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3317,7 +3317,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-37-navigate-backwards-to-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3393,7 +3393,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-38-navigate-forwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3443,7 +3443,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-39-navigate-backwards-to-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3493,7 +3493,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-40-navigate-to-first-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3565,7 +3565,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-41-navigate-to-last-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3637,7 +3637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-42-navigate-to-first-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3683,7 +3683,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-43-navigate-to-last-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3729,7 +3729,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-44-activate-link-in-dropdown-reading.html?at=jaws">jaws</a></li>
@@ -3805,7 +3805,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-45-activate-link-in-dropdown-interaction.html?at=jaws">jaws</a></li>
@@ -3879,7 +3879,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/disclosure-navigation/test-46-activate-link-in-dropdown-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/form.html
+++ b/build/review/form.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-01-navigate-forwards-into-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -927,7 +927,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-02-navigate-forwards-into-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1005,7 +1005,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-03-navigate-forwards-into-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1056,7 +1056,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-04-navigate-backwards-into-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1139,7 +1139,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-05-navigate-backwards-into-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1217,7 +1217,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-06-navigate-backwards-into-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1268,7 +1268,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-07-navigate-forwards-out-of-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1350,7 +1350,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-08-navigate-forwards-out-of-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1427,7 +1427,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-09-navigate-forwards-out-of-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1477,7 +1477,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-10-navigate-backwards-out-of-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1559,7 +1559,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-11-navigate-backwards-out-of-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1636,7 +1636,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-12-navigate-backwards-out-of-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-13-navigate-forwards-to-a-text-input-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1770,7 +1770,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-14-navigate-forwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1852,7 +1852,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-15-navigate-forwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1904,7 +1904,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-16-navigate-backwards-to-a-text-input-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1988,7 +1988,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-17-navigate-backwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -2070,7 +2070,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-18-navigate-backwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2122,7 +2122,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-19-navigate-forwards-to-a-button-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2204,7 +2204,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-20-navigate-backwards-to-a-button-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>

--- a/build/review/form.html
+++ b/build/review/form.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-01-navigate-forwards-into-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -927,7 +927,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-02-navigate-forwards-into-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1005,7 +1005,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-03-navigate-forwards-into-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1056,7 +1056,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-04-navigate-backwards-into-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1139,7 +1139,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-05-navigate-backwards-into-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1217,7 +1217,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-06-navigate-backwards-into-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1268,7 +1268,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-07-navigate-forwards-out-of-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1350,7 +1350,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-08-navigate-forwards-out-of-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1427,7 +1427,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-09-navigate-forwards-out-of-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1477,7 +1477,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-10-navigate-backwards-out-of-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1559,7 +1559,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-11-navigate-backwards-out-of-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1636,7 +1636,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-12-navigate-backwards-out-of-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-13-navigate-forwards-to-a-text-input-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1770,7 +1770,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-14-navigate-forwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1852,7 +1852,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-15-navigate-forwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1904,7 +1904,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-16-navigate-backwards-to-a-text-input-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1988,7 +1988,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-17-navigate-backwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -2070,7 +2070,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-18-navigate-backwards-to-a-text-input-inside-a-form-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2122,7 +2122,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-19-navigate-forwards-to-a-button-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>
@@ -2204,7 +2204,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/form/test-20-navigate-backwards-to-a-button-inside-a-form-landmark-reading.html?at=jaws">jaws</a></li>

--- a/build/review/horizontal-slider.html
+++ b/build/review/horizontal-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -929,7 +929,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1016,7 +1016,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1186,7 +1186,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1242,7 +1242,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1298,7 +1298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1385,7 +1385,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1472,7 +1472,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1528,7 +1528,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1601,7 +1601,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1648,7 +1648,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1721,7 +1721,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1768,7 +1768,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-14-increment-slider-by-ten-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1839,7 +1839,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-15-increment-slider-by-ten-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-16-decrement-slider-by-ten-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1956,7 +1956,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-17-decrement-slider-by-ten-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2002,7 +2002,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2074,7 +2074,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2193,7 +2193,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/horizontal-slider.html
+++ b/build/review/horizontal-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -929,7 +929,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1016,7 +1016,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1101,7 +1101,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1186,7 +1186,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1242,7 +1242,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1298,7 +1298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1385,7 +1385,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1472,7 +1472,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1528,7 +1528,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1601,7 +1601,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1648,7 +1648,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1721,7 +1721,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1768,7 +1768,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-14-increment-slider-by-ten-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1839,7 +1839,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-15-increment-slider-by-ten-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-16-decrement-slider-by-ten-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1956,7 +1956,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-17-decrement-slider-by-ten-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2002,7 +2002,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2074,7 +2074,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2193,7 +2193,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/horizontal-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/main.html
+++ b/build/review/main.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-01-navigate-forwards-into-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -925,7 +925,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-02-navigate-forwards-into-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-03-navigate-forwards-into-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1049,7 +1049,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-04-navigate-backwards-into-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-05-navigate-backwards-into-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1204,7 +1204,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-06-navigate-backwards-into-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1253,7 +1253,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-07-navigate-forwards-out-of-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1333,7 +1333,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-08-navigate-forwards-out-of-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1408,7 +1408,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-09-navigate-forwards-out-of-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1457,7 +1457,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-10-navigate-backwards-out-of-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1537,7 +1537,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-11-navigate-backwards-out-of-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1612,7 +1612,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-12-navigate-backwards-out-of-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1661,7 +1661,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-13-navigate-forwards-to-a-heading-inside-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1740,7 +1740,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-14-navigate-forwards-to-a-heading-inside-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1789,7 +1789,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-15-navigate-backwards-to-a-heading-inside-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1868,7 +1868,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-16-navigate-backwards-to-a-heading-inside-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/main.html
+++ b/build/review/main.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-01-navigate-forwards-into-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -925,7 +925,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-02-navigate-forwards-into-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-03-navigate-forwards-into-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1049,7 +1049,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-04-navigate-backwards-into-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1129,7 +1129,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-05-navigate-backwards-into-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1204,7 +1204,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-06-navigate-backwards-into-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1253,7 +1253,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-07-navigate-forwards-out-of-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1333,7 +1333,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-08-navigate-forwards-out-of-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1408,7 +1408,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-09-navigate-forwards-out-of-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1457,7 +1457,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-10-navigate-backwards-out-of-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1537,7 +1537,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-11-navigate-backwards-out-of-a-main-landmark-interaction.html?at=jaws">jaws</a></li>
@@ -1612,7 +1612,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-12-navigate-backwards-out-of-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1661,7 +1661,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-13-navigate-forwards-to-a-heading-inside-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1740,7 +1740,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-14-navigate-forwards-to-a-heading-inside-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1789,7 +1789,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-15-navigate-backwards-to-a-heading-inside-a-main-landmark-reading.html?at=jaws">jaws</a></li>
@@ -1868,7 +1868,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/main/test-16-navigate-backwards-to-a-heading-inside-a-main-landmark-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions-active-descendant.html
+++ b/build/review/menu-button-actions-active-descendant.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1442,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1528,7 +1528,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1672,7 +1672,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1756,7 +1756,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1810,7 +1810,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1890,7 +1890,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1941,7 +1941,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2021,7 +2021,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2072,7 +2072,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2203,7 +2203,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2281,7 +2281,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2331,7 +2331,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2404,7 +2404,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2452,7 +2452,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2525,7 +2525,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions-active-descendant.html
+++ b/build/review/menu-button-actions-active-descendant.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1442,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1528,7 +1528,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1616,7 +1616,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1672,7 +1672,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1756,7 +1756,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1810,7 +1810,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1890,7 +1890,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1941,7 +1941,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2021,7 +2021,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2072,7 +2072,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2203,7 +2203,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2281,7 +2281,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2331,7 +2331,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2404,7 +2404,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2452,7 +2452,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2525,7 +2525,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions-active-descendant/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions.html
+++ b/build/review/menu-button-actions.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1442,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1527,7 +1527,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1614,7 +1614,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1670,7 +1670,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1806,7 +1806,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1935,7 +1935,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2014,7 +2014,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2064,7 +2064,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2143,7 +2143,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2193,7 +2193,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2270,7 +2270,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2319,7 +2319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2392,7 +2392,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2440,7 +2440,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2513,7 +2513,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menu-button-actions.html
+++ b/build/review/menu-button-actions.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-01-navigate-forwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -921,7 +921,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-02-navigate-backwards-to-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1000,7 +1000,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-03-navigate-forwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1073,7 +1073,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-04-navigate-backwards-to-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-05-navigate-forwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1195,7 +1195,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-06-navigate-backwards-to-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-07-read-information-about-menu-button-reading.html?at=jaws">jaws</a></li>
@@ -1319,7 +1319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-08-read-information-about-menu-button-interaction.html?at=jaws">jaws</a></li>
@@ -1394,7 +1394,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-09-read-information-about-menu-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1442,7 +1442,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-10-open-menu-reading.html?at=jaws">jaws</a></li>
@@ -1527,7 +1527,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-11-open-menu-interaction.html?at=jaws">jaws</a></li>
@@ -1614,7 +1614,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-12-open-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1670,7 +1670,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-13-open-menu-to-last-item-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-14-open-menu-to-last-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1806,7 +1806,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-15-read-information-about-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-16-read-information-about-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1935,7 +1935,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-17-navigate-to-first-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2014,7 +2014,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-18-navigate-to-first-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2064,7 +2064,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-19-navigate-to-last-item-in-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2143,7 +2143,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-20-navigate-to-last-item-in-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2193,7 +2193,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-21-navigate-to-item-in-menu-by-typing-character-interaction.html?at=jaws">jaws</a></li>
@@ -2270,7 +2270,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-22-navigate-to-item-in-menu-by-typing-character-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2319,7 +2319,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-23-activate-menu-item-interaction.html?at=jaws">jaws</a></li>
@@ -2392,7 +2392,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-24-activate-menu-item-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2440,7 +2440,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-25-close-menu-interaction.html?at=jaws">jaws</a></li>
@@ -2513,7 +2513,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menu-button-actions/test-26-close-menu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menubar-editor.html
+++ b/build/review/menubar-editor.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -986,7 +986,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1067,7 +1067,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1197,7 +1197,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1266,7 +1266,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1345,7 +1345,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1396,7 +1396,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1475,7 +1475,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1525,7 +1525,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1605,7 +1605,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1657,7 +1657,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1735,7 +1735,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1785,7 +1785,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1914,7 +1914,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1992,7 +1992,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2043,7 +2043,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2123,7 +2123,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2175,7 +2175,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2261,7 +2261,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2316,7 +2316,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -2390,7 +2390,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -2474,7 +2474,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2528,7 +2528,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2612,7 +2612,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2696,7 +2696,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2750,7 +2750,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2834,7 +2834,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2918,7 +2918,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2972,7 +2972,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3056,7 +3056,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3140,7 +3140,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3194,7 +3194,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3278,7 +3278,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3362,7 +3362,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3416,7 +3416,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3498,7 +3498,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3580,7 +3580,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/menubar-editor.html
+++ b/build/review/menubar-editor.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-01-navigate-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -923,7 +923,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-02-activate-menubar-reading.html?at=jaws">jaws</a></li>
@@ -986,7 +986,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-03-tab-to-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1067,7 +1067,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-04-navigate-to-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-05-navigate-to-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1197,7 +1197,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-06-navigate-to-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -1266,7 +1266,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-07-navigate-to-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1345,7 +1345,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-08-navigate-to-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1396,7 +1396,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-09-navigate-to-open-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1475,7 +1475,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-10-navigate-to-open-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1525,7 +1525,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-11-open-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1605,7 +1605,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-12-open-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1657,7 +1657,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-13-close-submenu-of-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -1735,7 +1735,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-14-close-submenu-of-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1785,7 +1785,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-15-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-16-navigate-to-checked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1914,7 +1914,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-17-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -1992,7 +1992,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-18-navigate-to-unchecked-menuitemradio-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2043,7 +2043,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-19-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2123,7 +2123,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-20-navigate-to-unchecked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2175,7 +2175,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-21-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2261,7 +2261,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-22-navigate-to-checked-menuitemcheckbox-in-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2316,7 +2316,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-23-read-menuitem-in-menubar-reading.html?at=jaws">jaws</a></li>
@@ -2390,7 +2390,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-24-read-menuitem-in-menubar-interaction.html?at=jaws">jaws</a></li>
@@ -2474,7 +2474,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-25-read-menuitem-in-menubar-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2528,7 +2528,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-26-read-unchecked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2612,7 +2612,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-27-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2696,7 +2696,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-28-read-unchecked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2750,7 +2750,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-29-read-checked-menuitemradio-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -2834,7 +2834,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-30-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -2918,7 +2918,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-31-read-checked-menuitemradio-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2972,7 +2972,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-32-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3056,7 +3056,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-33-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3140,7 +3140,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-34-read-unchecked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3194,7 +3194,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-35-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3278,7 +3278,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-36-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3362,7 +3362,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-37-read-checked-menuitemcheckbox-in-a-group-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3416,7 +3416,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-38-read-disabled-menuitem-in-a-submenu-reading.html?at=jaws">jaws</a></li>
@@ -3498,7 +3498,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-39-read-disabled-menuitem-in-a-submenu-interaction.html?at=jaws">jaws</a></li>
@@ -3580,7 +3580,7 @@ Navigate to &#39;Italic&#39; menu item checkbox using the following commands:
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/menubar-editor/test-40-read-disabled-menuitem-in-a-submenu-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/meter.html
+++ b/build/review/meter.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-01-navigate-forwards-to-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -925,7 +925,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-02-navigate-forwards-to-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -979,7 +979,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-03-navigate-backwards-to-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -1062,7 +1062,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-04-navigate-backwards-to-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1116,7 +1116,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-05-read-information-about-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -1201,7 +1201,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-06-read-information-about-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-07-trigger-a-meter-update-reading.html?at=jaws">jaws</a></li>
@@ -1329,7 +1329,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-08-trigger-a-meter-update-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-09-trigger-a-meter-update-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/meter.html
+++ b/build/review/meter.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-01-navigate-forwards-to-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -925,7 +925,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-02-navigate-forwards-to-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -979,7 +979,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-03-navigate-backwards-to-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -1062,7 +1062,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-04-navigate-backwards-to-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1116,7 +1116,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-05-read-information-about-a-meter-reading.html?at=jaws">jaws</a></li>
@@ -1201,7 +1201,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-06-read-information-about-a-meter-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-07-trigger-a-meter-update-reading.html?at=jaws">jaws</a></li>
@@ -1329,7 +1329,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-08-trigger-a-meter-update-interaction.html?at=jaws">jaws</a></li>
@@ -1402,7 +1402,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/meter/test-09-trigger-a-meter-update-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/minimal-data-grid.html
+++ b/build/review/minimal-data-grid.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-01-navigate-forwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -926,7 +926,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-02-navigate-backwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -1008,7 +1008,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-03-navigate-forwards-to-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1061,7 +1061,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-04-navigate-into-end-of-grid-reading.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-05-navigate-into-end-of-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1199,7 +1199,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-06-move-focus-forwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1283,7 +1283,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-07-move-focus-backwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1367,7 +1367,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-08-move-focus-forwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-09-move-focus-backwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1535,7 +1535,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-10-move-focus-forwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1588,7 +1588,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-11-move-focus-backwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1641,7 +1641,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-12-read-information-about-grid-cell-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-13-read-information-about-grid-cell-interaction.html?at=jaws">jaws</a></li>
@@ -1793,7 +1793,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-14-read-information-about-grid-cell-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1841,7 +1841,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-15-read-information-about-grid-cell-containing-link-reading.html?at=jaws">jaws</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-16-read-information-about-grid-cell-containing-link-interaction.html?at=jaws">jaws</a></li>
@@ -1997,7 +1997,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-17-read-information-about-grid-cell-containing-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-18-navigate-to-next-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2120,7 +2120,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-19-navigate-to-next-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2194,7 +2194,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-20-navigate-to-next-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2243,7 +2243,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-21-navigate-to-previous-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2317,7 +2317,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-22-navigate-to-previous-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2391,7 +2391,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-23-navigate-to-previous-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2440,7 +2440,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-24-navigate-to-next-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2519,7 +2519,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-25-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2596,7 +2596,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-26-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2647,7 +2647,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-27-navigate-to-previous-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2726,7 +2726,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-28-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2802,7 +2802,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-29-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2853,7 +2853,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-30-navigate-to-next-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2927,7 +2927,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-31-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3001,7 +3001,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-32-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3050,7 +3050,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-33-navigate-to-previous-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3124,7 +3124,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-34-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3198,7 +3198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-35-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3248,7 +3248,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-36-navigate-to-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3322,7 +3322,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-37-navigate-to-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3396,7 +3396,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-38-navigate-to-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3444,7 +3444,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-39-navigate-to-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3518,7 +3518,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-40-navigate-to-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3592,7 +3592,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-41-navigate-to-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3640,7 +3640,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-42-navigate-to-cell-containing-link-on-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3716,7 +3716,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-43-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3792,7 +3792,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-44-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3841,7 +3841,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-45-navigate-to-cell-containing-link-on-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3917,7 +3917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-46-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3993,7 +3993,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-47-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4042,7 +4042,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-48-navigate-to-first-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4116,7 +4116,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-49-navigate-to-first-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4163,7 +4163,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-50-navigate-to-last-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4237,7 +4237,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-51-navigate-to-last-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4284,7 +4284,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-52-navigate-to-first-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4358,7 +4358,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-53-navigate-to-first-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4405,7 +4405,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-54-navigate-to-last-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4479,7 +4479,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-55-navigate-to-last-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/minimal-data-grid.html
+++ b/build/review/minimal-data-grid.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-01-navigate-forwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -926,7 +926,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-02-navigate-backwards-to-grid-reading.html?at=jaws">jaws</a></li>
@@ -1008,7 +1008,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-03-navigate-forwards-to-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1061,7 +1061,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-04-navigate-into-end-of-grid-reading.html?at=jaws">jaws</a></li>
@@ -1146,7 +1146,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-05-navigate-into-end-of-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1199,7 +1199,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-06-move-focus-forwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1283,7 +1283,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-07-move-focus-backwards-into-grid-reading.html?at=jaws">jaws</a></li>
@@ -1367,7 +1367,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-08-move-focus-forwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1451,7 +1451,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-09-move-focus-backwards-into-grid-interaction.html?at=jaws">jaws</a></li>
@@ -1535,7 +1535,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-10-move-focus-forwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1588,7 +1588,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-11-move-focus-backwards-into-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1641,7 +1641,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-12-read-information-about-grid-cell-reading.html?at=jaws">jaws</a></li>
@@ -1717,7 +1717,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-13-read-information-about-grid-cell-interaction.html?at=jaws">jaws</a></li>
@@ -1793,7 +1793,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-14-read-information-about-grid-cell-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1841,7 +1841,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-15-read-information-about-grid-cell-containing-link-reading.html?at=jaws">jaws</a></li>
@@ -1919,7 +1919,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-16-read-information-about-grid-cell-containing-link-interaction.html?at=jaws">jaws</a></li>
@@ -1997,7 +1997,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-17-read-information-about-grid-cell-containing-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-18-navigate-to-next-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2120,7 +2120,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-19-navigate-to-next-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2194,7 +2194,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-20-navigate-to-next-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2243,7 +2243,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-21-navigate-to-previous-colum-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2317,7 +2317,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-22-navigate-to-previous-colum-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2391,7 +2391,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-23-navigate-to-previous-colum-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2440,7 +2440,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-24-navigate-to-next-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2519,7 +2519,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-25-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2596,7 +2596,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-26-navigate-to-next-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2647,7 +2647,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-27-navigate-to-previous-colum-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2726,7 +2726,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-28-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -2802,7 +2802,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-29-navigate-to-previous-colum-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2853,7 +2853,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-30-navigate-to-next-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -2927,7 +2927,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-31-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3001,7 +3001,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-32-navigate-to-next-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3050,7 +3050,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-33-navigate-to-previous-column-from-cel-containing-link-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3124,7 +3124,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-34-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3198,7 +3198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-35-navigate-to-previous-column-from-cel-containing-link-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3248,7 +3248,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-36-navigate-to-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3322,7 +3322,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-37-navigate-to-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3396,7 +3396,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-38-navigate-to-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3444,7 +3444,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-39-navigate-to-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3518,7 +3518,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-40-navigate-to-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3592,7 +3592,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-41-navigate-to-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3640,7 +3640,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-42-navigate-to-cell-containing-link-on-next-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3716,7 +3716,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-43-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3792,7 +3792,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-44-navigate-to-cell-containing-link-on-next-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3841,7 +3841,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-45-navigate-to-cell-containing-link-on-previous-row-in-grid-reading.html?at=jaws">jaws</a></li>
@@ -3917,7 +3917,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-46-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -3993,7 +3993,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-47-navigate-to-cell-containing-link-on-previous-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4042,7 +4042,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-48-navigate-to-first-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4116,7 +4116,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-49-navigate-to-first-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4163,7 +4163,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-50-navigate-to-last-cell-of-row-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4237,7 +4237,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-51-navigate-to-last-cell-of-row-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4284,7 +4284,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-52-navigate-to-first-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4358,7 +4358,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-53-navigate-to-first-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -4405,7 +4405,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-54-navigate-to-last-cell-in-grid-interaction.html?at=jaws">jaws</a></li>
@@ -4479,7 +4479,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/minimal-data-grid/test-55-navigate-to-last-cell-in-grid-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/modal-dialog.html
+++ b/build/review/modal-dialog.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -922,7 +922,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1002,7 +1002,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1054,7 +1054,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1126,7 +1126,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1318,7 +1318,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1392,7 +1392,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1440,7 +1440,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1512,7 +1512,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1558,7 +1558,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1630,7 +1630,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1676,7 +1676,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1750,7 +1750,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1797,7 +1797,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1869,7 +1869,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1915,7 +1915,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2081,7 +2081,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2135,7 +2135,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -2213,7 +2213,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2291,7 +2291,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2341,7 +2341,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -2421,7 +2421,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -2501,7 +2501,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2553,7 +2553,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2634,7 +2634,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2715,7 +2715,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/modal-dialog.html
+++ b/build/review/modal-dialog.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-01-open-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -922,7 +922,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-02-open-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1002,7 +1002,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-03-open-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1054,7 +1054,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-04-close-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1126,7 +1126,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-05-close-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-06-close-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1244,7 +1244,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-07-close-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -1318,7 +1318,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-08-close-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -1392,7 +1392,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-09-close-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1440,7 +1440,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-10-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1512,7 +1512,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-11-navigate-to-last-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1558,7 +1558,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-12-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -1630,7 +1630,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-13-navigate-to-first-focusable-element-in-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1676,7 +1676,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-14-navigate-to-beginning-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1750,7 +1750,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-15-navigate-to-beginning-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1797,7 +1797,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-16-navigate-to-end-of-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1869,7 +1869,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-17-navigate-to-end-of-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1915,7 +1915,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-18-open-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-19-open-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2081,7 +2081,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-20-open-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2135,7 +2135,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-21-close-nested-modal-dialog-reading.html?at=jaws">jaws</a></li>
@@ -2213,7 +2213,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-22-close-nested-modal-dialog-interaction.html?at=jaws">jaws</a></li>
@@ -2291,7 +2291,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-23-close-nested-modal-dialog-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2341,7 +2341,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-24-close-nested-modal-dialog-using-button-reading.html?at=jaws">jaws</a></li>
@@ -2421,7 +2421,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-25-close-nested-modal-dialog-using-button-interaction.html?at=jaws">jaws</a></li>
@@ -2501,7 +2501,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-26-close-nested-modal-dialog-using-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2553,7 +2553,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-27-open-nested-modal-dialog-using-link-reading.html?at=jaws">jaws</a></li>
@@ -2634,7 +2634,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-28-open-nested-modal-dialog-using-link-interaction.html?at=jaws">jaws</a></li>
@@ -2715,7 +2715,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/modal-dialog/test-29-open-nested-modal-dialog-using-link-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-aria-activedescendant.html
+++ b/build/review/radiogroup-aria-activedescendant.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -933,7 +933,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -990,7 +990,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1081,7 +1081,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1138,7 +1138,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1229,7 +1229,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1286,7 +1286,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1377,7 +1377,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1434,7 +1434,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1521,7 +1521,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1577,7 +1577,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1664,7 +1664,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1720,7 +1720,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1807,7 +1807,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2006,7 +2006,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2088,7 +2088,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2168,7 +2168,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2220,7 +2220,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2302,7 +2302,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2382,7 +2382,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2434,7 +2434,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2517,7 +2517,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2600,7 +2600,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2653,7 +2653,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2736,7 +2736,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2819,7 +2819,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2872,7 +2872,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2955,7 +2955,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3009,7 +3009,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3092,7 +3092,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3146,7 +3146,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3229,7 +3229,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3282,7 +3282,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3365,7 +3365,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3418,7 +3418,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3489,7 +3489,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3560,7 +3560,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-aria-activedescendant.html
+++ b/build/review/radiogroup-aria-activedescendant.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -933,7 +933,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -990,7 +990,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1081,7 +1081,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1138,7 +1138,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1229,7 +1229,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1286,7 +1286,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1377,7 +1377,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1434,7 +1434,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1521,7 +1521,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1577,7 +1577,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1664,7 +1664,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1720,7 +1720,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1807,7 +1807,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1863,7 +1863,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1950,7 +1950,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2006,7 +2006,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2088,7 +2088,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2168,7 +2168,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2220,7 +2220,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2302,7 +2302,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2382,7 +2382,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2434,7 +2434,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2517,7 +2517,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2600,7 +2600,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2653,7 +2653,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2736,7 +2736,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2819,7 +2819,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2872,7 +2872,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2955,7 +2955,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3009,7 +3009,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3092,7 +3092,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3146,7 +3146,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3229,7 +3229,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3282,7 +3282,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3365,7 +3365,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3418,7 +3418,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3489,7 +3489,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3560,7 +3560,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-aria-activedescendant/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-roving-tabindex.html
+++ b/build/review/radiogroup-roving-tabindex.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -988,7 +988,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1078,7 +1078,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1134,7 +1134,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1224,7 +1224,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1280,7 +1280,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1370,7 +1370,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1426,7 +1426,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1512,7 +1512,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1567,7 +1567,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1653,7 +1653,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1708,7 +1708,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1794,7 +1794,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1849,7 +1849,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1935,7 +1935,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1990,7 +1990,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2072,7 +2072,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2204,7 +2204,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2366,7 +2366,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2418,7 +2418,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2500,7 +2500,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2582,7 +2582,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2634,7 +2634,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2716,7 +2716,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2798,7 +2798,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2850,7 +2850,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2932,7 +2932,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2985,7 +2985,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3067,7 +3067,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3120,7 +3120,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3202,7 +3202,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3254,7 +3254,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3336,7 +3336,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3388,7 +3388,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3459,7 +3459,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3530,7 +3530,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/radiogroup-roving-tabindex.html
+++ b/build/review/radiogroup-roving-tabindex.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-01-navigate-to-first-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-02-navigate-to-first-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -988,7 +988,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-03-navigate-to-last-unchecked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1078,7 +1078,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-04-navigate-to-last-unchecked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1134,7 +1134,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-05-navigate-to-first-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1224,7 +1224,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-06-navigate-to-first-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1280,7 +1280,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-07-navigate-to-last-checked-radio-button-in-group-reading.html?at=jaws">jaws</a></li>
@@ -1370,7 +1370,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-08-navigate-to-last-checked-radio-button-in-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1426,7 +1426,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-09-navigate-forwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1512,7 +1512,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-10-navigate-forwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1567,7 +1567,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-11-navigate-backwards-to-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1653,7 +1653,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-12-navigate-backwards-to-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1708,7 +1708,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-13-navigate-forwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1794,7 +1794,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-14-navigate-forwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1849,7 +1849,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-15-navigate-backwards-to-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -1935,7 +1935,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-16-navigate-backwards-to-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1990,7 +1990,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-17-navigate-out-of-start-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2072,7 +2072,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-18-navigate-out-of-start-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2152,7 +2152,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-19-navigate-out-of-start-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2204,7 +2204,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-20-navigate-out-of-end-of-radio-group-reading.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-21-navigate-out-of-end-of-radio-group-interaction.html?at=jaws">jaws</a></li>
@@ -2366,7 +2366,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-22-navigate-out-of-end-of-radio-group-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2418,7 +2418,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-23-read-information-about-unchecked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2500,7 +2500,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-24-read-information-about-unchecked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2582,7 +2582,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-25-read-information-about-unchecked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2634,7 +2634,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-26-read-information-about-checked-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -2716,7 +2716,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-27-read-information-about-checked-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2798,7 +2798,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-28-read-information-about-checked-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2850,7 +2850,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-29-navigate-to-next-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -2932,7 +2932,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-30-navigate-to-next-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2985,7 +2985,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-31-navigate-to-previous-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3067,7 +3067,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-32-navigate-to-previous-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3120,7 +3120,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-33-navigate-to-first-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3202,7 +3202,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-34-navigate-to-first-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3254,7 +3254,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-35-navigate-to-last-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3336,7 +3336,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-36-navigate-to-last-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -3388,7 +3388,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-37-check-radio-button-reading.html?at=jaws">jaws</a></li>
@@ -3459,7 +3459,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-38-check-radio-button-interaction.html?at=jaws">jaws</a></li>
@@ -3530,7 +3530,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/radiogroup-roving-tabindex/test-39-check-radio-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/rating-slider.html
+++ b/build/review/rating-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1314,7 +1314,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1404,7 +1404,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1494,7 +1494,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1552,7 +1552,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-10-increment-slider-by-one-half-star-interaction.html?at=jaws">jaws</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-11-increment-slider-by-one-half-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1677,7 +1677,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-12-decrement-slider-by-one-half-star-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-13-decrement-slider-by-one-half-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1802,7 +1802,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-14-increment-slider-by-one-star-interaction.html?at=jaws">jaws</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-15-increment-slider-by-one-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1924,7 +1924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-16-decrement-slider-by-one-star-interaction.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-17-decrement-slider-by-one-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2170,7 +2170,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2245,7 +2245,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/rating-slider.html
+++ b/build/review/rating-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1314,7 +1314,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1404,7 +1404,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1494,7 +1494,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1552,7 +1552,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-10-increment-slider-by-one-half-star-interaction.html?at=jaws">jaws</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-11-increment-slider-by-one-half-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1677,7 +1677,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-12-decrement-slider-by-one-half-star-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-13-decrement-slider-by-one-half-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1802,7 +1802,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-14-increment-slider-by-one-star-interaction.html?at=jaws">jaws</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-15-increment-slider-by-one-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1924,7 +1924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-16-decrement-slider-by-one-star-interaction.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-17-decrement-slider-by-one-star-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2170,7 +2170,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2245,7 +2245,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/rating-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/seek-slider.html
+++ b/build/review/seek-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1314,7 +1314,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1404,7 +1404,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1494,7 +1494,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1552,7 +1552,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1677,7 +1677,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1802,7 +1802,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-14-increment-slider-by-fifteen-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-15-increment-slider-by-fifteen-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1924,7 +1924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-16-decrement-slider-by-fifteen-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-17-decrement-slider-by-fifteen-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2170,7 +2170,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2245,7 +2245,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/seek-slider.html
+++ b/build/review/seek-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -932,7 +932,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1022,7 +1022,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1110,7 +1110,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1198,7 +1198,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1256,7 +1256,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1314,7 +1314,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1404,7 +1404,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1494,7 +1494,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1552,7 +1552,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1628,7 +1628,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1677,7 +1677,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1753,7 +1753,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1802,7 +1802,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-14-increment-slider-by-fifteen-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1876,7 +1876,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-15-increment-slider-by-fifteen-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1924,7 +1924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-16-decrement-slider-by-fifteen-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1998,7 +1998,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-17-decrement-slider-by-fifteen-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2046,7 +2046,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2121,7 +2121,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2170,7 +2170,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2245,7 +2245,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/seek-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/switch.html
+++ b/build/review/switch.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-01-navigate-forwards-to-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-02-navigate-forwards-to-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1001,7 +1001,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-03-navigate-forwards-to-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1053,7 +1053,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-04-navigate-backwards-to-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -1135,7 +1135,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-05-navigate-backwards-to-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1212,7 +1212,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-06-navigate-backwards-to-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1264,7 +1264,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-07-navigate-forwards-to-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1346,7 +1346,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-08-navigate-forwards-to-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -1423,7 +1423,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-09-navigate-forwards-to-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1475,7 +1475,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-10-navigate-backwards-to-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1557,7 +1557,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-11-navigate-backwards-to-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -1634,7 +1634,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-12-navigate-backwards-to-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-13-read-information-about-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -1765,7 +1765,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-14-read-information-about-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1844,7 +1844,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-15-read-information-about-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1895,7 +1895,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-16-read-information-about-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1974,7 +1974,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-17-read-information-about-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -2053,7 +2053,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-18-read-information-about-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2104,7 +2104,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-19-operate-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -2177,7 +2177,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-20-operate-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -2250,7 +2250,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-21-operate-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2298,7 +2298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-22-operate-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -2371,7 +2371,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-23-operate-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -2444,7 +2444,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-24-operate-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/switch.html
+++ b/build/review/switch.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-01-navigate-forwards-to-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-02-navigate-forwards-to-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1001,7 +1001,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-03-navigate-forwards-to-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1053,7 +1053,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-04-navigate-backwards-to-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -1135,7 +1135,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-05-navigate-backwards-to-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1212,7 +1212,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-06-navigate-backwards-to-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1264,7 +1264,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-07-navigate-forwards-to-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1346,7 +1346,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-08-navigate-forwards-to-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -1423,7 +1423,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-09-navigate-forwards-to-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1475,7 +1475,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-10-navigate-backwards-to-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1557,7 +1557,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-11-navigate-backwards-to-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -1634,7 +1634,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-12-navigate-backwards-to-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-13-read-information-about-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -1765,7 +1765,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-14-read-information-about-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -1844,7 +1844,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-15-read-information-about-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1895,7 +1895,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-16-read-information-about-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -1974,7 +1974,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-17-read-information-about-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -2053,7 +2053,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-18-read-information-about-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2104,7 +2104,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-19-operate-a-switch-in-the-off-state-reading.html?at=jaws">jaws</a></li>
@@ -2177,7 +2177,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-20-operate-a-switch-in-the-off-state-interaction.html?at=jaws">jaws</a></li>
@@ -2250,7 +2250,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-21-operate-a-switch-in-the-off-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2298,7 +2298,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-22-operate-a-switch-in-the-on-state-reading.html?at=jaws">jaws</a></li>
@@ -2371,7 +2371,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-23-operate-a-switch-in-the-on-state-interaction.html?at=jaws">jaws</a></li>
@@ -2444,7 +2444,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/switch/test-24-operate-a-switch-in-the-on-state-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/tabs-manual-activation.html
+++ b/build/review/tabs-manual-activation.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1020,7 +1020,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1107,7 +1107,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1194,7 +1194,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1310,7 +1310,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1393,7 +1393,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1476,7 +1476,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1529,7 +1529,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1607,7 +1607,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1685,7 +1685,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1735,7 +1735,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1816,7 +1816,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1897,7 +1897,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1949,7 +1949,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2030,7 +2030,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2082,7 +2082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2210,7 +2210,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2362,7 +2362,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2412,7 +2412,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2462,7 +2462,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2535,7 +2535,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2608,7 +2608,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2656,7 +2656,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2737,7 +2737,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2818,7 +2818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/tabs-manual-activation.html
+++ b/build/review/tabs-manual-activation.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-01-navigate-forwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -931,7 +931,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-02-navigate-backwards-to-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1020,7 +1020,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-03-navigate-forwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1107,7 +1107,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-04-navigate-backwards-to-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1194,7 +1194,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-05-navigate-forwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1252,7 +1252,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-06-navigate-backwards-to-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1310,7 +1310,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-07-read-information-about-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1393,7 +1393,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-08-read-information-about-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1476,7 +1476,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-09-read-information-about-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1529,7 +1529,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-10-navigate-to-next-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1607,7 +1607,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-11-navigate-to-next-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1685,7 +1685,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-12-navigate-to-next-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1735,7 +1735,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-13-navigate-to-previous-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -1816,7 +1816,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-14-navigate-to-previous-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -1897,7 +1897,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-15-navigate-to-previous-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1949,7 +1949,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-16-navigate-to-first-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2030,7 +2030,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-17-navigate-to-first-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2082,7 +2082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-18-navigate-to-last-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2160,7 +2160,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-19-navigate-to-last-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2210,7 +2210,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-20-navigate-forwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2286,7 +2286,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-21-navigate-backwards-to-tab-panel-interaction.html?at=jaws">jaws</a></li>
@@ -2362,7 +2362,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-22-navigate-forwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2412,7 +2412,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-23-navigate-backwards-to-tab-panel-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2462,7 +2462,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-24-activate-tab-in-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2535,7 +2535,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-25-activate-tab-in-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2608,7 +2608,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-26-activate-tab-in-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2656,7 +2656,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-27-delete-tab-from-tab-list-reading.html?at=jaws">jaws</a></li>
@@ -2737,7 +2737,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-28-delete-tab-from-tab-list-interaction.html?at=jaws">jaws</a></li>
@@ -2818,7 +2818,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/tabs-manual-activation/test-29-delete-tab-from-tab-list-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/toggle-button.html
+++ b/build/review/toggle-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-01-navigate-forwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-02-navigate-backwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1006,7 +1006,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-03-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1082,7 +1082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-04-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1158,7 +1158,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-05-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1209,7 +1209,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-06-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-07-navigate-forwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1342,7 +1342,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-08-navigate-backwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1424,7 +1424,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-09-navigate-forwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1500,7 +1500,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-10-navigate-backwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1576,7 +1576,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-11-navigate-forwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1627,7 +1627,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-12-navigate-backwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1678,7 +1678,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-13-read-information-about-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1756,7 +1756,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-14-read-information-about-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1834,7 +1834,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-15-read-information-about-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1884,7 +1884,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-16-read-information-about-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1962,7 +1962,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-17-read-information-about-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2040,7 +2040,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-18-read-information-about-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2090,7 +2090,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-19-operate-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2164,7 +2164,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-20-operate-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2238,7 +2238,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-21-operate-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2288,7 +2288,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-22-operate-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2362,7 +2362,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-23-operate-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2436,7 +2436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-24-operate-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/toggle-button.html
+++ b/build/review/toggle-button.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-01-navigate-forwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -924,7 +924,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-02-navigate-backwards-to-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1006,7 +1006,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-03-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1082,7 +1082,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-04-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1158,7 +1158,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-05-navigate-forwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1209,7 +1209,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-06-navigate-backwards-to-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1260,7 +1260,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-07-navigate-forwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1342,7 +1342,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-08-navigate-backwards-to-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1424,7 +1424,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-09-navigate-forwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1500,7 +1500,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-10-navigate-backwards-to-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1576,7 +1576,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-11-navigate-forwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1627,7 +1627,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-12-navigate-backwards-to-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1678,7 +1678,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-13-read-information-about-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1756,7 +1756,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-14-read-information-about-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -1834,7 +1834,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-15-read-information-about-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1884,7 +1884,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-16-read-information-about-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -1962,7 +1962,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-17-read-information-about-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2040,7 +2040,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-18-read-information-about-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2090,7 +2090,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-19-operate-not-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2164,7 +2164,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-20-operate-not-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2238,7 +2238,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-21-operate-not-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2288,7 +2288,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-22-operate-pressed-toggle-button-reading.html?at=jaws">jaws</a></li>
@@ -2362,7 +2362,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-23-operate-pressed-toggle-button-interaction.html?at=jaws">jaws</a></li>
@@ -2436,7 +2436,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/toggle-button/test-24-operate-pressed-toggle-button-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/vertical-temperature-slider.html
+++ b/build/review/vertical-temperature-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -933,7 +933,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1024,7 +1024,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1113,7 +1113,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1202,7 +1202,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1261,7 +1261,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1320,7 +1320,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1411,7 +1411,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1502,7 +1502,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1561,7 +1561,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1637,7 +1637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1762,7 +1762,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1811,7 +1811,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-14-increment-slider-by-twenty-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-15-increment-slider-by-twenty-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1933,7 +1933,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-16-decrement-slider-by-twenty-steps-interaction.html?at=jaws">jaws</a></li>
@@ -2007,7 +2007,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-17-decrement-slider-by-twenty-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2055,7 +2055,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2130,7 +2130,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2179,7 +2179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2254,7 +2254,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
+        <li>Last edited: Tue Feb 8 14:56:03 2022 +0000</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/build/review/vertical-temperature-slider.html
+++ b/build/review/vertical-temperature-slider.html
@@ -842,7 +842,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-01-navigate-forwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -933,7 +933,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-02-navigate-backwards-to-slider-reading.html?at=jaws">jaws</a></li>
@@ -1024,7 +1024,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-03-navigate-forwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1113,7 +1113,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-04-navigate-backwards-to-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1202,7 +1202,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-05-navigate-forwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1261,7 +1261,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-06-navigate-backwards-to-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1320,7 +1320,7 @@
       <ul class="jaws nvda">
         <li>Mode: reading</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-07-read-information-about-slider-reading.html?at=jaws">jaws</a></li>
@@ -1411,7 +1411,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-08-read-information-about-slider-interaction.html?at=jaws">jaws</a></li>
@@ -1502,7 +1502,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-09-read-information-about-slider-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1561,7 +1561,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-10-increment-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1637,7 +1637,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-11-increment-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1686,7 +1686,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-12-decrement-slider-by-one-step-interaction.html?at=jaws">jaws</a></li>
@@ -1762,7 +1762,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-13-decrement-slider-by-one-step-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1811,7 +1811,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-14-increment-slider-by-twenty-steps-interaction.html?at=jaws">jaws</a></li>
@@ -1885,7 +1885,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-15-increment-slider-by-twenty-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -1933,7 +1933,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-16-decrement-slider-by-twenty-steps-interaction.html?at=jaws">jaws</a></li>
@@ -2007,7 +2007,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-17-decrement-slider-by-twenty-steps-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2055,7 +2055,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-18-decrement-slider-to-minimum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2130,7 +2130,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-19-decrement-slider-to-minimum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>
@@ -2179,7 +2179,7 @@
       <ul class="jaws nvda">
         <li>Mode: interaction</li>
         <li>Applies to: jaws, nvda</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-20-increment-slider-to-maximum-value-interaction.html?at=jaws">jaws</a></li>
@@ -2254,7 +2254,7 @@
       <ul class="voiceover_macos">
         <li>Mode: interaction</li>
         <li>Applies to: voiceover_macos</li>
-        <li>Last edited: Thu Feb 3 16:00:56 2022 +0000</li>
+        <li>Last edited: Tue Feb 8 09:44:35 2022 -0500</li>
         <li>Tests:
           <ul>
               <li><a href="../tests/vertical-temperature-slider/test-21-increment-slider-to-maximum-value-interaction.html?at=voiceover_macos">voiceover_macos</a></li>

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -813,7 +813,9 @@ function readCSV(record) {
         csv({
           mapHeaders: ({ header, index }) => {
             if (header.toLowerCase().includes('\ufeff'))
-              console.error(`Unwanted U+FEFF found for key ${header} at index ${index} while processing CSV.`);
+              console.error(
+                `Unwanted U+FEFF found for key ${header} at index ${index} while processing CSV.`
+              );
             return header.replace(/^\uFEFF/g, '');
           },
           mapValues: ({ header, value }) => {

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -801,7 +801,6 @@ function exampleTemplateParams(name, source) {
   };
 }
 
-
 function cleanObjectBOM(obj) {
   const result = {};
 

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -801,6 +801,24 @@ function exampleTemplateParams(name, source) {
   };
 }
 
+
+function cleanObjectBOM(obj) {
+  const result = {};
+
+  Object.entries(obj).forEach(([key, value]) => {
+    if (key.toLowerCase().includes('\ufeff'))
+      console.error(
+        `Unwanted U+FEFF found for key in key, value pair (${key}: ${value}) while processing CSVs.`
+      );
+    if (value.toLowerCase().includes('\ufeff'))
+      console.error(
+        `Unwanted U+FEFF found for value in key, value pair (${key}: ${value}) while processing CSVs.`
+      );
+    result[key.replace(/^\uFEFF/g, '')] = value.replace(/^\uFEFF/g, '');
+  });
+  return result;
+}
+
 /**
  * @param {FileRecord.Record} record
  * @returns {Promise<string[][]>}
@@ -811,7 +829,7 @@ function readCSV(record) {
     Readable.from(record.buffer)
       .pipe(csv())
       .on('data', row => {
-        rows.push(row);
+        rows.push(cleanObjectBOM(row));
       })
       .on('end', () => {
         resolve(rows);


### PR DESCRIPTION
[Preview Tests](https://raw.githack.com/w3c/aria-at/bocoup/fix-issue-590/build/index.html)

Address #590.

Based on https://github.com/w3c/aria-at/issues/590#issuecomment-1021413237

> @s3ththompson 
> .. I'm not sure yet whether it's appropriate to silently ignore the BOM mark, but it does seem like we should be able to at least warn when it's encountered.

I've gone ahead and logged a warning message back to the terminal of its presence, as we're currently unsure of any other side effects it may cause (although I haven't come across any others while testing) so removing it would be ideal.

It is also removed from the CSV being processed, to allow for the script to continue running as expected.