### PR TITLE
V2-maker Changes

### DIFF
--- a/scripts/v2makerUtil.js
+++ b/scripts/v2makerUtil.js
@@ -158,6 +158,8 @@ function translateCommand(screenReader, commandSequence, substitutions) {
     if (newCommandSettings.length > 0) commandSettings = newCommandSettings.join(' ');
   }
   commandSequence = commandSequence.replaceAll('_', '+');
+  commandSequence = commandSequence.replaceAll('one', '1');
+  commandSequence = commandSequence.replaceAll('two', '2');
   return { commandSequence, commandSettings };
 }
 

--- a/tests/support.json
+++ b/tests/support.json
@@ -13,7 +13,7 @@
         "virtualCursor": {
           "screenText": "virtual cursor active",
           "instructions": [
-            "Press &lt;kbd&gt;Alt&lt;/kbd&gt;+&lt;kbd&gt;Delete &lt;/kbd&gt; to determine which cursor is active.",
+            "Press &lt;kbd&gt;Alt&lt;/kbd&gt;+&lt;kbd&gt;Delete&lt;/kbd&gt; to determine which cursor is active.",
             "If the PC cursor is active, press &lt;kbd&gt;Escape&lt;/kbd&gt; to activate the virtual cursor."
           ]
         },
@@ -40,14 +40,14 @@
           "screenText": "browse mode on",
           "instructions": [
             "Press &lt;kbd&gt;insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt;.",
-            "If NVDA made the focus mode sound , press &lt;kbd&gt;Insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt; again to turn browse mode back on."
+            "If NVDA made the focus mode sound, press &lt;kbd&gt;Insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt; again to turn browse mode back on."
           ]
         },
         "focusMode": {
           "screenText": "focus mode on",
           "instructions": [
             "Press &lt;kbd&gt;insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt;.",
-            "If NVDA made the browse mode sound , press &lt;kbd&gt;Insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt; again to turn focus mode back on."
+            "If NVDA made the browse mode sound, press &lt;kbd&gt;Insert&lt;/kbd&gt;+&lt;kbd&gt;Space&lt;/kbd&gt; again to turn focus mode back on."
           ]
         }
       }


### PR DESCRIPTION
* Removes whitespace in `support.json`
* Replaces instance of commands that had 'one' or 'two' with their numerical values as `shift+one` or `two` isn't a command that can be translated with the new `commands.json`