### PR TITLE
Ignore variable values when checking mocks with `npm test`

### DIFF
--- a/__test__/__snapshots__/createReviewPages.test.js.snap
+++ b/__test__/__snapshots__/createReviewPages.test.js.snap
@@ -54,8 +54,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/alert/index.html" aria-label="Index: alert">Index</a></td>
             <td><a href="./review/alert.html" aria-label="Review: alert">Review</a></td>
             <td><p aria-label="Number of Tests: 1">1</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/ca4c80fd" target="_blank">ca4c80fd Change priority of role assertion to 3 (#1054)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Banner Landmark</th>
@@ -63,8 +62,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/banner/index.html" aria-label="Index: banner">Index</a></td>
             <td><a href="./review/banner.html" aria-label="Review: banner">Review</a></td>
             <td><p aria-label="Number of Tests: 26">26</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/836fb2a9" target="_blank">836fb2a9 Validation for test csv formats (#980)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Color Viewer Slider</th>
@@ -72,8 +70,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/horizontal-slider/index.html" aria-label="Index: horizontal-slider">Index</a></td>
             <td><a href="./review/horizontal-slider.html" aria-label="Review: horizontal-slider">Review</a></td>
             <td><p aria-label="Number of Tests: 9">9</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6d4763d8" target="_blank">6d4763d8 Update singleQuickKeyNavOn for J and shift+j VoiceOver commands (#1082)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Command Button Example</th>
@@ -81,8 +78,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/command-button/index.html" aria-label="Index: command-button">Index</a></td>
             <td><a href="./review/command-button.html" aria-label="Review: command-button">Review</a></td>
             <td><p aria-label="Number of Tests: 3">3</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/5d5ba084" target="_blank">5d5ba084 Update VoiceOver navigation commands for Command and Toggle Button (#1048)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -7192,8 +7188,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/alert/index.html" aria-label="Index: alert">Index</a></td>
             <td><a href="./review/alert.html" aria-label="Review: alert">Review</a></td>
             <td><p aria-label="Number of Tests: 1">1</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/ca4c80fd" target="_blank">ca4c80fd Change priority of role assertion to 3 (#1054)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Banner Landmark</th>
@@ -7201,8 +7196,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/banner/index.html" aria-label="Index: banner">Index</a></td>
             <td><a href="./review/banner.html" aria-label="Review: banner">Review</a></td>
             <td><p aria-label="Number of Tests: 26">26</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/836fb2a9" target="_blank">836fb2a9 Validation for test csv formats (#980)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Color Viewer Slider</th>
@@ -7210,8 +7204,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/horizontal-slider/index.html" aria-label="Index: horizontal-slider">Index</a></td>
             <td><a href="./review/horizontal-slider.html" aria-label="Review: horizontal-slider">Review</a></td>
             <td><p aria-label="Number of Tests: 9">9</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6d4763d8" target="_blank">6d4763d8 Update singleQuickKeyNavOn for J and shift+j VoiceOver commands (#1082)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Command Button Example</th>
@@ -7219,8 +7212,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/command-button/index.html" aria-label="Index: command-button">Index</a></td>
             <td><a href="./review/command-button.html" aria-label="Review: command-button">Review</a></td>
             <td><p aria-label="Number of Tests: 3">3</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/5d5ba084" target="_blank">5d5ba084 Update VoiceOver navigation commands for Command and Toggle Button (#1048)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -14330,8 +14322,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/alert/index.html" aria-label="Index: alert">Index</a></td>
             <td><a href="./review/alert.html" aria-label="Review: alert">Review</a></td>
             <td><p aria-label="Number of Tests: 1">1</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/ca4c80fd" target="_blank">ca4c80fd Change priority of role assertion to 3 (#1054)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Banner Landmark</th>
