### PR TITLE
chore: increase Dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    open-pull-requests-limit: 99
     directory: "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 99
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Will let Dependabot open more than the default 5 PRs at once