### PR TITLE
Force LF mode for js/mjs files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+*.js text eol=lf
+*.mjs text eol=lf
+
 # build folder
 /build/**/*.json        -diff -merge
 /build/**/*.html        linguist-generated=true


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-979--aria-at.netlify.app)

eslint/prettier are really arguing with git here...  everytime I run lint --fix, it modifies every file to replace CRLF - since the tooling does LF mode, we should tell git to treat the files as LF mode.