### PR TITLE
Replace fs.rmSync() usage with rimraf.sync()

### DIFF
--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -15,6 +15,7 @@ const {
 
 const csv = require('csv-parser');
 const beautify = require('json-beautify');
+const rimraf = require('rimraf');
 
 const { validate } = require('../lib/util/error');
 const { reindent } = require('../lib/util/lines');
@@ -743,7 +744,7 @@ ${rows}
       if (file.includes('.html') && (file.split(path.sep).pop().match(/\./g) || []).length > 1) {
         // remove generated html files from source which include scripts which are no longer generated
         if (!checkedSourceHtmlScriptFiles.includes(filePath)) {
-          fs.rmSync(path.join(sourceFolder, file));
+          rimraf.sync(path.join(sourceFolder, file));
         }
       }
     });


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-673--aria-at.netlify.app)

There is implicit support for `node >=12` in this project. Removing fs.rmSync() which has support on [node >=v14.14.0](https://nodejs.org/api/fs.html#fsrmsyncpath-options) helps preserve this.

Based on https://github.com/w3c/aria-at/pull/341#issuecomment-1082221667.

cc @nschonni 