### PR TITLE
support.json: Add VO settings for new single and arrow quick key nav added to VO in latest macOS

### DIFF
--- a/tests/support.json
+++ b/tests/support.json
@@ -70,6 +70,34 @@
             "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
             "If VoiceOver said 'quick nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
           ]
+        },
+        "arrowQuickKeyNavOn": {
+          "screenText": "arrow quick key nav on",
+          "instructions": [
+            "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+            "If VoiceOver said 'arrow quick key nav off', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back on."
+          ]
+        },
+        "arrowQuickKeyNavOff": {
+          "screenText": "arrow quick key nav off",
+          "instructions": [
+            "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+            "If VoiceOver said 'arrow quick key nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
+          ]
+        },
+        "singleQuickKeyNavOn": {
+          "screenText": "single quick key nav on",
+          "instructions": [
+            "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
+            "If VoiceOver said 'single quick key nav off', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back on."
+          ]
+        },
+        "singleQuickKeyNavOff": {
+          "screenText": "single quick key nav off",
+          "instructions": [
+            "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
+            "If VoiceOver said 'single quick key nav on', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back off."
+          ]
         }
       }
     }


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1020--aria-at.netlify.app)

In a recent build of macOS, quick nav was split into two separate settings: one for single letter keys and one for arrow keys. Now the settings required for a test depends on whether the command sequence being tested is an arrow key command, quick nav letter command, or both.