### PR TITLE
Update `update-reference.js` script to support APG site migration

### DIFF
--- a/scripts/update-reference.js
+++ b/scripts/update-reference.js
@@ -1,31 +1,29 @@
-const fse = require('fs-extra');
 const path = require('path');
+const fse = require('fs-extra');
 const simpleGit = require('simple-git');
-const mustache = require('mustache');
-const np = require('node-html-parser');
 
-const tmpPath = path.join(__dirname, 'tmp');
-let repoBasePath = tmpPath;
 const cloneURL = 'https://github.com/w3c/aria-practices';
+const apgPath = path.join(__dirname, 'aria-practices');
+let apgRepositoryBasePath = apgPath;
 
 const args = require('minimist')(process.argv.slice(2), {
   alias: {
     h: 'help',
-    r: 'aria-practices-repo',
+    r: 'aria-practices-directory',
   },
 });
 
 if (args.help) {
   console.log(`
 Default use:
-  node update-reference.js exampleName [-a ariaPracticesDirectory]
-    It will copy the latest example html from the aria-practices repo into this repo.
-    It will clone the latest aria-practice directory or use an existing clone.
-    The example html url for the example needs to be specificed in the references.csv file for the example named.
-    The copied reference will be placed in a dated folder to provide a form of version control for the refernece files.
-    The new reference will only be used with the reference.csv file is updated to point to the new reference folder.
+  node update-reference.js exampleName [-r ariaPracticesDirectory]
+    It will copy the latest example html from the aria-practices repository into this repository.
+    It will clone the latest aria-practices directory or use an existing clone.
+    The example html url for the example needs to be specified in the references.csv file for the example named.
+    The copied reference will be placed in a dated folder to provide a form of version control for the reference files.
+    The new reference will only be used when the reference.csv file, reference value is updated to point to the new reference folder.
   Arguments:
-    -r, --aria-practices-repo
+    -r, --aria-practices-directory
     -h, --help
        Show this message.
 `);
@@ -86,17 +84,85 @@ async function copyExampleToRepo(exampleName) {
       process.exit();
     }
     const referencesCsv = fse.readFileSync(referencesCsvFile, 'UTF-8');
-    const exampleUrl = (
+    let exampleUrl = (
       (referencesCsv || '').split(/\r?\n/).find(s => s.startsWith('example,')) || ''
     ).split(',')[1];
+
+    // TODO: Deprecate this when all tests support the v2 format
+    // If v2 test format
+    if (exampleUrl === 'metadata')
+      exampleUrl = (
+        (referencesCsv || '').split(/\r?\n/).find(s => s.startsWith('example,')) || ''
+      ).split(',')[2];
+
     if (!exampleUrl) {
       console.log('`example` must be defined in the references.csv file');
       process.exit();
     }
+
+    // TODO: Deprecate this when all references.csv examples use the w3.org/WAI/ARIA/apg links
+    // Supporting older content; but recommend switching over to prevent future issues
+    let updatedExampleUrl;
+    if (exampleUrl.includes('https://w3c.github.io/aria-practices/')) {
+      const oldApgBaseUrl = exampleUrl.includes('/landmarks/')
+        ? 'https://w3c.github.io/aria-practices/examples/landmarks/'
+        : 'https://w3c.github.io/aria-practices/examples/';
+
+      const waiBaseUrl = exampleUrl.includes('/landmarks/')
+        ? 'https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/'
+        : 'https://www.w3.org/WAI/ARIA/apg/patterns/';
+
+      updatedExampleUrl = exampleUrl.replace(oldApgBaseUrl, waiBaseUrl);
+
+      if (exampleUrl.includes('/landmarks/')) {
+        // Eg: https://w3c.github.io/aria-practices/examples/landmarks/banner.html to
+        //     https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html
+        // Nothing further required
+      } else {
+        // Eg: https://w3c.github.io/aria-practices/examples/alert/alert.html to
+        //     https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert.html
+        console.log('pre.updatedExampleUrl', updatedExampleUrl);
+        let examplePathToUpdate = updatedExampleUrl.split(waiBaseUrl)[1];
+
+        const insertIndex = updatedExampleUrl.indexOf('/');
+        if (insertIndex > -1)
+          examplePathToUpdate =
+            examplePathToUpdate.substring(0, insertIndex) +
+            'examples/' +
+            examplePathToUpdate.substring(insertIndex);
+
+        updatedExampleUrl = waiBaseUrl + examplePathToUpdate;
+      }
+
+      console.log(
+        'Converting example url found for ' +
+          exampleName +
+          ', from "' +
+          exampleUrl +
+          '" to "' +
+          updatedExampleUrl +
+          '".\nPlease update the url found in tests/' +
+          exampleName +
+          '/data/references.csv to the latest known location to avoid future issues when running this script.\n'
+      );
+
+      exampleUrl = updatedExampleUrl;
+    }
+
+    // Url paths on w3.org/WAI/ARIA/apg expected to end in .html get redirected to the same url without .html
+    // Eg: https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert.html becomes
+    //     https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert/
+    //
+    // The latter is most likely what test authors will include here since the
+    // url is being copied directly from w3.org/WAI/ARIA/apg
+    if (exampleUrl.charAt(exampleUrl.length - 1) === '/') {
+      exampleUrl = exampleUrl.slice(0, -1) + '.html';
+    }
+
     let examplePath;
-    if (exampleUrl.indexOf('https://w3c.github.io/aria-practices/examples/') >= 0) {
-      examplePath = exampleUrl.split('https://w3c.github.io/aria-practices/')[1];
-      examplePath = path.join(...examplePath.split('/')); // Ensure path type is correct regardless of OS
+    if (exampleUrl.indexOf('https://www.w3.org/WAI/ARIA/apg/patterns/') >= 0) {
+      examplePath = exampleUrl.split('https://www.w3.org/WAI/ARIA/apg/')[1];
+      examplePath = path.join('content', ...examplePath.split('/')); // Ensure path type is correct regardless of OS
     } else {
       console.log(
         '`example` must be defined in references.csv with the format `https://w3c.github.io/aria-practices/examples/<PATH_TO_EXAMPLE>.html`'
@@ -105,23 +171,23 @@ async function copyExampleToRepo(exampleName) {
     }
 
     if (!args.r) {
-      await fse.remove(tmpPath);
-      console.log('Cloning the aria-practice repo.');
+      await fse.remove(apgPath);
+      console.log('Cloning w3c/aria-practices repository ...');
       const git = simpleGit();
-      await git.clone(cloneURL, tmpPath);
+      await git.clone(cloneURL, apgPath);
     } else {
-      repoBasePath = args.r;
+      apgRepositoryBasePath = args.r;
     }
 
-    const htmlFileAbsolute = path.join(repoBasePath, examplePath);
-    console.log(`Locating the matching example file ${posixPath(htmlFileAbsolute)}.`);
+    const htmlFileAbsolute = path.join(apgRepositoryBasePath, examplePath);
+    console.log(`Locating the matching example file ${posixPath(htmlFileAbsolute)} ...`);
     try {
       fse.statSync(htmlFileAbsolute);
     } catch (err) {
       console.log(
-        `The example html '${posixPath(
+        `The example html file '${posixPath(
           htmlFileAbsolute
-        )}' does not exist. Please enure the current example html utl is in the references.csv file.`
+        )}' does not exist. Please ensure the correct example html path is in references.csv.`
       );
       process.exit();
     }
@@ -138,7 +204,7 @@ async function copyExampleToRepo(exampleName) {
       +currentDateTime.getMinutes() +
       currentDateTime.getSeconds();
     const referenceDir = path.join(
-      tmpPath,
+      apgPath,
       '..',
       '..',
       'tests',
@@ -150,32 +216,37 @@ async function copyExampleToRepo(exampleName) {
     const filterFunc = src => {
       return src.indexOf('.html') === -1 || src === htmlFileAbsolute;
     };
-    console.log('Copying assets to timestamped local directory.\n\n');
+
+    const pathAfterPatterns = htmlFileAbsolute.split(`patterns${path.sep}`)[1];
+    const pathToExamples = pathAfterPatterns.substring(0, pathAfterPatterns.lastIndexOf(path.sep));
+
     await fse.copy(
-      path.join(
-        repoBasePath,
-        'examples',
-        htmlFileAbsolute.split(`examples${path.sep}`)[1].split(path.sep)[0]
-      ),
+      path.join(apgRepositoryBasePath, 'content', 'patterns', pathToExamples),
       referenceDir,
-      { filter: filterFunc }
+      {
+        filter: filterFunc,
+      }
     );
+
     const referenceHtml = locateFile(referenceDir, path.basename(examplePath));
     const referenceHtmlPath = path.join(
       'reference',
       referenceHtml.split(`reference${path.sep}`)[1]
     );
-    console.log(`Reference file created at ${posixPath(
+    console.log(`Reference files created at ${posixPath(
       `tests/${exampleName}/${referenceHtmlPath}`
+    )}.\n
+To switch the tests to run the updated reference:
+\t1. Update ${posixPath(
+      path.join('tests', exampleName, 'data', 'references.csv')
+    )} reference value with ${posixPath(referenceHtmlPath)}.
+\t2. Open the html file and edit it to only include the example. The title, imported assets, h1 with the example name, and the div with the actual example (Usually #ex1) need to be preserved, but everything else can be removed.
+\t3. Run npm run build --testplan=${exampleName}, to generate variations of the the new reference example with the setupScript values defined in ${posixPath(
+      path.join('tests', exampleName, 'data', 'tests.csv')
     )}.
-To switch the test to run the updated reference:
-\t1. Commit this change
-\t2. Update ${posixPath(
-      path.join('tests', exampleName, 'data', 'reference.csv')
-    )} with the reference ${posixPath(referenceHtmlPath)}
-\t3. Open the html file and edit it to only include the example. The title, imported assets, h1 with the example name, and the div with the actual example (Usually #ex1) need to be preserved, but everything else can be removed.`);
+\t4. Commit these changes.`);
   } finally {
-    await fse.remove(tmpPath);
+    await fse.remove(apgPath);
   }
 }
 

--- a/scripts/update-reference.js
+++ b/scripts/update-reference.js
@@ -9,21 +9,21 @@ let apgRepositoryBasePath = apgPath;
 const args = require('minimist')(process.argv.slice(2), {
   alias: {
     h: 'help',
-    r: 'aria-practices-directory',
+    r: 'aria-practices-repository',
   },
 });
 
 if (args.help) {
   console.log(`
 Default use:
-  node update-reference.js exampleName [-r ariaPracticesDirectory]
+  node update-reference.js exampleName [-r ariaPracticesRepository]
     It will copy the latest example html from the aria-practices repository into this repository.
     It will clone the latest aria-practices directory or use an existing clone.
     The example html url for the example needs to be specified in the references.csv file for the example named.
     The copied reference will be placed in a dated folder to provide a form of version control for the reference files.
-    The new reference will only be used when the reference.csv file, reference value is updated to point to the new reference folder.
+    The new reference will only be used when the references.csv file's reference value is updated to point to the new reference folder.
   Arguments:
-    -r, --aria-practices-directory
+    -r, --aria-practices-repository
     -h, --help
        Show this message.
 `);
@@ -69,7 +69,7 @@ async function copyExampleToRepo(exampleName) {
       console.log(
         `The test directory '${posixPath(
           testDirectory
-        )}' does not exist. Please enure the provide path name was correct.`
+        )}' does not exist. Please ensure the provide path name was correct.`
       );
       process.exit();
     }
@@ -143,9 +143,10 @@ async function copyExampleToRepo(exampleName) {
           exampleUrl +
           '" to "' +
           updatedExampleUrl +
-          '".\n[warning]: Please update the url found in tests/' +
+          '".\n' +
+          '[warning]: Please update the url found in tests/' +
           exampleName +
-          '/data/references.csv to the latest known location to avoid future issues when running this script.\n'
+          '/data/references.csv to the latest known example url to avoid future issues when running this script.\n'
       );
 
       exampleUrl = updatedExampleUrl;

--- a/scripts/update-reference.js
+++ b/scripts/update-reference.js
@@ -137,13 +137,13 @@ async function copyExampleToRepo(exampleName) {
       }
 
       console.log(
-        'Converting example url found for ' +
+        '[warning]: Converting example url found for ' +
           exampleName +
           ', from "' +
           exampleUrl +
           '" to "' +
           updatedExampleUrl +
-          '".\nPlease update the url found in tests/' +
+          '".\n[warning]: Please update the url found in tests/' +
           exampleName +
           '/data/references.csv to the latest known location to avoid future issues when running this script.\n'
       );

--- a/scripts/update-reference.js
+++ b/scripts/update-reference.js
@@ -112,7 +112,10 @@ async function copyExampleToRepo(exampleName) {
         ? 'https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/'
         : 'https://www.w3.org/WAI/ARIA/apg/patterns/';
 
-      updatedExampleUrl = exampleUrl.replace(oldApgBaseUrl, waiBaseUrl);
+      updatedExampleUrl = exampleUrl
+        .replace(oldApgBaseUrl, waiBaseUrl)
+        // All index.html from the older example folders are now {exampleName}.html
+        .replace('index.html', `${exampleName}.html`);
 
       if (exampleUrl.includes('/landmarks/')) {
         // Eg: https://w3c.github.io/aria-practices/examples/landmarks/banner.html to
@@ -123,11 +126,11 @@ async function copyExampleToRepo(exampleName) {
         //     https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert.html
         let examplePathToUpdate = updatedExampleUrl.split(waiBaseUrl)[1];
 
-        const insertIndex = updatedExampleUrl.indexOf('/');
+        const insertIndex = examplePathToUpdate.indexOf('/');
         if (insertIndex > -1)
           examplePathToUpdate =
             examplePathToUpdate.substring(0, insertIndex) +
-            'examples/' +
+            '/examples' +
             examplePathToUpdate.substring(insertIndex);
 
         updatedExampleUrl = waiBaseUrl + examplePathToUpdate;

--- a/scripts/update-reference.js
+++ b/scripts/update-reference.js
@@ -121,7 +121,6 @@ async function copyExampleToRepo(exampleName) {
       } else {
         // Eg: https://w3c.github.io/aria-practices/examples/alert/alert.html to
         //     https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert.html
-        console.log('pre.updatedExampleUrl', updatedExampleUrl);
         let examplePathToUpdate = updatedExampleUrl.split(waiBaseUrl)[1];
 
         const insertIndex = updatedExampleUrl.indexOf('/');
@@ -189,6 +188,7 @@ async function copyExampleToRepo(exampleName) {
           htmlFileAbsolute
         )}' does not exist. Please ensure the correct example html path is in references.csv.`
       );
+      await fse.remove(apgPath);
       process.exit();
     }
 


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1076--aria-at.netlify.app)

Addresses #1073.

This PR updates the `npm run update-reference` script to support the migration for example links in references.csv now that `w3.org/WAI/ARIA/apg` is being used in place of `w3c.github.io/aria-practices`.