### PR TITLE
Remove Up/Down Arrow NVDA commands from certain radiogroup tests

### DIFF
--- a/tests/radiogroup-aria-activedescendant/data/commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/commands.csv
@@ -1,15 +1,15 @@
 testId,task,mode,at,commandA,commandB,commandC
 1,Navigate to the first unchecked radio button in a group,READING,JAWS,F,A,"DOWN,DOWN"
-1,Navigate to the first unchecked radio button in a group,READING,NVDA,F,R,DOWN
+1,Navigate to the first unchecked radio button in a group,READING,NVDA,F,R,
 2,Navigate to the first unchecked radio button in a group,INTERACTION,VOICEOVER_MACOS,"CTRL_OPT_RIGHT,CTRL_OPT_RIGHT",CTRL_OPT_CMD_J,
 3,Navigate to the last unchecked radio button in a group,READING,JAWS,SHIFT_F,SHIFT_A,"UP,UP"
-3,Navigate to the last unchecked radio button in a group,READING,NVDA,SHIFT_F,SHIFT_R,UP
+3,Navigate to the last unchecked radio button in a group,READING,NVDA,SHIFT_F,SHIFT_R,
 4,Navigate to the last unchecked radio button in a group,INTERACTION,VOICEOVER_MACOS,"CTRL_OPT_LEFT,CTRL_OPT_LEFT",SHIFT_CTRL_OPT_CMD_J,
 5,Navigate to the first checked radio button in a group,READING,JAWS,F,A,"DOWN,DOWN"
-5,Navigate to the first checked radio button in a group,READING,NVDA,F,R,DOWN
+5,Navigate to the first checked radio button in a group,READING,NVDA,F,R,
 6,Navigate to the first checked radio button in a group,INTERACTION,VOICEOVER_MACOS,"CTRL_OPT_RIGHT,CTRL_OPT_RIGHT",CTRL_OPT_CMD_J,
 7,Navigate to the last checked radio button in a group,READING,JAWS,SHIFT_F,SHIFT_A,"UP,UP"
-7,Navigate to the last checked radio button in a group,READING,NVDA,SHIFT_F,SHIFT_R,UP
+7,Navigate to the last checked radio button in a group,READING,NVDA,SHIFT_F,SHIFT_R,
 8,Navigate to the last checked radio button in a group,INTERACTION,VOICEOVER_MACOS,"CTRL_OPT_LEFT,CTRL_OPT_LEFT",SHIFT_CTRL_OPT_CMD_J,
 9,Navigate forwards to an unchecked radio button,INTERACTION,JAWS,TAB,,
 9,Navigate forwards to an unchecked radio button,INTERACTION,NVDA,TAB,,
@@ -34,23 +34,23 @@ testId,task,mode,at,commandA,commandB,commandC
 21,Navigate out of the end of a radio group,INTERACTION,NVDA,TAB,,
 22,Navigate out of the end of a radio group,INTERACTION,VOICEOVER_MACOS,TAB,"CTRL_OPT_RIGHT,CTRL_OPT_RIGHT",
 23,Read information about an unchecked radio button,READING,JAWS,INS_TAB,INS_UP,
-23,Read information about an unchecked radio button,READING,NVDA,INS_TAB,INS_UP,
+23,Read information about an unchecked radio button,READING,NVDA,INS_TAB,,
 24,Read information about an unchecked radio button,INTERACTION,JAWS,INS_TAB,INS_UP,
 24,Read information about an unchecked radio button,INTERACTION,NVDA,INS_TAB,INS_UP,
 25,Read information about an unchecked radio button,INTERACTION,VOICEOVER_MACOS,CTRL_OPT_F3,CTRL_OPT_F4,
 26,Read information about a checked radio button,READING,JAWS,INS_TAB,INS_UP,
-26,Read information about a checked radio button,READING,NVDA,INS_TAB,INS_UP,
+26,Read information about a checked radio button,READING,NVDA,INS_TAB,,
 27,Read information about a checked radio button,INTERACTION,JAWS,INS_TAB,INS_UP,
 27,Read information about a checked radio button,INTERACTION,NVDA,INS_TAB,INS_UP,
 28,Read information about a checked radio button,INTERACTION,VOICEOVER_MACOS,CTRL_OPT_F3,CTRL_OPT_F4,
 29,Navigate to the next unchecked radio button,READING,JAWS,F,A,DOWN
-29,Navigate to the next unchecked radio button,READING,NVDA,F,R,DOWN
+29,Navigate to the next unchecked radio button,READING,NVDA,F,R,
 30,Navigate to the previous unchecked radio button,READING,JAWS,SHIFT_F,SHIFT_A,UP
-30,Navigate to the previous unchecked radio button,READING,NVDA,SHIFT_F,SHIFT_R,UP
+30,Navigate to the previous unchecked radio button,READING,NVDA,SHIFT_F,SHIFT_R,
 31,Navigate to the next checked radio button,READING,JAWS,F,A,DOWN
-31,Navigate to the next checked radio button,READING,NVDA,F,R,DOWN
+31,Navigate to the next checked radio button,READING,NVDA,F,R,
 32,Navigate to the previous checked radio button,READING,JAWS,SHIFT_F,SHIFT_A,UP
-32,Navigate to the previous checked radio button,READING,NVDA,SHIFT_F,SHIFT_R,UP
+32,Navigate to the previous checked radio button,READING,NVDA,SHIFT_F,SHIFT_R,
 33,Navigate to the next radio button,INTERACTION,JAWS,DOWN,RIGHT,
 33,Navigate to the next radio button,INTERACTION,NVDA,DOWN,RIGHT,
 34,Navigate to the next radio button,INTERACTION,VOICEOVER_MACOS,CTRL_OPT_RIGHT,DOWN,RIGHT

--- a/tests/radiogroup-aria-activedescendant/data/js/setFocusOnFirstRadioButton.js
+++ b/tests/radiogroup-aria-activedescendant/data/js/setFocusOnFirstRadioButton.js
@@ -7,4 +7,5 @@ radios.forEach(r => {
 });
 radios[0].classList.add('focus');
 radioGroup.setAttribute('aria-activedescendant', radios[0].id);
+testPageDocument.querySelector('#group_label_1').style.display = 'none';
 radioGroup.focus();

--- a/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusOnFirstRadioButton.html
+++ b/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusOnFirstRadioButton.html
@@ -22,6 +22,7 @@
         });
         radios[0].classList.add('focus');
         radioGroup.setAttribute('aria-activedescendant', radios[0].id);
+        testPageDocument.querySelector('#group_label_1').style.display = 'none';
         radioGroup.focus();
 
       };


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-710--aria-at.netlify.app)

The following commands have been removed, all in reading mode for NVDA:
* Navigate to the first unchecked radio button in a group: Down Arrow
* Navigate to the last unchecked radio button in a group: Up Arrow
* Navigate to the first checked radio button in a group: Down Arrow
* Navigate to the last checked radio button in a group: Up Arrow
* Read information about an unchecked radio button: Insert+Up Arrow
* Read information about a checked radio button: Insert+Up Arrow
* Navigate to the next unchecked radio button: Down Arrow
* Navigate to the previous unchecked radio button: Up Arrow
* Navigate to the next checked radio button: Down Arrow
* Navigate to the previous checked radio button: Up Arrow