@@ -14339,8 +14330,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/banner/index.html" aria-label="Index: banner">Index</a></td>
             <td><a href="./review/banner.html" aria-label="Review: banner">Review</a></td>
             <td><p aria-label="Number of Tests: 26">26</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/836fb2a9" target="_blank">836fb2a9 Validation for test csv formats (#980)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Color Viewer Slider</th>
@@ -14348,8 +14338,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/horizontal-slider/index.html" aria-label="Index: horizontal-slider">Index</a></td>
             <td><a href="./review/horizontal-slider.html" aria-label="Review: horizontal-slider">Review</a></td>
             <td><p aria-label="Number of Tests: 9">9</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6d4763d8" target="_blank">6d4763d8 Update singleQuickKeyNavOn for J and shift+j VoiceOver commands (#1082)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Command Button Example</th>
@@ -14357,8 +14346,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/command-button/index.html" aria-label="Index: command-button">Index</a></td>
             <td><a href="./review/command-button.html" aria-label="Review: command-button">Review</a></td>
             <td><p aria-label="Number of Tests: 3">3</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/5d5ba084" target="_blank">5d5ba084 Update VoiceOver navigation commands for Command and Toggle Button (#1048)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -21468,8 +21456,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/alert/index.html" aria-label="Index: alert">Index</a></td>
             <td><a href="./review/alert.html" aria-label="Review: alert">Review</a></td>
             <td><p aria-label="Number of Tests: 1">1</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/ca4c80fd" target="_blank">ca4c80fd Change priority of role assertion to 3 (#1054)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Banner Landmark</th>
@@ -21477,8 +21464,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/banner/index.html" aria-label="Index: banner">Index</a></td>
             <td><a href="./review/banner.html" aria-label="Review: banner">Review</a></td>
             <td><p aria-label="Number of Tests: 26">26</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/836fb2a9" target="_blank">836fb2a9 Validation for test csv formats (#980)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Color Viewer Slider</th>
@@ -21486,8 +21472,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/horizontal-slider/index.html" aria-label="Index: horizontal-slider">Index</a></td>
             <td><a href="./review/horizontal-slider.html" aria-label="Review: horizontal-slider">Review</a></td>
             <td><p aria-label="Number of Tests: 9">9</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6d4763d8" target="_blank">6d4763d8 Update singleQuickKeyNavOn for J and shift+j VoiceOver commands (#1082)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
           <tr>
             <th>Command Button Example</th>
@@ -21495,8 +21480,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
             <td><a href="./tests/command-button/index.html" aria-label="Index: command-button">Index</a></td>
             <td><a href="./review/command-button.html" aria-label="Review: command-button">Review</a></td>
             <td><p aria-label="Number of Tests: 3">3</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/5d5ba084" target="_blank">5d5ba084 Update VoiceOver navigation commands for Command and Toggle Button (#1048)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -28606,8 +28590,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
             <td><a href="./tests/banner/index.html" aria-label="Index: banner">Index</a></td>
             <td><a href="./review/banner.html" aria-label="Review: banner">Review</a></td>
             <td><p aria-label="Number of Tests: 26">26</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/836fb2a9" target="_blank">836fb2a9 Validation for test csv formats (#980)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -31621,8 +31604,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
             <td><a href="./tests/alert/index.html" aria-label="Index: alert">Index</a></td>
             <td><a href="./review/alert.html" aria-label="Review: alert">Review</a></td>
             <td><p aria-label="Number of Tests: 1">1</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/ca4c80fd" target="_blank">ca4c80fd Change priority of role assertion to 3 (#1054)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -32104,8 +32086,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
             <td><a href="./tests/command-button/index.html" aria-label="Index: command-button">Index</a></td>
             <td><a href="./review/command-button.html" aria-label="Review: command-button">Review</a></td>
             <td><p aria-label="Number of Tests: 3">3</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/5d5ba084" target="_blank">5d5ba084 Update VoiceOver navigation commands for Command and Toggle Button (#1048)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 
