### PR TITLE
Support assertionExceptions without priority prefix

### DIFF
--- a/lib/data/parse-test-csv-row.js
+++ b/lib/data/parse-test-csv-row.js
@@ -3,6 +3,8 @@
 
 'use strict';
 
+const { setDefaultAssertionExceptionsFromTest } = require('../util/assertion-exception');
+
 /**
  * @param {AriaATCSV.Test} testRow
  * @returns {AriaATParsed.Test}
@@ -216,12 +218,16 @@ function parseTestCSVRowV2({ tests, assertions, scripts, commands }) {
             at => at.key === key && at.settings === (command.settings || 'defaultMode')
           )
         ) {
+          const assertionExceptions = setDefaultAssertionExceptionsFromTest(
+            command.assertionExceptions,
+            assertions
+          );
           const commandInfo = {
             testId: command.testId,
             command: command.command,
             settings: command.settings || 'defaultMode',
             presentationNumber: Number(command.presentationNumber),
-            assertionExceptions: command.assertionExceptions,
+            assertionExceptions: assertionExceptions,
           };
 
           // Test level commandInfo, useful for getting assertionExceptions and

--- a/lib/data/process-test-directory.js
+++ b/lib/data/process-test-directory.js
@@ -215,7 +215,7 @@ const processTestDirectory = async ({ directory, args = {} }) => {
   const validCommandKeys = /^(?:testId|command|settings|assertionExceptions|presentationNumber)$/;
   const numericKeyFormat = /^_(\d+)$/;
   const idFormat = /^[A-Za-z0-9-]+$/;
-  const assertionsExceptionsFormat = /^([0123]:[a-zA-Z-\d]+\s*)+$/;
+  const assertionsExceptionsFormat = /^(([0123]:)?[a-zA-Z-\d]+\s*)+$/;
   const settingsFormat = /^[A-Za-z0-9-\s]+$/;
   function validateCommandsKeys(row) {
     // example header:

--- a/lib/util/assertion-exception.js
+++ b/lib/util/assertion-exception.js
@@ -1,0 +1,38 @@
+/**
+ * Generates the assertionException string with a default priority prefix
+ * @param {String} assertionException
+ * @param {Number} defaultPriority
+ * @returns {String}
+ */
+function setDefaultAssertionException(assertionException, defaultPriority) {
+  if (assertionException && !assertionException.includes(':')) {
+    return `${defaultPriority}:${assertionException}`;
+  }
+  return assertionException;
+}
+
+/**
+ * Finds the default assertion value for an assertionException without
+ * a priority prefix in a string of assertionExceptions and recreates
+ * the string with the new default assertion priorities
+ * @param {String} assertionExceptions
+ * @param {Array} assertions
+ * @returns {String}
+ */
+function setDefaultAssertionExceptionsFromTest(assertionExceptions, assertions) {
+  return assertionExceptions
+    .split(' ')
+    .map(assertionException => {
+      const assertion = assertions.find(assertion =>
+        assertionException.includes(assertion.assertionId)
+      );
+      if (assertion) {
+        const defaultPriority = assertion.priority;
+        return setDefaultAssertionException(assertionException, defaultPriority);
+      }
+      return assertionException;
+    })
+    .join(' ');
+}
+
+exports.setDefaultAssertionExceptionsFromTest = setDefaultAssertionExceptionsFromTest;


### PR DESCRIPTION
This PR addresses #1046, providing support for test plans with assertionExceptions that do not have a priority prefix.

The following changes were added:

- Relaxed regex check on assertionExceptions
- Util file for setting default assertion priorities