### PR TITLE
Menu button test plans: Change priority of assertion stateCollapsed from 1 to 2

### DIFF
--- a/tests/menu-button-actions-active-descendant/data/assertions.csv
+++ b/tests/menu-button-actions-active-descendant/data/assertions.csv
@@ -8,7 +8,7 @@ numberItemsMenu4,2,"Number of items in the menu,'(4', is conveyed","convey numbe
 roleFocusedItemMenuItem,2,"Role of the focused item, 'menu item', is conveyed","convey role of the focused item, 'menu item'",menuitem
 roleMenu,3,Role 'menu' is conveyed,convey role 'menu',menu
 roleMenuButton,1,Role 'menu button' is conveyed,convey role 'menu button',button aria-haspopup
-stateCollapsed,1,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
+stateCollapsed,2,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
 interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},
 positionFocusedItemMenu1,2,"Position of the focused item in the menu, '1', is conveyed","convey position of the focused item in the menu, '1'",aria-posinset aria-activedescendant
 positionFocusedItemMenu2,2,"Position of the focused item in the menu, '2', is conveyed","convey position of the focused item in the menu, '2'",aria-posinset aria-activedescendant

--- a/tests/menu-button-actions/data/assertions.csv
+++ b/tests/menu-button-actions/data/assertions.csv
@@ -8,7 +8,7 @@ numberItemsMenu4,2,"Number of items in the menu,'(4', is conveyed","convey numbe
 roleFocusedItemMenuItem,2,"Role of the focused item, 'menu item', is conveyed","convey role of the focused item, 'menu item'",menuitem
 roleMenu,3,Role 'menu' is conveyed,convey role 'menu',menu
 roleMenuButton,1,Role 'menu button' is conveyed,convey role 'menu button',button aria-haspopup
-stateCollapsed,1,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
+stateCollapsed,2,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
 interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},
 positionFocusedItemMenu1,2,"Position of the focused item in the menu, '1', is conveyed","convey position of the focused item in the menu, '1'",aria-posinset 
 positionFocusedItemMenu2,2,"Position of the focused item in the menu, '2', is conveyed","convey position of the focused item in the menu, '2'",aria-posinset 

--- a/tests/menu-button-navigation/data/assertions.csv
+++ b/tests/menu-button-navigation/data/assertions.csv
@@ -8,7 +8,7 @@ numberItemsMenu6,2,"Number of items in the menu,'(6', is conveyed","convey numbe
 roleFocusedItemMenuItem,2,"Role of the focused item, 'menu item', is conveyed","convey role of the focused item, 'menu item'",menuitem
 roleMenu,3,Role 'menu' is conveyed,convey role 'menu',menu
 roleMenuButton,1,Role 'menu button' is conveyed,convey role 'menu button',button aria-haspopup
-stateCollapsed,1,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
+stateCollapsed,2,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
 interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},
 positionFocusedItemMenu1,2,"Position of the focused item in the menu, '1', is conveyed","convey position of the focused item in the menu, '1'",aria-posinset 
 positionFocusedItemMenu2,2,"Position of the focused item in the menu, '2', is conveyed","convey position of the focused item in the menu, '2'",aria-posinset 


### PR DESCRIPTION
Resolves issue #1150 by modifying assertions.csv for each of the three menu button test plans.
Changes the priority of one assertion (stateCollapsed) from 1 to 2