### PR TITLE
Differentiate settings for prior releases of VO

### DIFF
--- a/tests/support.json
+++ b/tests/support.json
@@ -66,14 +66,14 @@
         "quickNavOn": {
           "screenText": "quick nav on",
           "instructions": [
-            "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+            "When using macOS 13 and earlier, simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
             "If VoiceOver said 'quick nav off', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back on."
           ]
         },
         "quickNavOff": {
           "screenText": "quick nav off",
           "instructions": [
-            "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+            "When using macOS 13 and earlier, simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
             "If VoiceOver said 'quick nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
           ]
         },


### PR DESCRIPTION
The version of VoiceOver bundled with macOS 14 introduced two settings where it previously offered one. Prior releases offered a single setting for quick navigation (which this group referred to as "quick nav"). Starting with the macOS 14 release, it offered two settings, dubbed by this group as "arrow quick key nav" and "single quick key nav."

The `support.json` file documents all three settings but does not explain the distinction. This may confuse readers who lack the historical context because the instructions for "quick nav" and "arrow quick key nav" are identical.

Extend the instructions for "quick nav" to explain the context in which this setting is relevant.

(This change was discussed at the June 5, 2024 meeting of the ARIA-AT Community Group: https://www.w3.org/2024/06/05-aria-at-minutes.html#t11)