### PR TITLE
Update JAWS Test Instructions

### DIFF
--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -1051,8 +1051,8 @@ const MODE_INSTRUCTION_TEMPLATES_QUERYABLE = Queryable.from('modeInstructionTemp
     mode: 'reading',
     render: data => {
       const altDelete = data.key.where({ id: 'ALT_DELETE' });
-      const insZ = data.key.where({ id: 'INS_Z' });
-      return `Verify the Virtual Cursor is active by pressing ${altDelete.keystroke}. If it is not, turn on the Virtual Cursor by pressing ${insZ.keystroke}.`;
+      const esc = data.key.where({ id: 'ESC' });
+      return `Verify the Virtual Cursor is active by pressing ${altDelete.keystroke}. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing ${esc.keystroke}.`;
     },
   },
   {

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -79,7 +79,7 @@ class KeysInput {
       at: atKey,
       modeInstructions: {
         reading: {
-          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing ${keys.ESC}.`,
           nvda: `Ensure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
           voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
         }[atKey],

--- a/tests/resources/at-commands.mjs
+++ b/tests/resources/at-commands.mjs
@@ -34,7 +34,7 @@ export class commandsAPI {
 
     this.MODE_INSTRUCTIONS = {
       reading: {
-        jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+        jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing ${keys.ESC}.`,
         nvda: `Ensure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
         voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
       },


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-794--aria-at.netlify.app)

Updated JAWS test instructions regarding exiting Forms Mode based on https://github.com/w3c/aria-at/issues/731#issuecomment-1158078906 and https://github.com/w3c/aria-at/issues/731#issuecomment-1167912369.

The instructions will now read as:
> Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing Escape.

instead of:
> Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, turn on the Virtual Cursor by pressing Insert+Z.