### PR TITLE
Radio Group Test Plans Update

### DIFF
--- a/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,virtualCursor,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,a,virtualCursor,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,0:nameGroupPizzaCrust,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,virtualCursor,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,pcCursor,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,virtualCursor,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,virtualCursor,0:nam
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,pcCursor,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,virtualCursor,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,a,virtualCursor,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,0:nameGroupPizzaCrust,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,virtualCursor,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,pcCursor,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,virtualCursor,,7

--- a/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,,10.1
+navOutStartRadioGroup,up up,virtualCursor,0:nameGroupPizzaCrust,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,virtualCursor,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,a,virtualCursor,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,0:nameGroupPizzaCrust,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down down,virtualCursor,0:nameGroupPizzaCrust,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,virtualCursor,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,pcCursor,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,virtualCursor,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,virtualCursor,0:nam
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,pcCursor,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,virtualCursor,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,a,virtualCursor,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,0:nameGroupPizzaCrust,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down down,virtualCursor,0:nameGroupPizzaCrust,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,virtualCursor,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,pcCursor,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,virtualCursor,,7

--- a/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,,10.1
+navOutStartRadioGroup,up up up,virtualCursor,,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/jaws-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,virtualCursor,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,a,virtualCursor,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down down,virtualCursor,0:nameGroupPizzaCrust,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down down,virtualCursor,,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,virtualCursor,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,pcCursor,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,virtualCursor,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,virtualCursor,0:nam
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,pcCursor,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,virtualCursor,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,a,virtualCursor,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down down,virtualCursor,0:nameGroupPizzaCrust,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down down,virtualCursor,,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,virtualCursor,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,pcCursor,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,virtualCursor,,7
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,0:nameGroupPizzaCrust,10.1
+navOutStartRadioGroup,up up,virtualCursor,,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
+++ b/tests/radiogroup-aria-activedescendant/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
@@ -8,3 +8,4 @@ radios.forEach(r => {
 radios[0].classList.add('focus');
 radios[0].setAttribute('aria-checked', 'true');
 radioGroup.setAttribute('aria-activedescendant', radios[0].id);
+testPageDocument.querySelector('#beforelink').focus();

--- a/tests/radiogroup-aria-activedescendant/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
+++ b/tests/radiogroup-aria-activedescendant/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
@@ -1,4 +1,4 @@
-// sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading
+// sets the state of the first radio button to checked, and sets focus on a link before the radio group
 let radioGroup = testPageDocument.querySelector('[role="radiogroup"]');
 let radios = testPageDocument.querySelectorAll('[role="radio"]');
 radios.forEach(r => {
@@ -8,5 +8,3 @@ radios.forEach(r => {
 radios[0].classList.add('focus');
 radios[0].setAttribute('aria-checked', 'true');
 radioGroup.setAttribute('aria-activedescendant', radios[0].id);
-testPageDocument.querySelector('#beforelink').focus();
-testPageDocument.querySelector('#group_label_1').style.display = 'none';

--- a/tests/radiogroup-aria-activedescendant/data/js/setFocusBeforeRadioGroup.js
+++ b/tests/radiogroup-aria-activedescendant/data/js/setFocusBeforeRadioGroup.js
@@ -1,3 +1,2 @@
-// sets focus on a link before the radio group, and hides the group heading
+// sets focus on a link before the radio group
 testPageDocument.querySelector('#beforelink').focus();
-testPageDocument.querySelector('#group_label_1').style.display = 'none';

--- a/tests/radiogroup-aria-activedescendant/data/js/setFocusOnFirstRadioButton.js
+++ b/tests/radiogroup-aria-activedescendant/data/js/setFocusOnFirstRadioButton.js
@@ -7,5 +7,4 @@ radios.forEach(r => {
 });
 radios[0].classList.add('focus');
 radioGroup.setAttribute('aria-activedescendant', radios[0].id);
-testPageDocument.querySelector('#group_label_1').style.display = 'none';
 radioGroup.focus();

--- a/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,browseMode,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,r,browseMode,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,0:nameGroupPizzaCrust,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,browseMode,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,focusMode,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,browseMode,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,browseMode,0:nameTh
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,focusMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,browseMode,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,r,browseMode,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,0:nameGroupPizzaCrust,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,browseMode,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,focusMode,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,browseMode,,7
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up,browseMode,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up up,browseMode,0:nameGroupPizzaCrust,10.1
+navOutStartRadioGroup,up up,browseMode,,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
@@ -1,22 +1,26 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,browseMode,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,r,browseMode,,1.1
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,0:nameGroupPizzaCrust,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,browseMode,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,focusMode,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,browseMode,,3
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+r,browseMode,,3.1
+navBackInToRadioGroupWhereNoRadioButtonsAreChecked,up,browseMode,,3.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,browseMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1 2:interactionModeEnabled,3.3
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,focusMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,browseMode,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,r,browseMode,,5.1
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,0:nameGroupPizzaCrust,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,browseMode,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,focusMode,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,browseMode,,7
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+r,browseMode,,7.1
+NavBackIntoRadioGroupWhereLastRadioChecked,up,browseMode,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up up,browseMode,,10.1
+navOutStartRadioGroup,up up,browseMode,0:nameGroupPizzaCrust,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/nvda-commands.csv
@@ -16,7 +16,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,shift+r,browseMode,,7.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up,browseMode,,10.1
+navOutStartRadioGroup,up up,browseMode,,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-aria-activedescendant/data/scripts.csv
+++ b/tests/radiogroup-aria-activedescendant/data/scripts.csv
@@ -1,9 +1,9 @@
 setupScript,setupScriptDescription
 checkFirstRadioButtonAndSetFocusAfterRadioGroup,"sets the state of the first radio button to checked, and sets focus on a link after the radio group"
-checkFirstRadioButtonAndSetFocusBeforeRadioGroup,"sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading"
+checkFirstRadioButtonAndSetFocusBeforeRadioGroup,"sets the state of the first radio button to checked, and sets focus on a link before the radio group"
 checkThirdRadioButtonAndSetFocusAfterRadioGroup,"sets the state of the third radio button to checked, and sets focus on a link after the radio group"
 setFocusAfterRadioGroup,sets focus on a link after the radio group
-setFocusBeforeRadioGroup,"sets focus on a link before the radio group, and hides the group heading"
+setFocusBeforeRadioGroup,"sets focus on a link before the radio group"
 setFocusOnAndCheckFirstRadioButton,"sets focus on the first radio button, and sets its state to checked"
 setFocusOnFirstRadioButton,sets focus on the first radio button
 setFocusOnFirstRadioButtonAndCheckSecondRadioButton,"sets focus on the first radio button, and checks the  second radio button"

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,0:nameGroupPizzaCrust,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,0:nameGroupPizzaCrust,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -1,11 +1,11 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,,2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,,,2.1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,j,singleQuickKeyNavOn,,2.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+left ctrl+opt+left,,,4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+j,singleQuickKeyNavOn,,4.1
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,4.2
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,,6
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,,,6.1
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6.2
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left ctrl+opt+left,,,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -1,11 +1,11 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,,2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,,,2.1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,j,singleQuickKeyNavOn,,2.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+left ctrl+opt+left,,,4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+j,singleQuickKeyNavOn,,4.1
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,4.2
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,,6
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,,,6.1
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6.2
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8

--- a/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-aria-activedescendant/data/voiceover_macos-commands.csv
@@ -1,11 +1,11 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,,,2.1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,j,singleQuickKeyNavOn,,2.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+left ctrl+opt+left,,,4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+j,singleQuickKeyNavOn,,4.1
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,4.2
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,,,6.1
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6.2
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8

--- a/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
+++ b/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
@@ -13,7 +13,7 @@
     (function() {
       function setupScript(testPageDocument) {
         // checkFirstRadioButtonAndSetFocusBeforeRadioGroup
-        // sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading
+        // sets the state of the first radio button to checked, and sets focus on a link before the radio group
         let radioGroup = testPageDocument.querySelector('[role="radiogroup"]');
         let radios = testPageDocument.querySelectorAll('[role="radio"]');
         radios.forEach(r => {
@@ -23,8 +23,6 @@
         radios[0].classList.add('focus');
         radios[0].setAttribute('aria-checked', 'true');
         radioGroup.setAttribute('aria-activedescendant', radios[0].id);
-        testPageDocument.querySelector('#beforelink').focus();
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
 
       };
       document.addEventListener('click', function(event) {

--- a/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
+++ b/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
@@ -23,6 +23,7 @@
         radios[0].classList.add('focus');
         radios[0].setAttribute('aria-checked', 'true');
         radioGroup.setAttribute('aria-activedescendant', radios[0].id);
+        testPageDocument.querySelector('#beforelink').focus();
 
       };
       document.addEventListener('click', function(event) {

--- a/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusBeforeRadioGroup.html
+++ b/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusBeforeRadioGroup.html
@@ -13,9 +13,8 @@
     (function() {
       function setupScript(testPageDocument) {
         // setFocusBeforeRadioGroup
-        // sets focus on a link before the radio group, and hides the group heading
+        // sets focus on a link before the radio group
         testPageDocument.querySelector('#beforelink').focus();
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
 
       };
       document.addEventListener('click', function(event) {

--- a/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusOnFirstRadioButton.html
+++ b/tests/radiogroup-aria-activedescendant/reference/2022-4-7_113015/radio-activedescendant.setFocusOnFirstRadioButton.html
@@ -22,7 +22,6 @@
         });
         radios[0].classList.add('focus');
         radioGroup.setAttribute('aria-activedescendant', radios[0].id);
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
         radioGroup.focus();
 
       };

--- a/tests/radiogroup-roving-tabindex/data/assertions.csv
+++ b/tests/radiogroup-roving-tabindex/data/assertions.csv
@@ -7,10 +7,10 @@ nameNavigateBackFromHere,1,"Name of the link, 'Navigate backwards from here', is
 nameNavigateForwardsFromHere,1,"Name of the link, 'Navigate forwards from here', is conveyed","convey name of the link, 'Navigate forwards from here'",htmlLink
 nameRegularCrust,1,"Name of the radio button, 'Regular crust', is conveyed","convey name of the radio button, 'Regular crust'",radio
 nameThinCrust,1,"Name of the radio button, 'Thin crust', is conveyed","convey name of the radio button, 'Thin crust'",radio
-numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-activedescendant aria-setsize radio
-positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-activedescendant aria-posinset radio
-positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-activedescendant aria-posinset radio
-positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-activedescendant aria-posinset radio
+numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-setsize radio
+positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-posinset radio
+positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-posinset radio
+positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-posinset radio
 roleGroup,2,Role 'group' is conveyed,convey role 'group',radiogroup
 roleLink,1,Role 'link' is conveyed,convey role 'link',htmlLink
 roleRadio,1,Role 'radio button' is conveyed,convey role 'radio button',radio

--- a/tests/radiogroup-roving-tabindex/data/assertions.csv
+++ b/tests/radiogroup-roving-tabindex/data/assertions.csv
@@ -7,10 +7,10 @@ nameNavigateBackFromHere,1,"Name of the link, 'Navigate backwards from here', is
 nameNavigateForwardsFromHere,1,"Name of the link, 'Navigate forwards from here', is conveyed","convey name of the link, 'Navigate forwards from here'",htmlLink
 nameRegularCrust,1,"Name of the radio button, 'Regular crust', is conveyed","convey name of the radio button, 'Regular crust'",radio
 nameThinCrust,1,"Name of the radio button, 'Thin crust', is conveyed","convey name of the radio button, 'Thin crust'",radio
-numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-setsize radio
-positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-posinset radio
-positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-posinset radio
-positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-posinset radio
+numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-activedescendant aria-setsize radio
+positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-activedescendant aria-posinset radio
+positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-activedescendant aria-posinset radio
+positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-activedescendant aria-posinset radio
 roleGroup,2,Role 'group' is conveyed,convey role 'group',radiogroup
 roleLink,1,Role 'link' is conveyed,convey role 'link',htmlLink
 roleRadio,1,Role 'radio button' is conveyed,convey role 'radio button',radio

--- a/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,virtualCursor,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,a,virtualCursor,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,0:nameGroupPizzaCrust,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,virtualCursor,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,pcCursor,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,virtualCursor,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,virtualCursor,0:nam
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,pcCursor,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,virtualCursor,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,a,virtualCursor,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,0:nameGroupPizzaCrust,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,virtualCursor,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,pcCursor,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,virtualCursor,,7

--- a/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,virtualCursor,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,a,virtualCursor,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,virtualCursor,0:nameGroupPizzaCrust,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down down,virtualCursor,,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,virtualCursor,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,pcCursor,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,virtualCursor,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,virtualCursor,0:nam
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,pcCursor,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,virtualCursor,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,a,virtualCursor,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,virtualCursor,0:nameGroupPizzaCrust,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down down,virtualCursor,,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,virtualCursor,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,pcCursor,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,virtualCursor,,7

--- a/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,,10.1
+navOutStartRadioGroup,up up,virtualCursor,0:nameGroupPizzaCrust,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,,10.1
+navOutStartRadioGroup,up up up,virtualCursor,,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/jaws-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up up,virtualCursor,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,virtualCursor,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,pcCursor,,7.4
 navOutStartRadioGroup,shift+u,virtualCursor,3:groupBoundary ,10
-navOutStartRadioGroup,up up,virtualCursor,0:nameGroupPizzaCrust,10.1
+navOutStartRadioGroup,up up,virtualCursor,,10.1
 navOutStartRadioGroup,shift+tab,virtualCursor,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,pcCursor,3:groupBoundary ,10.3
 navOutEndRadioGroup,u,virtualCursor,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
+++ b/tests/radiogroup-roving-tabindex/data/js/checkFirstRadioButtonAndSetFocusBeforeRadioGroup.js
@@ -1,4 +1,4 @@
-// sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading
+// sets the state of the first radio button to checked, and sets focus on a link before the radio group
 let radios = testPageDocument.querySelectorAll('[role="radio"]');
 radios.forEach(r => {
   r.setAttribute('tabindex', '-1');
@@ -8,4 +8,3 @@ radios.forEach(r => {
 radios[0].setAttribute('tabindex', '0');
 radios[0].setAttribute('aria-checked', 'true');
 testPageDocument.querySelector('#beforelink').focus();
-testPageDocument.querySelector('#group_label_1').style.display = 'none';

--- a/tests/radiogroup-roving-tabindex/data/js/setFocusBeforeRadioGroup.js
+++ b/tests/radiogroup-roving-tabindex/data/js/setFocusBeforeRadioGroup.js
@@ -1,3 +1,2 @@
-// sets focus on a link before the radio group, and hides the group heading
+// sets focus on a link before the radio group
 testPageDocument.querySelector('#beforelink').focus();
-testPageDocument.querySelector('#group_label_1').style.display = 'none';

--- a/tests/radiogroup-roving-tabindex/data/js/setFocusOnFirstRadioButton.js
+++ b/tests/radiogroup-roving-tabindex/data/js/setFocusOnFirstRadioButton.js
@@ -7,5 +7,4 @@ radios.forEach(r => {
 });
 radios[0].classList.add('focus');
 radios[0].setAttribute('tabindex', '0');
-testPageDocument.querySelector('#group_label_1').style.display = 'none';
 radios[0].focus();

--- a/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
@@ -20,7 +20,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,up,browseMode,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up up,browseMode,0:nameGroupPizzaCrust,10.1
+navOutStartRadioGroup,up up,browseMode,,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
@@ -1,7 +1,7 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,browseMode,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,r,browseMode,,1.1
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,0:nameGroupPizzaCrust,1.2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,browseMode,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,focusMode,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,browseMode,,3
@@ -11,7 +11,7 @@ navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,browseMode,0:nameTh
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,focusMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,browseMode,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,r,browseMode,,5.1
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,0:nameGroupPizzaCrust,5.2
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,browseMode,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,focusMode,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,browseMode,,7

--- a/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
@@ -1,22 +1,26 @@
 testId,command,settings,assertionExceptions,presentationNumber
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,f,browseMode,,1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,r,browseMode,,1.1
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,down down,browseMode,0:nameGroupPizzaCrust,1.2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,browseMode,2:interactionModeEnabled,1.3
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,focusMode,,1.4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+f,browseMode,,3
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+r,browseMode,,3.1
+navBackInToRadioGroupWhereNoRadioButtonsAreChecked,up,browseMode,,3.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,browseMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1 2:interactionModeEnabled,3.3
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,focusMode,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,3.4
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,f,browseMode,,5
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,r,browseMode,,5.1
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,down down,browseMode,0:nameGroupPizzaCrust,5.2
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,browseMode,2:interactionModeEnabled,5.3
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,focusMode,,5.4
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+f,browseMode,,7
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+r,browseMode,,7.1
+NavBackIntoRadioGroupWhereLastRadioChecked,up,browseMode,,7.2
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up up,browseMode,,10.1
+navOutStartRadioGroup,up up,browseMode,0:nameGroupPizzaCrust,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/nvda-commands.csv
@@ -16,7 +16,7 @@ NavBackIntoRadioGroupWhereLastRadioChecked,shift+r,browseMode,,7.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,browseMode,2:interactionModeEnabled,7.3
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,focusMode,,7.4
 navOutStartRadioGroup,shift+k,browseMode,3:groupBoundary ,10
-navOutStartRadioGroup,up,browseMode,,10.1
+navOutStartRadioGroup,up up,browseMode,,10.1
 navOutStartRadioGroup,shift+tab,browseMode,3:groupBoundary ,10.2
 navOutStartRadioGroup,shift+tab,focusMode,3:groupBoundary ,10.3
 navOutEndRadioGroup,k,browseMode,3:groupBoundary ,12

--- a/tests/radiogroup-roving-tabindex/data/scripts.csv
+++ b/tests/radiogroup-roving-tabindex/data/scripts.csv
@@ -1,9 +1,9 @@
 setupScript,setupScriptDescription
 checkFirstRadioButtonAndSetFocusAfterRadioGroup,"sets the state of the first radio button to checked, and sets focus on a link after the radio group"
-checkFirstRadioButtonAndSetFocusBeforeRadioGroup,"sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading"
+checkFirstRadioButtonAndSetFocusBeforeRadioGroup,"sets the state of the first radio button to checked, and sets focus on a link before the radio group"
 checkThirdRadioButtonAndSetFocusAfterRadioGroup,"sets the state of the third radio button to checked, and sets focus on a link after the radio group"
 setFocusAfterRadioGroup,sets focus on a link after the radio group
-setFocusBeforeRadioGroup,"sets focus on a link before the radio group, and hides the group heading"
+setFocusBeforeRadioGroup,"sets focus on a link before the radio group"
 setFocusOnAndCheckFirstRadioButton,"sets focus on the first radio button, and sets its state to checked"
 setFocusOnFirstRadioButton,sets focus on the first radio button
 setFocusOnFirstRadioButtonAndCheckSecondRadioButton,"sets focus on the first radio button, and checks the  second radio button"

--- a/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,0:nameGroupPizzaCrust,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,0:nameGroupPizzaCrust,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
@@ -1,11 +1,11 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,,2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,,,2.1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,j,singleQuickKeyNavOn,,2.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+left ctrl+opt+left,,,4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+j,singleQuickKeyNavOn,,4.1
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,4.2
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,,6
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,,,6.1
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6.2
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8

--- a/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
@@ -11,7 +11,7 @@ navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+j,singleQuickKeyNavOn,,8.1
 NavBackIntoRadioGroupWhereLastRadioChecked,shift+tab,,,8.2
-navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left,,,10
+navOutStartRadioGroup,ctrl+opt+left ctrl+opt+left ctrl+opt+left,,,10
 navOutStartRadioGroup,shift+tab,,3:groupBoundary ,10.1
 navOutStartRadioGroup,shift+l,singleQuickKeyNavOn,3:groupBoundary ,10.2
 navOutEndRadioGroup,ctrl+opt+right ctrl+opt+right,,,12

--- a/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
+++ b/tests/radiogroup-roving-tabindex/data/voiceover_macos-commands.csv
@@ -1,11 +1,11 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,2
+navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,,2
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,tab,,,2.1
 navForwardsInToRadioGroupWhereNoRadioButtonsAreChecked,j,singleQuickKeyNavOn,,2.2
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,ctrl+opt+left ctrl+opt+left,,,4
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+j,singleQuickKeyNavOn,,4.1
 navBackInToRadioGroupWhereNoRadioButtonsAreChecked,shift+tab,,0:nameThinCrust 1:nameRegularCrust 0:positionRadio3 2:positionRadio1,4.2
-navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right,,0:nameGroupPizzaCrust,6
+navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,ctrl+opt+right ctrl+opt+right ctrl+opt+right,,,6
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,tab,,,6.1
 navForwardsInToRadioGroupWhereFirstRadioButtonIsChecked,j,singleQuickKeyNavOn,,6.2
 NavBackIntoRadioGroupWhereLastRadioChecked,ctrl+opt+left ctrl+opt+left,,,8

--- a/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
+++ b/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.checkFirstRadioButtonAndSetFocusBeforeRadioGroup.html
@@ -13,7 +13,7 @@
     (function() {
       function setupScript(testPageDocument) {
         // checkFirstRadioButtonAndSetFocusBeforeRadioGroup
-        // sets the state of the first radio button to checked, sets focus on a link before the radio group, and hides the group heading
+        // sets the state of the first radio button to checked, and sets focus on a link before the radio group
         let radios = testPageDocument.querySelectorAll('[role="radio"]');
         radios.forEach(r => {
           r.setAttribute('tabindex', '-1');
@@ -23,7 +23,6 @@
         radios[0].setAttribute('tabindex', '0');
         radios[0].setAttribute('aria-checked', 'true');
         testPageDocument.querySelector('#beforelink').focus();
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
 
       };
       document.addEventListener('click', function(event) {

--- a/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.setFocusBeforeRadioGroup.html
+++ b/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.setFocusBeforeRadioGroup.html
@@ -13,9 +13,8 @@
     (function() {
       function setupScript(testPageDocument) {
         // setFocusBeforeRadioGroup
-        // sets focus on a link before the radio group, and hides the group heading
+        // sets focus on a link before the radio group
         testPageDocument.querySelector('#beforelink').focus();
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
 
       };
       document.addEventListener('click', function(event) {

--- a/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.setFocusOnFirstRadioButton.html
+++ b/tests/radiogroup-roving-tabindex/reference/2021-3-15_144141/radio.setFocusOnFirstRadioButton.html
@@ -22,7 +22,6 @@
         });
         radios[0].classList.add('focus');
         radios[0].setAttribute('tabindex', '0');
-        testPageDocument.querySelector('#group_label_1').style.display = 'none';
         radios[0].focus();
 
       };


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1179--aria-at.netlify.app)

Resolves #1176
This update modifies the `radiogroup-aria-activedescendant` and `radiogroup-roving-tabindex` test plans to ensure consistency across all three screen readers (NVDA, JAWS, and VoiceOver):

*  The group label, previously hidden by the setup scripts, is now consistently visible in the test examples. Setup script descriptions have been updated accordingly to reflect this change.
*  An extra up arrow key press has been added to NVDA's test steps when navigating out of a radio group.
*  Assertions related to the group label when the screen reader cursor enters the radio group have been removed to standardize testing across screen readers.
*  Up and down arrow key commands have been incorporated into NVDA's test for consistent navigation when entering and exiting a radio group, matching  JAWS and VoiceOver tests.