### PR TITLE
Additional support for `MAY` in `aria-at-test-io-format.mjs`

### DIFF
--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1344,6 +1344,14 @@ export class TestRunInputOutput {
             ({ priority, result }) => priority === 2 && result !== CommonResultMap.PASS
           ),
         },
+        3: {
+          pass: countAssertions(
+            ({ priority, result }) => priority === 3 && result === CommonResultMap.PASS
+          ),
+          fail: countAssertions(
+            ({ priority, result }) => priority === 3 && result !== CommonResultMap.PASS
+          ),
+        },
         unexpectedCount: countUnexpectedBehaviors(({ checked }) => checked),
       },
       commands: state.commands.map(command => ({
@@ -1379,7 +1387,8 @@ export class TestRunInputOutput {
       ) || command.unexpected.behaviors.some(({ checked }) => checked)
         ? CommandSupportJSONMap.FAILING
         : allAssertions.some(
-            ({ priority, result }) => priority === 2 && result !== CommonResultMap.PASS
+            ({ priority, result }) =>
+              (priority === 2 || priority === 3) && result !== CommonResultMap.PASS
           )
         ? CommandSupportJSONMap.ALL_REQUIRED
         : CommandSupportJSONMap.FULL;
@@ -1455,7 +1464,8 @@ export class TestRunInputOutput {
         output: command.atOutput.value,
         assertionResults: command.assertions.map(assertion => ({
           assertion: {
-            priority: assertion.priority === 1 ? 'REQUIRED' : 'OPTIONAL',
+            priority:
+              assertion.priority === 1 ? 'MUST' : assertion.priority === 2 ? 'SHOULD' : 'MAY',
             text: assertion.description,
           },
           passed: assertion.result === 'pass',
@@ -1640,10 +1650,10 @@ const UnexpectedBehaviorImpactMap = createEnumMap({
 /** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */
 
 /**
- * Command result derived from priority 1 and 2 assertions.
+ * Command result derived from priority 1, 2 and 3 assertions.
  *
  * Support is "FAILING" is priority 1 assertions fail. Support is "ALL REQUIRED"
- * if priority 2 assertions fail.
+ * if priority 2 or 3 assertions fail.
  *
  * In the submitted json object values may contain spaces and are in ALL CAPS.
  *
@@ -1830,7 +1840,7 @@ function invariant(test, message, ...args) {
  */
 
 /**
- * @typedef {{[key in "1" | "2"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
+ * @typedef {{[key in "1" | "2" | "3"]: SubmitResultSummaryPriorityJSON}} SubmitResultSummaryPriorityMapJSON
  */
 
 /**

--- a/tests/resources/types/aria-at-test-result.js
+++ b/tests/resources/types/aria-at-test-result.js
@@ -4,8 +4,9 @@
  */
 
 /**
- * @typedef {"REQUIRED"
- *   | "OPTIONAL"} AriaATTestResult.AssertionPriorityJSON
+ * @typedef {"MUST"
+ *   | "SHOULD"
+ *   | "MAY"} AriaATTestResult.AssertionPriorityJSON
  */
 
 /**


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1056--aria-at.netlify.app)

In reviewing https://github.com/w3c/aria-at-app/pull/1064, realized some harness support for these files were added to aria-at-app but not here.