@@ -33258,8 +33239,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
             <td><a href="./tests/horizontal-slider/index.html" aria-label="Index: horizontal-slider">Index</a></td>
             <td><a href="./review/horizontal-slider.html" aria-label="Review: horizontal-slider">Review</a></td>
             <td><p aria-label="Number of Tests: 9">9</p></td>
-            <td><a href="https://github.com/w3c/aria-at/commit/6d4763d8" target="_blank">6d4763d8 Update singleQuickKeyNavOn for J and shift+j VoiceOver commands (#1082)
-</a></td>
+            <td><a href="https://github.com/w3c/aria-at/commit/" target="_blank"></a></td>
           </tr>
     </table>
 

--- a/__test__/__snapshots__/createReviewPages.test.js.snap
+++ b/__test__/__snapshots__/createReviewPages.test.js.snap
@@ -265,7 +265,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Trigger an alert</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Thu Apr 25 20:00:57 2024 -0700</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/alert/test-03-triggerAlert.html?at=jaws">JAWS</a></li>
@@ -722,7 +722,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda">Test 1: Navigate forwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -946,7 +946,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 2: Navigate forwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -1030,7 +1030,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 3: Navigate forwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -1101,7 +1101,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 4: Navigate backwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -1285,7 +1285,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 5: Navigate backwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -1369,7 +1369,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 6: Navigate backwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -1440,7 +1440,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 7: Navigate forwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -1584,7 +1584,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 8: Navigate forwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -1668,7 +1668,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 9: Navigate forwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -1739,7 +1739,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 10: Navigate backwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -1883,7 +1883,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 11: Navigate backwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -1967,7 +1967,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 12: Navigate backwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -2038,7 +2038,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 13: Navigate forwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -2252,7 +2252,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 14: Navigate forwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -2354,7 +2354,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 15: Navigate forwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -2471,7 +2471,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 16: Navigate backwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -2660,7 +2660,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 17: Navigate backwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -2753,7 +2753,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 18: Navigate backwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -2857,7 +2857,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 19: Navigate forwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -2941,7 +2941,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 20: Navigate forwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -2992,7 +2992,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 21: Navigate backwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -3076,7 +3076,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 22: Navigate backwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -3127,7 +3127,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 23: Navigate forwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -3267,7 +3267,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 24: Navigate forwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -3322,7 +3322,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 25: Navigate backwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -3462,7 +3462,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 26: Navigate backwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -3694,7 +3694,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-05-navForwardsToButton.html?at=jaws">JAWS</a></li>
@@ -4036,7 +4036,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-06-navBackToButton.html?at=jaws">JAWS</a></li>
@@ -4378,7 +4378,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-09-reqInfoAboutButton.html?at=jaws">JAWS</a></li>
@@ -4816,7 +4816,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-05-navForwardsToSlider.html?at=jaws">JAWS</a></li>
@@ -5341,7 +5341,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-06-navBackToSlider.html?at=jaws">JAWS</a></li>
@@ -5866,7 +5866,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-09-reqInfoAboutSlider.html?at=jaws">JAWS</a></li>
@@ -6337,7 +6337,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 4: Increment a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-11-incrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -6520,7 +6520,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 5: Decrement a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-13-decrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -6703,7 +6703,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 6: Increment a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-15-incrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -6811,7 +6811,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 7: Decrement a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-17-decrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -6919,7 +6919,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 8: Decrement a slider to the minimum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-19-decrementSliderToMinimumValue.html?at=jaws">JAWS</a></li>
@@ -7027,7 +7027,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 9: Increment a slider to the maximum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-21-incrementSliderToMaximumValue.html?at=jaws">JAWS</a></li>
@@ -7403,7 +7403,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Trigger an alert</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Thu Apr 25 20:00:57 2024 -0700</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/alert/test-03-triggerAlert.html?at=jaws">JAWS</a></li>
@@ -7860,7 +7860,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda">Test 1: Navigate forwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -8084,7 +8084,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 2: Navigate forwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -8168,7 +8168,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 3: Navigate forwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -8239,7 +8239,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 4: Navigate backwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -8423,7 +8423,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 5: Navigate backwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -8507,7 +8507,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 6: Navigate backwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -8578,7 +8578,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 7: Navigate forwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -8722,7 +8722,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 8: Navigate forwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -8806,7 +8806,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 9: Navigate forwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -8877,7 +8877,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 10: Navigate backwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -9021,7 +9021,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 11: Navigate backwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -9105,7 +9105,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 12: Navigate backwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -9176,7 +9176,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 13: Navigate forwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -9390,7 +9390,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 14: Navigate forwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -9492,7 +9492,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 15: Navigate forwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -9609,7 +9609,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 16: Navigate backwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -9798,7 +9798,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 17: Navigate backwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -9891,7 +9891,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 18: Navigate backwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -9995,7 +9995,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 19: Navigate forwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -10079,7 +10079,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 20: Navigate forwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -10130,7 +10130,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 21: Navigate backwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -10214,7 +10214,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 22: Navigate backwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -10265,7 +10265,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 23: Navigate forwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -10405,7 +10405,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 24: Navigate forwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -10460,7 +10460,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 25: Navigate backwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -10600,7 +10600,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 26: Navigate backwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -10832,7 +10832,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-05-navForwardsToButton.html?at=jaws">JAWS</a></li>
@@ -11174,7 +11174,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-06-navBackToButton.html?at=jaws">JAWS</a></li>
@@ -11516,7 +11516,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-09-reqInfoAboutButton.html?at=jaws">JAWS</a></li>
@@ -11954,7 +11954,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-05-navForwardsToSlider.html?at=jaws">JAWS</a></li>
@@ -12479,7 +12479,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-06-navBackToSlider.html?at=jaws">JAWS</a></li>
@@ -13004,7 +13004,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-09-reqInfoAboutSlider.html?at=jaws">JAWS</a></li>
@@ -13475,7 +13475,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 4: Increment a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-11-incrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -13658,7 +13658,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 5: Decrement a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-13-decrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -13841,7 +13841,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 6: Increment a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-15-incrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -13949,7 +13949,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 7: Decrement a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-17-decrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -14057,7 +14057,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 8: Decrement a slider to the minimum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-19-decrementSliderToMinimumValue.html?at=jaws">JAWS</a></li>
@@ -14165,7 +14165,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 9: Increment a slider to the maximum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-21-incrementSliderToMaximumValue.html?at=jaws">JAWS</a></li>
@@ -14541,7 +14541,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Trigger an alert</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Thu Apr 25 20:00:57 2024 -0700</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/alert/test-03-triggerAlert.html?at=jaws">JAWS</a></li>
@@ -14998,7 +14998,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda">Test 1: Navigate forwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -15222,7 +15222,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 2: Navigate forwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -15306,7 +15306,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 3: Navigate forwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -15377,7 +15377,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 4: Navigate backwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -15561,7 +15561,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 5: Navigate backwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -15645,7 +15645,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 6: Navigate backwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -15716,7 +15716,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 7: Navigate forwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -15860,7 +15860,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 8: Navigate forwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -15944,7 +15944,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 9: Navigate forwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -16015,7 +16015,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 10: Navigate backwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -16159,7 +16159,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 11: Navigate backwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -16243,7 +16243,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 12: Navigate backwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -16314,7 +16314,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 13: Navigate forwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -16528,7 +16528,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 14: Navigate forwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -16630,7 +16630,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 15: Navigate forwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -16747,7 +16747,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 16: Navigate backwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -16936,7 +16936,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 17: Navigate backwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -17029,7 +17029,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 18: Navigate backwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -17133,7 +17133,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 19: Navigate forwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -17217,7 +17217,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 20: Navigate forwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -17268,7 +17268,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 21: Navigate backwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -17352,7 +17352,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 22: Navigate backwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -17403,7 +17403,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 23: Navigate forwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -17543,7 +17543,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 24: Navigate forwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -17598,7 +17598,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 25: Navigate backwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -17738,7 +17738,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 26: Navigate backwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -17970,7 +17970,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-05-navForwardsToButton.html?at=jaws">JAWS</a></li>
@@ -18312,7 +18312,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-06-navBackToButton.html?at=jaws">JAWS</a></li>
@@ -18654,7 +18654,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-09-reqInfoAboutButton.html?at=jaws">JAWS</a></li>
@@ -19092,7 +19092,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-05-navForwardsToSlider.html?at=jaws">JAWS</a></li>
@@ -19617,7 +19617,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-06-navBackToSlider.html?at=jaws">JAWS</a></li>
@@ -20142,7 +20142,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-09-reqInfoAboutSlider.html?at=jaws">JAWS</a></li>
@@ -20613,7 +20613,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 4: Increment a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-11-incrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -20796,7 +20796,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 5: Decrement a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-13-decrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -20979,7 +20979,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 6: Increment a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-15-incrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -21087,7 +21087,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 7: Decrement a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-17-decrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -21195,7 +21195,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 8: Decrement a slider to the minimum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-19-decrementSliderToMinimumValue.html?at=jaws">JAWS</a></li>
@@ -21303,7 +21303,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 9: Increment a slider to the maximum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-21-incrementSliderToMaximumValue.html?at=jaws">JAWS</a></li>
@@ -21679,7 +21679,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Trigger an alert</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Thu Apr 25 20:00:57 2024 -0700</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/alert/test-03-triggerAlert.html?at=jaws">JAWS</a></li>
@@ -22136,7 +22136,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda">Test 1: Navigate forwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -22360,7 +22360,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 2: Navigate forwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -22444,7 +22444,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 3: Navigate forwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -22515,7 +22515,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 4: Navigate backwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -22699,7 +22699,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 5: Navigate backwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -22783,7 +22783,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 6: Navigate backwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -22854,7 +22854,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 7: Navigate forwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -22998,7 +22998,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 8: Navigate forwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -23082,7 +23082,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 9: Navigate forwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -23153,7 +23153,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 10: Navigate backwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -23297,7 +23297,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 11: Navigate backwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -23381,7 +23381,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 12: Navigate backwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -23452,7 +23452,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 13: Navigate forwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -23666,7 +23666,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 14: Navigate forwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -23768,7 +23768,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 15: Navigate forwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -23885,7 +23885,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 16: Navigate backwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -24074,7 +24074,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 17: Navigate backwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -24167,7 +24167,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 18: Navigate backwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -24271,7 +24271,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 19: Navigate forwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -24355,7 +24355,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 20: Navigate forwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -24406,7 +24406,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 21: Navigate backwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -24490,7 +24490,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 22: Navigate backwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -24541,7 +24541,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 23: Navigate forwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -24681,7 +24681,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 24: Navigate forwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -24736,7 +24736,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda">Test 25: Navigate backwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -24876,7 +24876,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="voiceover_macos">Test 26: Navigate backwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -25108,7 +25108,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-05-navForwardsToButton.html?at=jaws">JAWS</a></li>
@@ -25450,7 +25450,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-06-navBackToButton.html?at=jaws">JAWS</a></li>
@@ -25792,7 +25792,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-09-reqInfoAboutButton.html?at=jaws">JAWS</a></li>
@@ -26230,7 +26230,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-05-navForwardsToSlider.html?at=jaws">JAWS</a></li>
@@ -26755,7 +26755,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-06-navBackToSlider.html?at=jaws">JAWS</a></li>
@@ -27280,7 +27280,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-09-reqInfoAboutSlider.html?at=jaws">JAWS</a></li>
@@ -27751,7 +27751,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 4: Increment a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-11-incrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -27934,7 +27934,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 5: Decrement a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-13-decrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -28117,7 +28117,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 6: Increment a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-15-incrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -28225,7 +28225,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 7: Decrement a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-17-decrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -28333,7 +28333,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 8: Decrement a slider to the minimum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-19-decrementSliderToMinimumValue.html?at=jaws">JAWS</a></li>
@@ -28441,7 +28441,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 9: Increment a slider to the maximum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-21-incrementSliderToMaximumValue.html?at=jaws">JAWS</a></li>
@@ -28769,7 +28769,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
 
     <h2 class="jaws nvda">Test 1: Navigate forwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-01-navigate-forwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -28993,7 +28993,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 2: Navigate forwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-02-navigate-forwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -29077,7 +29077,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 3: Navigate forwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-03-navigate-forwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -29148,7 +29148,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 4: Navigate backwards into a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-04-navigate-backwards-into-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -29332,7 +29332,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 5: Navigate backwards into a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-05-navigate-backwards-into-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -29416,7 +29416,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 6: Navigate backwards into a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-06-navigate-backwards-into-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -29487,7 +29487,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 7: Navigate forwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-07-navigate-forwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -29631,7 +29631,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 8: Navigate forwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-08-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -29715,7 +29715,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 9: Navigate forwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-09-navigate-forwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -29786,7 +29786,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 10: Navigate backwards out of a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-10-navigate-backwards-out-of-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -29930,7 +29930,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 11: Navigate backwards out of a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-11-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -30014,7 +30014,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 12: Navigate backwards out of a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-12-navigate-backwards-out-of-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -30085,7 +30085,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 13: Navigate forwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -30299,7 +30299,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 14: Navigate forwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -30401,7 +30401,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 15: Navigate forwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -30518,7 +30518,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 16: Navigate backwards to a button inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -30707,7 +30707,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 17: Navigate backwards to a button inside a banner landmark in interaction mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=jaws">JAWS</a></li>
@@ -30800,7 +30800,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 18: Navigate backwards to a button inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -30904,7 +30904,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 19: Navigate forwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -30988,7 +30988,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 20: Navigate forwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -31039,7 +31039,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 21: Navigate backwards to an image inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -31123,7 +31123,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 22: Navigate backwards to an image inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -31174,7 +31174,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 23: Navigate forwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -31314,7 +31314,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 24: Navigate forwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -31369,7 +31369,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="jaws nvda">Test 25: Navigate backwards to a heading inside a banner landmark in reading mode</h2>
     <ul class="jaws nvda">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading.html?at=jaws">JAWS</a></li>
@@ -31509,7 +31509,7 @@ exports[`review pages creation runs createReviewPages successfully for v1 tests 
       </div>
     <h2 class="voiceover_macos">Test 26: Navigate backwards to a heading inside a banner landmark</h2>
     <ul class="voiceover_macos">
-      <li>Last Edited: Wed Aug 23 16:30:34 2023 -0400</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/banner/test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction.html?at=voiceover_macos">VoiceOver for macOS</a></li>
@@ -31767,7 +31767,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Trigger an alert</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Thu Apr 25 20:00:57 2024 -0700</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/alert/test-03-triggerAlert.html?at=jaws">JAWS</a></li>
@@ -32256,7 +32256,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-05-navForwardsToButton.html?at=jaws">JAWS</a></li>
@@ -32598,7 +32598,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-06-navBackToButton.html?at=jaws">JAWS</a></li>
@@ -32940,7 +32940,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a button</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Tue Mar 12 15:04:25 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/command-button/test-09-reqInfoAboutButton.html?at=jaws">JAWS</a></li>
@@ -33410,7 +33410,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
 
     <h2 class="jaws nvda voiceover_macos">Test 1: Navigate forwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-05-navForwardsToSlider.html?at=jaws">JAWS</a></li>
@@ -33935,7 +33935,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 2: Navigate backwards to a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-06-navBackToSlider.html?at=jaws">JAWS</a></li>
@@ -34460,7 +34460,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 3: Request information about a slider</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-09-reqInfoAboutSlider.html?at=jaws">JAWS</a></li>
@@ -34931,7 +34931,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 4: Increment a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-11-incrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -35114,7 +35114,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 5: Decrement a slider by one step</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-13-decrementSliderByOneStep.html?at=jaws">JAWS</a></li>
@@ -35297,7 +35297,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 6: Increment a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-15-incrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -35405,7 +35405,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 7: Decrement a slider by ten steps</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-17-decrementSliderByTenSteps.html?at=jaws">JAWS</a></li>
@@ -35513,7 +35513,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 8: Decrement a slider to the minimum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-19-decrementSliderToMinimumValue.html?at=jaws">JAWS</a></li>
@@ -35621,7 +35621,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
       </div>
     <h2 class="jaws nvda voiceover_macos">Test 9: Increment a slider to the maximum value</h2>
     <ul class="jaws nvda voiceover_macos">
-      <li>Last Edited: Wed Jun 26 11:57:35 2024 -0600</li>
+      <li>Last Edited: </li>
       <li>Tests:
         <ul>
             <li><a href="../tests/horizontal-slider/test-21-incrementSliderToMaximumValue.html?at=jaws">JAWS</a></li>

--- a/scripts/test-reviewer/createReviewPages.mjs
+++ b/scripts/test-reviewer/createReviewPages.mjs
@@ -225,5 +225,10 @@ export function createReviewPages(config) {
   });
 
   // Generate build/index.html entry file
-  generateIndexPage({ indexTemplate, allTestsForPattern, indexFileBuildOutputPath });
+  generateIndexPage({
+    indexTemplate,
+    allTestsForPattern,
+    indexFileBuildOutputPath,
+    testMode: args.testMode,
+  });
 }

--- a/scripts/test-reviewer/createReviewPages.mjs
+++ b/scripts/test-reviewer/createReviewPages.mjs
@@ -196,7 +196,7 @@ export function createReviewPages(config) {
         helpLinks,
         helpLinksTitle,
         helpLinksExist,
-        lastEdited,
+        lastEdited: args.testMode ? null : lastEdited,
         isV2,
       });
     });

--- a/scripts/test-reviewer/generateReviewPages.mjs
+++ b/scripts/test-reviewer/generateReviewPages.mjs
@@ -13,6 +13,7 @@ const generatePatternPages = ({
   allTestsForPattern,
   referencesForPattern,
   reviewBuildDirectory,
+  testMode = false,
 }) => {
   patterns.forEach(pattern => {
     const references = referencesForPattern[pattern];
@@ -33,7 +34,12 @@ const generatePatternPages = ({
   });
 };
 
-const generateIndexPage = ({ indexTemplate, allTestsForPattern, indexFileBuildOutputPath }) => {
+const generateIndexPage = ({
+  indexTemplate,
+  allTestsForPattern,
+  indexFileBuildOutputPath,
+  testMode = false,
+}) => {
   const renderedIndex = mustache.render(indexTemplate, {
     patterns: Object.keys(allTestsForPattern)
       .map(pattern => {
@@ -48,8 +54,8 @@ const generateIndexPage = ({ indexTemplate, allTestsForPattern, indexFileBuildOu
           patternName: pattern,
           title: allTestsForPattern[pattern][0].title,
           numberOfTests: allTestsForPattern[pattern].length,
-          commit: lastCommit.split(' ')[0],
-          commitDescription: lastCommit,
+          commit: testMode ? null : lastCommit.split(' ')[0],
+          commitDescription: testMode ? null : lastCommit,
         };
       })
       .sort((a, b) => {


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1166--aria-at.netlify.app)

This is to avoid unnecessary snapshot failures, such as in #1165

* Ignore `lastEdited` value when creating review pages in test
* Ignore `commit` and `commitDescription` values when creating review index page in test

Those values had to be derived from the source folder rather than the tests' mock data so no need to track