### PR TITLE
Update collection form to capture unexpected behaviors severity and additional details

### DIFF
--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -254,6 +254,8 @@ const h3 = bind(element, 'h3');
 const hr = bind(element, 'hr');
 const input = bind(element, 'input');
 const label = bind(element, 'label');
+const select = bind(element, 'select');
+const option = bind(element, 'option');
 const legend = bind(element, 'legend');
 const li = bind(element, 'li');
 const ol = bind(element, 'ol');
@@ -436,7 +438,8 @@ function renderVirtualInstructionDocument(doc) {
         id(`cmd-${commandIndex}-problem-checkboxes`),
         legend(rich(unexpected.failChoice.options.header)),
         ...unexpected.failChoice.options.options.map(failOption =>
-          fragment(
+          fieldset(
+            legend(rich(failOption.description)),
             input(
               type('checkbox'),
               value(failOption.description),
@@ -456,32 +459,37 @@ function renderVirtualInstructionDocument(doc) {
                 }
               })
             ),
-            label(
-              forInput(`${failOption.description}-${commandIndex}`),
-              rich(failOption.description)
+            label(forInput(`${failOption.description}-${commandIndex}`), rich('Behavior occurred')),
+            br(),
+            label(forInput(`${failOption.description}-${commandIndex}-severity`), rich('Impact: ')),
+            select(
+              id(`${failOption.description}-${commandIndex}-severity`),
+              name(`${failOption.description}-${commandIndex}-severity`),
+              option('Moderate'),
+              option('High'),
+              disabled(!failOption.checked),
+              onchange(ev =>
+                failOption.severitychange(/** @type {HTMLInputElement} */ (ev.currentTarget).value)
+              )
             ),
             br(),
-            failOption.more
-              ? div(
-                  label(
-                    forInput(`${failOption.description}-${commandIndex}-input`),
-                    rich(failOption.more.description)
-                  ),
-                  input(
-                    type('text'),
-                    id(`${failOption.description}-${commandIndex}-input`),
-                    name(`${failOption.description}-${commandIndex}-input`),
-                    className(['undesirable-other-input']),
-                    disabled(!failOption.more.enabled),
-                    value(failOption.more.value),
-                    onchange(ev =>
-                      failOption.more.change(
-                        /** @type {HTMLInputElement} */ (ev.currentTarget).value
-                      )
-                    )
-                  )
+            div(
+              label(
+                forInput(`${failOption.description}-${commandIndex}-input`),
+                rich(failOption.more.description)
+              ),
+              input(
+                type('text'),
+                id(`${failOption.description}-${commandIndex}-input`),
+                name(`${failOption.description}-${commandIndex}-input`),
+                className(['undesirable-other-input']),
+                disabled(!failOption.more.enabled),
+                value(failOption.more.value),
+                onchange(ev =>
+                  failOption.more.change(/** @type {HTMLInputElement} */ (ev.currentTarget).value)
                 )
-              : fragment()
+              )
+            )
           )
         )
       )

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -13,6 +13,7 @@ import {
   userCloseWindow,
   userOpenWindow,
   WhitespaceStyleMap,
+  UnexpectedBehaviorSeverityMap,
 } from './aria-at-test-run.mjs';
 import { TestRunExport, TestRunInputOutput } from './aria-at-test-io-format.mjs';
 import { TestWindow } from './aria-at-test-window.mjs';
@@ -465,8 +466,8 @@ function renderVirtualInstructionDocument(doc) {
             select(
               id(`${failOption.description}-${commandIndex}-severity`),
               name(`${failOption.description}-${commandIndex}-severity`),
-              option('Moderate'),
-              option('High'),
+              option(UnexpectedBehaviorSeverityMap.MODERATE),
+              option(UnexpectedBehaviorSeverityMap.HIGH),
               disabled(!failOption.checked),
               onchange(ev =>
                 failOption.severitychange(/** @type {HTMLInputElement} */ (ev.currentTarget).value)

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1211,7 +1211,7 @@ export class TestRunInputOutput {
               behaviors: test.unexpectedBehaviors.map(({ description }) => ({
                 description,
                 checked: false,
-                severity: 'Moderate',
+                severity: UnexpectedBehaviorSeverityMap.MODERATE,
                 more: { highlightRequired: false, value: '' },
               })),
             },
@@ -1420,7 +1420,8 @@ export class TestRunInputOutput {
             behavior.checked
               ? {
                   text: behavior.description,
-                  otherUnexpectedBehaviorText: behavior.more ? behavior.more.value : null,
+                  severity: behavior.severity,
+                  unexpectedBehaviorText: behavior.more.value,
                 }
               : null
           )
@@ -1492,6 +1493,9 @@ export class TestRunInputOutput {
                 more: behavior.more
                   ? {
                       highlightRequired: false,
+                      severity: behaviorResult
+                        ? behavior.severity
+                        : UnexpectedBehaviorSeverityMap.MODERATE,
                       value: behaviorResult ? behaviorResult.otherUnexpectedBehaviorText : '',
                     }
                   : behavior.more,
@@ -1575,6 +1579,11 @@ const AssertionFailJSONMap = createEnumMap({
   INCORRECT_OUTPUT: 'Incorrect Output',
   NO_SUPPORT: 'No Support',
   FAIL: 'Fail',
+});
+
+const UnexpectedBehaviorSeverityMap = createEnumMap({
+  MODERATE: 'Moderate',
+  HIGH: 'High',
 });
 
 /** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1496,7 +1496,7 @@ export class TestRunInputOutput {
                       severity: behaviorResult
                         ? behavior.severity
                         : UnexpectedBehaviorSeverityMap.MODERATE,
-                      value: behaviorResult ? behaviorResult.otherUnexpectedBehaviorText : '',
+                      value: behaviorResult ? behaviorResult.unexpectedBehaviorText : '',
                     }
                   : behavior.more,
               };

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -699,8 +699,8 @@ class UnexpectedInput {
   static fromBuiltin() {
     return new UnexpectedInput({
       behaviors: [
-        ...UNEXPECTED_BEHAVIORS.map(description => ({ description, requireExplanation: false })),
-        { description: 'Other', requireExplanation: true },
+        ...UNEXPECTED_BEHAVIORS.map(description => ({ description })),
+        { description: 'Other' },
       ],
     });
   }
@@ -1208,10 +1208,11 @@ export class TestRunInputOutput {
               highlightRequired: false,
               hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
               tabbedBehavior: 0,
-              behaviors: test.unexpectedBehaviors.map(({ description, requireExplanation }) => ({
+              behaviors: test.unexpectedBehaviors.map(({ description }) => ({
                 description,
                 checked: false,
-                more: requireExplanation ? { highlightRequired: false, value: '' } : null,
+                severity: 'Moderate',
+                more: { highlightRequired: false, value: '' },
               })),
             },
           })
@@ -1735,7 +1736,6 @@ function invariant(test, message, ...args) {
 /**
  * @typedef BehaviorUnexpectedItem
  * @property {string} description
- * @property {boolean} requireExplanation
  */
 
 /**

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -298,6 +298,7 @@ export function instructionDocument(resultState, hooks) {
             options: resultUnexpectedBehavior.behaviors.map((behavior, unexpectedIndex) => {
               return {
                 description: behavior.description,
+                severity: behavior.severity,
                 enabled:
                   resultUnexpectedBehavior.hasUnexpected ===
                   HasUnexpectedBehaviorMap.HAS_UNEXPECTED,

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -19,6 +19,9 @@ export class TestRun {
       setCommandAssertion: bindDispatch(userChangeCommandAssertion),
       setCommandHasUnexpectedBehavior: bindDispatch(userChangeCommandHasUnexpectedBehavior),
       setCommandUnexpectedBehavior: bindDispatch(userChangeCommandUnexpectedBehavior),
+      setCommandUnexpectedBehaviorSeverity: bindDispatch(
+        userChangeCommandUnexpectedBehaviorSeverity
+      ),
       setCommandUnexpectedBehaviorMore: bindDispatch(userChangeCommandUnexpectedBehaviorMore),
       setCommandOutput: bindDispatch(userChangeCommandOutput),
       submit: () => submitResult(this),
@@ -312,6 +315,12 @@ export function instructionDocument(resultState, hooks) {
                       focusFirstRequired(),
                 change: checked =>
                   hooks.setCommandUnexpectedBehavior({ commandIndex, unexpectedIndex, checked }),
+                severitychange: severity =>
+                  hooks.setCommandUnexpectedBehaviorSeverity({
+                    commandIndex,
+                    unexpectedIndex,
+                    severity,
+                  }),
                 keydown: key => {
                   const increment = keyToFocusIncrement(key);
                   if (increment) {
@@ -324,30 +333,28 @@ export function instructionDocument(resultState, hooks) {
                   }
                   return false;
                 },
-                more: behavior.more
-                  ? {
-                      description: /** @type {Description[]} */ ([
-                        `If "other" selected, explain`,
-                        {
-                          required: true,
-                          highlightRequired: behavior.more.highlightRequired,
-                          description: '(required)',
-                        },
-                      ]),
-                      enabled: behavior.checked,
-                      value: behavior.more.value,
-                      focus:
-                        resultState.currentUserAction === 'validateResults' &&
-                        behavior.more.highlightRequired &&
-                        focusFirstRequired(),
-                      change: value =>
-                        hooks.setCommandUnexpectedBehaviorMore({
-                          commandIndex,
-                          unexpectedIndex,
-                          more: value,
-                        }),
-                    }
-                  : null,
+                more: {
+                  description: /** @type {Description[]} */ ([
+                    `Details: `,
+                    {
+                      required: true,
+                      highlightRequired: behavior.more.highlightRequired,
+                      description: '(required)',
+                    },
+                  ]),
+                  enabled: behavior.checked,
+                  value: behavior.more.value,
+                  focus:
+                    resultState.currentUserAction === 'validateResults' &&
+                    behavior.more.highlightRequired &&
+                    focusFirstRequired(),
+                  change: value =>
+                    hooks.setCommandUnexpectedBehaviorMore({
+                      commandIndex,
+                      unexpectedIndex,
+                      more: value,
+                    }),
+                },
               };
             }),
           },
