### PR TITLE
FileRecord.insert: merge directories and replace files

### DIFF
--- a/lib/util/file-record.js
+++ b/lib/util/file-record.js
@@ -379,16 +379,24 @@ function createHost({ fs = _fs.promises, path = _path } = {}) {
       record.entries = [];
     }
 
-    if (splitPath.length > 1) {
-      let entry = record.entries.find(({ name }) => name === splitPath[0]);
-      if (!entry) {
-        entry = { name: splitPath[0] };
-        record.entries.push(entry);
-      }
+    const name = splitPath[0];
+    let entry = record.entries.find(subrecord => subrecord.name === name);
+    if (!entry) {
+      entry = { name };
+      record.entries.push(entry);
+    }
 
+    if (splitPath.length > 1) {
       insertInRecord(entry, splitPath.slice(1), clone(item));
-    } else {
-      record.entries.push({ name: splitPath[0], ...clone(item) });
+    } else if (isDirectory(item)) {
+      for (const subentry of item.entries) {
+        insertInRecord(entry, [subentry.name], subentry);
+      }
+    } else if (isFile(item)) {
+      if (isDirectory(entry)) {
+        throw new Error('Cannot insert file where a directory exists.');
+      }
+      entry.buffer = item.buffer;
     }
   }
 


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-912--aria-at.netlify.app)

Fix #910 

When inserting directories, walk its entries and merge items into the record. When inserting files, replace buffer with new buffer.

-----

This is a change to FileRecord.insert that I think follows how the method currently works for the path parameter to the record parameter. Before this change inserting a directory or file record would append it to the parent directory stated by the path parameter. That causes some odd outcomes when adding items that are already in the record.

Seeing #910 I think this is a reasonable change to make FileRecord work how I think others would anticipate. An alternative we could do would be to make FileRecord more strict and instead of merging and replacing records, error if there is a record already at the given path.