### PR TITLE
Update JAWS commands for breadcrumb

### DIFF
--- a/tests/breadcrumb/data/commands.csv
+++ b/tests/breadcrumb/data/commands.csv
@@ -14,7 +14,7 @@ testId,task,mode,at,commandA,commandB,commandC,commandD,commandE,commandF,comman
 8,Read information about a breadcrumb link,INTERACTION,JAWS,INS_TAB,INS_UP,,,,,
 8,Read information about a breadcrumb link,INTERACTION,NVDA,INS_TAB,INS_UP,,,,,
 9,Read information about a breadcrumb link,INTERACTION,VOICEOVER_MACOS,CTRL_OPT_F3,CTRL_OPT_F4,,,,,
-10,Navigate forwards out of the Breadcrumb navigation landmark,READING,JAWS,"DOWN,DOWN",U,"SHIFT_PERIOD,DOWN,DOWN",TAB,,,
+10,Navigate forwards out of the Breadcrumb navigation landmark,READING,JAWS,"DOWN,DOWN,DOWN",U,"SHIFT_PERIOD,DOWN,DOWN",TAB,,,
 10,Navigate forwards out of the Breadcrumb navigation landmark,READING,NVDA,DOWN,U,K,COMMA,TAB,,
 11,Navigate forwards out of the Breadcrumb navigation landmark,INTERACTION,JAWS,TAB,,,,,,
 11,Navigate forwards out of the Breadcrumb navigation landmark,INTERACTION,NVDA,TAB,,,,,,


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-803--aria-at.netlify.app)

added a missing "Down Arrow" command to the "Navigate forwards out of the Breadcrumb navigation landmark" task for JAWS.