@@ -615,6 +622,44 @@ export function userChangeCommandUnexpectedBehavior({ commandIndex, unexpectedIn
  * @param {object} props
  * @param {number} props.commandIndex
  * @param {number} props.unexpectedIndex
+ * @param {string} props.severity
+ * @returns {(state: TestRunState) => TestRunState}
+ */
+export function userChangeCommandUnexpectedBehaviorSeverity({
+  commandIndex,
+  unexpectedIndex,
+  severity,
+}) {
+  return function (state) {
+    return {
+      ...state,
+      currentUserAction: UserActionMap.CHANGE_TEXT,
+      commands: state.commands.map((command, commandI) =>
+        commandI !== commandIndex
+          ? command
+          : /** @type {TestRunCommand} */ ({
+              ...command,
+              unexpected: {
+                ...command.unexpected,
+                behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
+                  unexpectedI !== unexpectedIndex
+                    ? unexpected
+                    : /** @type {TestRunUnexpectedBehavior} */ ({
+                        ...unexpected,
+                        severity: severity,
+                      })
+                ),
+              },
+            })
+      ),
+    };
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {number} props.commandIndex
+ * @param {number} props.unexpectedIndex
  * @param {string} props.more
  * @returns {(state: TestRunState) => TestRunState}
  */
@@ -762,7 +807,7 @@ function resultsTableDocument(state) {
 
         let passingAssertions = ['No passing assertions.'];
         let failingAssertions = ['No failing assertions.'];
-        let unexpectedBehaviors = ['No unexpect behaviors.'];
+        let unexpectedBehaviors = ['No unexpected behaviors.'];
 
         if (allAssertions.some(({ result }) => result === CommonResultMap.PASS)) {
           passingAssertions = allAssertions
@@ -777,7 +822,12 @@ function resultsTableDocument(state) {
         if (command.unexpected.behaviors.some(({ checked }) => checked)) {
           unexpectedBehaviors = command.unexpected.behaviors
             .filter(({ checked }) => checked)
-            .map(({ description, more }) => (more ? more.value : description));
+            .map(({ description, more, severity }) => {
+              let result = `${description} (`;
+              if (more) result = `${result}Details: ${more.value}, `;
+              result = `${result}Impact: ${severity})`;
+              return result;
+            });
         }
 
         return {
@@ -794,7 +844,7 @@ function resultsTableDocument(state) {
               : 'FULL',
           details: {
             output: /** @type {Description} */ [
-              'output:',
+              'Output:',
               /** @type {DescriptionWhitespace} */ ({ whitespace: WhitespaceStyleMap.LINE_BREAK }),
               ' ',
               ...command.atOutput.value.split(/(\r\n|\r|\n)/g).map(output =>
@@ -814,7 +864,7 @@ function resultsTableDocument(state) {
               items: failingAssertions,
             },
             unexpectedBehaviors: {
-              description: 'Unexpected Behavior',
+              description: 'Unexpected Behaviors',
               items: unexpectedBehaviors,
             },
           },
@@ -1122,6 +1172,7 @@ export function userValidateState() {
  * @property {(options: {commandIndex: number, hasUnexpected: HasUnexpectedBehavior}) => void } setCommandHasUnexpectedBehavior
  * @property {(options: {commandIndex: number, atOutput: string}) => void} setCommandOutput
  * @property {(options: {commandIndex: number, unexpectedIndex: number, checked}) => void } setCommandUnexpectedBehavior
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, severity: string}) => void } setCommandUnexpectedBehaviorSeverity
  * @property {(options: {commandIndex: number, unexpectedIndex: number, more: string}) => void } setCommandUnexpectedBehaviorMore
  * @property {() => void} submit
  */
@@ -1161,6 +1212,7 @@ export function userValidateState() {
  * @property {object} [more]
  * @property {boolean} more.highlightRequired
  * @property {string} more.value
+ * @property {string} severity
  */
 
 /**

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -472,6 +472,15 @@ export const AssertionResultMap = createEnumMap({
 });
 
 /**
+ * @typedef {EnumValues<typeof UnexpectedBehaviorSeverityMap>} UnexpectedBehaviorSeverity
+ */
+
+export const UnexpectedBehaviorSeverityMap = createEnumMap({
+  MODERATE: 'Moderate',
+  HIGH: 'High',
+});
+
+/**
  * @param {object} props
  * @param {number} props.commandIndex
  * @param {string} props.atOutput

--- a/tests/resources/types/aria-at-test-result.js
+++ b/tests/resources/types/aria-at-test-result.js
@@ -34,5 +34,6 @@
  * @property {object[]} scenarioResults[].unexpectedBehaviors
  * @property {string} scenarioResults[].unexpectedBehaviors[].id
  * @property {string} scenarioResults[].unexpectedBehaviors[].text
- * @property {string | null} [scenarioResults[].unexpectedBehaviors[].otherUnexpectedBehaviorText]
+ * @property {string} scenarioResults[].unexpectedBehaviors[].severity
+ * @property {string} scenarioResults[].unexpectedBehaviors[].unexpectedBehaviorText
  */


### PR DESCRIPTION
Supersedes #1006

This is additional work to support https://github.com/w3c/aria-at-app/issues/738.

> Modify the results collection form so that each behavior in the list of problematic behaviors has the following inputs:
> - A checkbox to indicate if the behavior occurred.
> - A select labeled "Impact" with values Moderate, and High. It is disabled if the checkbox is not checked and required if it is checked.
> - A text field labeled "Details" that is disabled if the checkbox is not checked and required if it is checked.