### PR TITLE
chore: quote Dependabot branch filter

### DIFF
--- a/.github/workflows/generate-and-commit-files.yml
+++ b/.github/workflows/generate-and-commit-files.yml
@@ -3,7 +3,7 @@ name: Generate and Commit Files
 on:
   pull_request:
     branches-ignore:
-      - dependabot/**
+      - 'dependabot/**'
 
 jobs:
   generate-and-commit-files:


### PR DESCRIPTION
Seems like it's still running on the Dependabot PRs, although not pushing anymore. Trying this to see if it will properly skip the job entirely.