### PR TITLE
Ensure scripts rootDirectory is consistent

### DIFF
--- a/scripts/create-all-tests.js
+++ b/scripts/create-all-tests.js
@@ -38,7 +38,7 @@ async function main() {
   const VALIDATE_CHECK = !!args.validate;
 
   const scriptsDirectory = path.dirname(__filename);
-  const rootDirectory = scriptsDirectory.split('scripts')[0];
+  const rootDirectory = path.join(scriptsDirectory, '../');
   const testsDirectory = path.join(rootDirectory, 'tests');
 
   const filteredTestPlans = fs.readdirSync(testsDirectory).filter(f =>

--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -81,7 +81,7 @@ const createExampleTests = async ({ directory, args = {} }) => {
 
   // cwd; @param rootDirectory is dependent on this file not moving from the scripts folder
   const scriptsDirectory = path.dirname(__filename);
-  const rootDirectory = scriptsDirectory.split('scripts')[0];
+  const rootDirectory = path.join(scriptsDirectory, '../');
 
   const testsDirectory = path.join(rootDirectory, 'tests');
   const testPlanDirectory = path.join(rootDirectory, directory);


### PR DESCRIPTION
This is an issue which may arise when contents of aria-at has to be processed from another environment such as https://github.com/w3c/aria-at-app where an additional 'scripts' may be a part of the path.