### PR TITLE
Update dependabot checks to "monthly" for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     open-pull-requests-limit: 99
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 99
     directory: "/"


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-889--aria-at.netlify.app)

This PR is meant to reduce the frequency of dependabot notifications to avoid _potentially_ daily notification "spam".