### PR TITLE
Radio buttons for assertion verdicts

### DIFF
--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -9,7 +9,6 @@ import {
   render,
 } from './vrender.mjs';
 import {
-  AssertionResultMap,
   userCloseWindow,
   userOpenWindow,
   WhitespaceStyleMap,
@@ -423,8 +422,8 @@ function renderVirtualInstructionDocument(doc) {
               `cmd-${commandIndex}-assertion-${assertionIndex}`,
               {
                 label: 'Yes',
-                checked: assertion.passed === AssertionResultMap.PASS,
-                click: () => assertion.click(AssertionResultMap.PASS),
+                checked: assertion.passed === true,
+                click: () => assertion.click(true),
               }
             ),
             radioChoice(
@@ -432,8 +431,8 @@ function renderVirtualInstructionDocument(doc) {
               `cmd-${commandIndex}-assertion-${assertionIndex}`,
               {
                 label: 'No',
-                checked: assertion.passed === AssertionResultMap.FAIL,
-                click: () => assertion.click(AssertionResultMap.FAIL),
+                checked: assertion.passed === false,
+                click: () => assertion.click(false),
               }
             )
           )

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -415,7 +415,29 @@ function renderVirtualInstructionDocument(doc) {
       fieldset(
         className(['assertions']),
         legend(rich(command.assertionsHeader.descriptionHeader)),
-        ...command.assertions.map(bind(commandResultAssertion, commandIndex))
+        ...command.assertions.map((assertion, assertionIndex) =>
+          fieldset(
+            legend(rich(assertion.description)),
+            radioChoice(
+              `cmd-${commandIndex}-assertion-${assertionIndex}-yes`,
+              `cmd-${commandIndex}-assertion-${assertionIndex}`,
+              {
+                label: 'Yes',
+                checked: assertion.passed === AssertionResultMap.PASS,
+                click: () => assertion.click(AssertionResultMap.PASS),
+              }
+            ),
+            radioChoice(
+              `cmd-${commandIndex}-assertion-${assertionIndex}-no`,
+              `cmd-${commandIndex}-assertion-${assertionIndex}`,
+              {
+                label: 'No',
+                checked: assertion.passed === AssertionResultMap.FAIL,
+                click: () => assertion.click(AssertionResultMap.FAIL),
+              }
+            )
+          )
+        )
       ),
       ...[command.unexpectedBehaviors].map(bind(commandResultUnexpectedBehavior, commandIndex))
     );

--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -549,24 +549,6 @@ function renderVirtualInstructionDocument(doc) {
   }
 
   /**
-   * @param {number} commandIndex
-   * @param {InstructionDocumentResultsCommandsAssertion} assertion
-   * @param {number} assertionIndex
-   */
-  function commandResultAssertion(commandIndex, assertion, assertionIndex) {
-    return label(
-      className(['assertion']),
-      input(
-        type('checkbox'),
-        id(`cmd-${commandIndex}-${assertionIndex}`),
-        checked(assertion.passed === AssertionResultMap.PASS),
-        onclick(assertion.click)
-      ),
-      rich(assertion.description)
-    );
-  }
-
-  /**
    * @param {string} idKey
    * @param {string} nameKey
    * @param {InstructionDocumentAssertionChoice} choice

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1294,13 +1294,13 @@ export class TestRunInputOutput {
               description: assertion.assertion,
               highlightRequired: false,
               priority: assertion.priority,
-              result: CommonResultMap.NOT_SET,
+              result: null,
             })),
             additionalAssertions: test.additionalAssertions.map(assertion => ({
               description: assertion.assertion,
               highlightRequired: false,
               priority: assertion.priority,
-              result: CommonResultMap.NOT_SET,
+              result: null,
             })),
             unexpected: {
               highlightRequired: false,

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1515,7 +1515,7 @@ export class TestRunInputOutput {
               assertion.priority === 1 ? 'MUST' : assertion.priority === 2 ? 'SHOULD' : 'MAY',
             text: assertion.description,
           },
-          passed: assertion.result === 'pass',
+          passed: assertion.result,
           failedReason:
             assertion.result === 'failIncorrect'
               ? 'INCORRECT_OUTPUT'
@@ -1574,13 +1574,7 @@ export class TestRunInputOutput {
             return {
               ...assertion,
               highlightRequired: false,
-              result: assertionResult.passed
-                ? 'pass'
-                : assertionResult.failedReason === 'INCORRECT_OUTPUT'
-                ? 'failIncorrect'
-                : assertionResult.failedReason === 'NO_OUTPUT'
-                ? 'failMissing'
-                : 'fail',
+              result: assertionResult.passed,
             };
           }),
           unexpected: {

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -389,7 +389,7 @@ export function instructionDocument(resultState, hooks) {
     const resultAssertion = resultState.commands[commandIndex].assertions[assertionIndex];
     return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
       description: [assertion],
-      passed: resultAssertion.result === AssertionResultMap.PASS,
+      passed: resultAssertion.result,
       click: newResult =>
         hooks.setCommandAssertion({
           commandIndex,
@@ -409,15 +409,12 @@ export function instructionDocument(resultState, hooks) {
       resultState.commands[commandIndex].additionalAssertions[assertionIndex];
     return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
       description: [assertion],
-      passed: resultAdditionalAssertion.result === CommonResultMap.PASS,
-      click: () =>
+      passed: resultAdditionalAssertion.result,
+      click: newResult =>
         hooks.setCommandAssertion({
           commandIndex,
           assertionIndex,
-          result:
-            resultAdditionalAssertion.result === AssertionResultMap.PASS
-              ? AssertionResultMap.FAIL
-              : AssertionResultMap.PASS,
+          result: newResult,
         }),
     });
   }
@@ -851,14 +848,14 @@ function resultsTableDocument(state) {
         let failingAssertions = ['No failing assertions'];
         let unexpectedBehaviors = ['None'];
 
-        if (allAssertions.some(({ result }) => result === CommonResultMap.PASS)) {
+        if (allAssertions.some(({ result }) => result)) {
           passingAssertions = allAssertions
-            .filter(({ result }) => result === CommonResultMap.PASS)
+            .filter(({ result }) => result)
             .map(({ description }) => description);
         }
-        if (allAssertions.some(({ result }) => result !== CommonResultMap.PASS)) {
+        if (allAssertions.some(({ result }) => !result)) {
           failingAssertions = allAssertions
-            .filter(({ result }) => result !== CommonResultMap.PASS)
+            .filter(({ result }) => !result)
             .map(({ description }) => description);
         }
         if (command.unexpected.behaviors.some(({ checked }) => checked)) {
@@ -875,13 +872,10 @@ function resultsTableDocument(state) {
         return {
           description: command.description,
           support:
-            allAssertions.some(
-              ({ priority, result }) => priority === 1 && result !== CommonResultMap.PASS
-            ) || command.unexpected.behaviors.some(({ checked }) => checked)
+            allAssertions.some(({ priority, result }) => priority === 1 && !result) ||
+            command.unexpected.behaviors.some(({ checked }) => checked)
               ? 'FAILING'
-              : allAssertions.some(
-                  ({ priority, result }) => priority === 2 && result !== CommonResultMap.PASS
-                )
+              : allAssertions.some(({ priority, result }) => priority === 2 && !result)
               ? 'ALL_REQUIRED'
               : 'FULL',
           details: {

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -1100,7 +1100,7 @@ export function userValidateState() {
 /**
  * @typedef InstructionDocumentResultsCommandsAssertion
  * @property {Description} description
- * @property {Boolean} passed
+ * @property {Boolean | null} passed
  * @property {boolean} [focus]
  * @property {() => void} click
  */

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -390,14 +390,11 @@ export function instructionDocument(resultState, hooks) {
     return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
       description: [assertion],
       passed: resultAssertion.result === AssertionResultMap.PASS,
-      click: () =>
+      click: newResult =>
         hooks.setCommandAssertion({
           commandIndex,
           assertionIndex,
-          result:
-            resultAssertion.result === AssertionResultMap.PASS
-              ? AssertionResultMap.FAIL
-              : AssertionResultMap.PASS,
+          result: newResult,
         }),
     });
   }

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -471,7 +471,7 @@ export const AdditionalAssertionResultMap = createEnumMap({
 });
 
 /**
- * @typedef {EnumValues<typeof AssertionResultMap>} AssertionResult
+ * @typedef {boolean | null} AssertionResult
  */
 
 export const AssertionResultMap = createEnumMap({

--- a/tests/resources/types/aria-at-test-result.js
+++ b/tests/resources/types/aria-at-test-result.js
@@ -30,7 +30,7 @@
  * @property {object} scenarioResults[].assertionResults[].assertion
  * @property {AriaATTestResult.AssertionPriorityJSON} scenarioResults[].assertionResults[].assertion.priority
  * @property {string} scenarioResults[].assertionResults[].assertion.text
- * @property {boolean} scenarioResults[].assertionResults[].passed
+ * @property {boolean | null} scenarioResults[].assertionResults[].result
  * @property {AriaATTestResult.AssertionFailedReasonJSON | null} [scenarioResults[].assertionResults[].failedReason]
  * @property {object[]} scenarioResults[].unexpectedBehaviors
  * @property {string} scenarioResults[].unexpectedBehaviors[].id


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1090--aria-at.netlify.app)

This PR replaces the checkbox with "yes" & "no" radio buttons in the assertion verdict form fields. This is part of the work of addressing [aria-at-ap/#1045](https://github.com/w3c/aria-at-app/issues/1045). The related app change is [aria-at-app/#1161](https://github.com/w3c/aria-at-app/pull/1161).

Note that nested fieldset was used as it matched other UI in the form. In my testing, both screen and screenreader, this proved usable but I am open to other structures.

Now both `assertion.passed` and `assertion.result` are `Boolean | null`. The `result` can technically be a string because of the legacy `failedReason` which no current form uses. I did not remove the code associated with this. This is also why `result` has been kept instead of being removed entirely.