### PR TITLE
chore: build but don't push for Dependabot

### DIFF
--- a/.github/workflows/generate-and-commit-files.yml
+++ b/.github/workflows/generate-and-commit-files.yml
@@ -2,8 +2,6 @@ name: Generate and Commit Files
 
 on:
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
 
 jobs:
   generate-and-commit-files:
@@ -32,6 +30,7 @@ jobs:
         run: npm run build
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           commit_message: Generate test and review files automatically
 

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -7,6 +7,8 @@ on:
       - "package*.json"
       - ".eslintrc.json"
       - ".github/workflows/js-lint.yml"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths:
       - "**/*.js"


### PR DESCRIPTION
Attempt 3 ...
Run the build like it currently since the skip isn't working, but don't push the result. This will at least test if the generate script works with any package changes.
Move the skiping to the lint job to avoid running it on push and PR, but try doublequotes for the globs