### PR TITLE
Correct generated code

### DIFF
--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -440,9 +440,9 @@ ${references}
     const commandJson = ${getCommandsJson()};
     initialize(supportJson, commandJson);
     verifyATBehavior(testJson);
-    displayTestPageAndInstructions("${
+    displayTestPageAndInstructions(${JSON.stringify(
       exampleScriptedFilesQueryable.where({ name: test.setupScript ? test.setupScript : '' }).path
-    }");
+    )});
   });
 </script>
   `;


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-655--aria-at.netlify.app)

When the build script is run in Windows, strings which describe paths will use the reverse solidus character to separate directory names and file names. This character takes on special meaning within JavaScript string literals (it begins an escape sequence), so it must be transformed if it is to retain its intended purpose in that context.

Use `JSON.stringify` to properly sanitize a value which is inserted into JavaScript program code.

---

The particulars of this bug (i.e. the differences between operating systems) may make the problem seem rare, but sanitization is a concern for any code generation (and even for projects that target a single platform). I haven't seen any other instances of unsafe code generation, but we should be on the lookout for similar patterns.