### PR TITLE
Tokenize `assertionPhrase`

### DIFF
--- a/lib/data/process-test-directory.js
+++ b/lib/data/process-test-directory.js
@@ -1410,16 +1410,10 @@ function mapDefined(maybeDefined, goal) {
  * @returns {AriaATValidated.Test}
  */
 function validateTest(testParsed, data, { addTestError = () => {} } = {}) {
-  const assertionStatementTokenPattern = /\{([^{}]+)}/g;
-  const replacedAssertionStatement = (assertionStatement, matches, replacements) => {
-    matches.forEach(
-      match =>
-        (assertionStatement = assertionStatement.replaceAll(
-          match,
-          replacements[match.slice(1, -1)]
-        ))
-    );
-    return assertionStatement;
+  const assertionStringTokenPattern = /\{([^{}]+)}/g;
+  const replacedAssertionStrings = (str, matches, replacements) => {
+    matches.forEach(match => (str = str.replaceAll(match, replacements[match.slice(1, -1)])));
+    return str;
   };
 
   if (!data.command.where({ testId: testParsed.testId })) {
@@ -1466,8 +1460,9 @@ function validateTest(testParsed, data, { addTestError = () => {} } = {}) {
 
   const assertions = testParsed.assertions.map(assertion => {
     assertion.tokenizedAssertionStatements = {};
+    assertion.tokenizedAssertionPhrases = {};
 
-    // There are assertion tokens to account for
+    // There are assertionStatement tokens to account for
     if (assertion.assertionStatement.includes('|')) {
       const [genericAssertionStatement, tokenizedAssertionStatement] =
         assertion.assertionStatement.split('|');
@@ -1476,7 +1471,7 @@ function validateTest(testParsed, data, { addTestError = () => {} } = {}) {
       assertion.assertionStatement = genericAssertionStatement;
 
       if (tokenizedAssertionStatement) {
-        const matches = tokenizedAssertionStatement.match(assertionStatementTokenPattern);
+        const matches = tokenizedAssertionStatement.match(assertionStringTokenPattern);
 
         testParsed.target.ats.forEach(at => {
           const { assertionTokens } = data.support.ats.where({ key: at.key });
@@ -1484,8 +1479,35 @@ function validateTest(testParsed, data, { addTestError = () => {} } = {}) {
             assertionTokens && matches.every(match => assertionTokens[match.slice(1, -1)]);
 
           if (tokensExist) {
-            assertion.tokenizedAssertionStatements[at.key] = replacedAssertionStatement(
+            assertion.tokenizedAssertionStatements[at.key] = replacedAssertionStrings(
               tokenizedAssertionStatement,
+              matches,
+              assertionTokens
+            );
+          }
+        });
+      }
+    }
+
+    // There are assertionPhrase tokens to account for
+    if (assertion.assertionPhrase.includes('|')) {
+      const [genericAssertionPhrase, tokenizedAssertionPhrase] =
+        assertion.assertionPhrase.split('|');
+
+      // Set fallback just in case tokenized statement or properties do not exist
+      assertion.assertionPhrase = genericAssertionPhrase;
+
+      if (tokenizedAssertionPhrase) {
+        const matches = tokenizedAssertionPhrase.match(assertionStringTokenPattern);
+
+        testParsed.target.ats.forEach(at => {
+          const { assertionTokens } = data.support.ats.where({ key: at.key });
+          const tokensExist =
+            assertionTokens && matches.every(match => assertionTokens[match.slice(1, -1)]);
+
+          if (tokensExist) {
+            assertion.tokenizedAssertionPhrases[at.key] = replacedAssertionStrings(
+              tokenizedAssertionPhrase,
               matches,
               assertionTokens
             );

--- a/scripts/test-reviewer.mjs
+++ b/scripts/test-reviewer.mjs
@@ -296,7 +296,7 @@ fse.readdirSync(testsBuildDirectory).forEach(function (directory) {
                 return {
                   assertionId: a.assertionId,
                   priority: getPriorityString(a.priority),
-                  assertionPhrase: a.assertionPhrase,
+                  assertionPhrase: a.tokenizedAssertionPhrases?.[at.key] || a.assertionPhrase,
                   assertionStatement:
                     a.tokenizedAssertionStatements?.[at.key] || a.assertionStatement,
                 };

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -817,7 +817,7 @@ class BehaviorInput {
             };
           }
 
-          // { assertionId, priority, assertionStatement, assertionPhrase, refIds, tokenizedAssertionStatements }
+          // { assertionId, priority, assertionStatement, assertionPhrase, refIds, tokenizedAssertionStatements, tokenizedAssertionPhrases }
           return {
             priority: assertion.priority,
             assertion:


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1038--aria-at.netlify.app)

Following the examples given for [assertionPhrase](https://github.com/w3c/aria-at/wiki/Test-Format-Definition-V2#assertionphrase), there is a need to also tokenize `assertionPhrase` in the same way `assertionStatement` is done.