### PR TITLE
Copy reference resources in build

### DIFF
--- a/scripts/create-example-tests.js
+++ b/scripts/create-example-tests.js
@@ -129,7 +129,7 @@ const createExampleTests = async ({ directory, args = {} }) => {
         entries: [
           {
             name: path.basename(directory),
-            entries: testPlanRecord.filter({ glob: 'reference{,/**}' }).record.entries,
+            entries: testPlanRecord.filter({ glob: 'reference/*/*{,/**}' }).record.entries,
           },
           { name: 'resources', ...resourcesRecord.record },
           { name: 'support.json', ...supportRecord.record },


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-911--aria-at.netlify.app)

Fix #910

When creating the a test plan's build, copy the resources (css, js, png, etc) that are in directories in the reference. The reference's html files are under the timestamp'd directory. Copying the directories (and contained resources) under the timestamped directory excludes the html files.

Copying the html files in the reference overlap with the generated html files can currently lead to errors writing the files to disk where the source file and generated file overlap.