### PR TITLE
Action Menubutton with Active Descendant: Remove some assertions for insert+up

### DIFF
--- a/tests/menu-button-actions-active-descendant/data/jaws-commands.csv
+++ b/tests/menu-button-actions-active-descendant/data/jaws-commands.csv
@@ -20,9 +20,9 @@ openMenu,enter,pcCursor,,11.1
 openMenu,down,pcCursor,,11.2
 openMenuToLastItem,up,pcCursor,,13
 reqInfoAboutMenuItem,ins+tab,virtualCursor,,15
-reqInfoAboutMenuItem,ins+up,virtualCursor,,15.1
+reqInfoAboutMenuItem,ins+up,virtualCursor,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
 reqInfoAboutMenuItem,ins+tab,pcCursor,,15.2
-reqInfoAboutMenuItem,ins+up,pcCursor,,15.3
+reqInfoAboutMenuItem,ins+up,pcCursor,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
 navToFirstItemMenu,home,pcCursor,,17
 navToFirstItemMenu,down,pcCursor,,17.1
 navToLastItemMenu,end,pcCursor,,19

--- a/tests/menu-button-actions-active-descendant/data/jaws-commands.csv
+++ b/tests/menu-button-actions-active-descendant/data/jaws-commands.csv
@@ -20,9 +20,9 @@ openMenu,enter,pcCursor,,11.1
 openMenu,down,pcCursor,,11.2
 openMenuToLastItem,up,pcCursor,,13
 reqInfoAboutMenuItem,ins+tab,virtualCursor,,15
-reqInfoAboutMenuItem,ins+up,virtualCursor,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
+reqInfoAboutMenuItem,ins+up,virtualCursor,3:positionFocusedItemMenu1 3:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
 reqInfoAboutMenuItem,ins+tab,pcCursor,,15.2
-reqInfoAboutMenuItem,ins+up,pcCursor,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
+reqInfoAboutMenuItem,ins+up,pcCursor,3:positionFocusedItemMenu1 3:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
 navToFirstItemMenu,home,pcCursor,,17
 navToFirstItemMenu,down,pcCursor,,17.1
 navToLastItemMenu,end,pcCursor,,19

--- a/tests/menu-button-actions-active-descendant/data/nvda-commands.csv
+++ b/tests/menu-button-actions-active-descendant/data/nvda-commands.csv
@@ -20,9 +20,9 @@ openMenu,enter,focusMode,,11.1
 openMenu,down,focusMode,,11.2
 openMenuToLastItem,up,focusMode,,13
 reqInfoAboutMenuItem,ins+tab,browseMode,,15
-reqInfoAboutMenuItem,ins+up,browseMode,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
+reqInfoAboutMenuItem,ins+up,browseMode,3:positionFocusedItemMenu1 3:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
 reqInfoAboutMenuItem,ins+tab,focusMode,,15.2
-reqInfoAboutMenuItem,ins+up,focusMode,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
+reqInfoAboutMenuItem,ins+up,focusMode,3:positionFocusedItemMenu1 3:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
 navToFirstItemMenu,home,focusMode,,17
 navToFirstItemMenu,down,focusMode,,17.1
 navToLastItemMenu,end,focusMode,,19

--- a/tests/menu-button-actions-active-descendant/data/nvda-commands.csv
+++ b/tests/menu-button-actions-active-descendant/data/nvda-commands.csv
@@ -20,9 +20,9 @@ openMenu,enter,focusMode,,11.1
 openMenu,down,focusMode,,11.2
 openMenuToLastItem,up,focusMode,,13
 reqInfoAboutMenuItem,ins+tab,browseMode,,15
-reqInfoAboutMenuItem,ins+up,browseMode,,15.1
+reqInfoAboutMenuItem,ins+up,browseMode,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.1
 reqInfoAboutMenuItem,ins+tab,focusMode,,15.2
-reqInfoAboutMenuItem,ins+up,focusMode,,15.3
+reqInfoAboutMenuItem,ins+up,focusMode,0:positionFocusedItemMenu1 0:numberItemsMenu4 0:nameMenuActions 0:roleMenu,15.3
 navToFirstItemMenu,home,focusMode,,17
 navToFirstItemMenu,down,focusMode,,17.1
 navToLastItemMenu,end,focusMode,,19


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1097--aria-at.netlify.app)

Consistent with the request in #1094, when requesting info about a menuitem inside of a menu with insert+up, changed assertions so that:
* Assertions for setsize and posinset are optional.
* Assertions for menu container name and menu container role are omitted.

Made equivalent changes for both JAWS and NVDA.

Does not change VoiceOver because request info commands vo-f3 and vo-f4 are not expected to have different verbosity levels.