### PR TITLE
ci: use pull_request_target for PR preview

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,6 +1,6 @@
 name: "Update Pull Request with Preview Link"
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   update_pr:


### PR DESCRIPTION
needed since it requires the GH token to update the issue/PR through the API