### PR TITLE
Remove `htmlparser2` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cross-var": "^1.1.0",
         "csv-parser": "^3.0.0",
         "fs-extra": "^10.0.1",
-        "htmlparser2": "^5.0.1",
         "inquirer": "^8.2.1",
         "json-beautify": "^1.1.1",
         "minimist": "^1.2.6",
@@ -2614,20 +2613,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "node_modules/htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/htmlparser2?sponsor=1"
-      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -6859,17 +6844,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
-        "entities": "^2.0.0"
-      }
     },
     "human-signals": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "cross-var": "^1.1.0",
     "csv-parser": "^3.0.0",
     "fs-extra": "^10.0.1",
-    "htmlparser2": "^5.0.1",
     "inquirer": "^8.2.1",
     "json-beautify": "^1.1.1",
     "minimist": "^1.2.6",


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-666--aria-at.netlify.app)

Remove `htmlparser2` dependency as it's no longer being used.

Related to https://github.com/w3c/aria-at/pull/656#issuecomment-1076509042.