### PR TITLE
fix: handling of `commands.json` aliases

### DIFF
--- a/__test__/__mocks__/tests/alert/data/jaws-commands.csv
+++ b/__test__/__mocks__/tests/alert/data/jaws-commands.csv
@@ -2,4 +2,4 @@ testId,command,settings,assertionExceptions,presentationNumber
 triggerAlert,space,virtualCursor,,1.0
 triggerAlert,enter,virtualCursor,,1.1
 triggerAlert,space,pcCursor,,2.0
-triggerAlert,enter,pcCursor,,2.1
+triggerAlert,jaws nvda vo del delete esc escape jaws+space nvda+space vo+space,pcCursor,,2.1

--- a/__test__/__snapshots__/createAllTests.test.js.snap
+++ b/__test__/__snapshots__/createAllTests.test.js.snap
@@ -10970,7 +10970,9 @@ exports[`V2 test format version runs createAllTests successfully (alert) 1`] = `
     "pcCursor": {
       "jaws": [
         [ "space|2" ],
-        [ "enter|2.1" ]
+        [
+          "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space|2.1"
+        ]
       ]
     },
     "browseMode": {
@@ -11328,15 +11330,51 @@ exports[`V2 test format version runs createAllTests successfully (alert) 6`] = `
       "settings": "pcCursor"
     },
     {
-      "id": "enter",
+      "id": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
       "keypresses": [
         {
-          "id": "enter",
-          "keystroke": "Enter"
+          "id": "jaws",
+          "keystroke": "Insert"
+        },
+        {
+          "id": "nvda",
+          "keystroke": "Insert"
+        },
+        {
+          "id": "vo",
+          "keystroke": "Control+Option"
+        },
+        {
+          "id": "del",
+          "keystroke": "Delete"
+        },
+        {
+          "id": "delete",
+          "keystroke": "Delete"
+        },
+        {
+          "id": "esc",
+          "keystroke": "Escape"
+        },
+        {
+          "id": "escape",
+          "keystroke": "Escape"
+        },
+        {
+          "id": "jaws+space",
+          "keystroke": "Insert+Space"
+        },
+        {
+          "id": "nvda+space",
+          "keystroke": "Insert+Space"
+        },
+        {
+          "id": "vo+space",
+          "keystroke": "Control+Option+Space"
         }
       ],
       "assertionExceptions": [],
-      "keystroke": "Enter",
+      "keystroke": "Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space",
       "presentationNumber": 2.1,
       "settings": "pcCursor"
     }
@@ -11997,7 +12035,7 @@ exports[`V2 test format version runs createAllTests successfully (alert) 11`] = 
       },
       {
         "testId": "triggerAlert",
-        "command": "enter",
+        "command": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
         "settings": "pcCursor",
         "presentationNumber": 2.1,
         "assertionExceptions": ""
@@ -12069,7 +12107,9 @@ exports[`V2 test format version runs createAllTests successfully (alert) 11`] = 
     "pcCursor": {
       "jaws": [
         [ "space|2" ],
-        [ "enter|2.1" ]
+        [
+          "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space|2.1"
+        ]
       ]
     },
     "browseMode": {
@@ -12166,7 +12206,7 @@ exports[`V2 test format version runs createAllTests successfully (alert) 12`] = 
       },
       {
         "testId": "triggerAlert",
-        "command": "enter",
+        "command": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
         "settings": "pcCursor",
         "presentationNumber": 2.1,
         "assertionExceptions": ""
@@ -26209,7 +26249,9 @@ exports[`all test format versions runs createAllTests successfully 1`] = `
     "pcCursor": {
       "jaws": [
         [ "space|2" ],
-        [ "enter|2.1" ]
+        [
+          "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space|2.1"
+        ]
       ]
     },
     "browseMode": {
@@ -26567,15 +26609,51 @@ exports[`all test format versions runs createAllTests successfully 6`] = `
       "settings": "pcCursor"
     },
     {
-      "id": "enter",
+      "id": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
       "keypresses": [
         {
-          "id": "enter",
-          "keystroke": "Enter"
+          "id": "jaws",
+          "keystroke": "Insert"
+        },
+        {
+          "id": "nvda",
+          "keystroke": "Insert"
+        },
+        {
+          "id": "vo",
+          "keystroke": "Control+Option"
+        },
+        {
+          "id": "del",
+          "keystroke": "Delete"
+        },
+        {
+          "id": "delete",
+          "keystroke": "Delete"
+        },
+        {
+          "id": "esc",
+          "keystroke": "Escape"
+        },
+        {
+          "id": "escape",
+          "keystroke": "Escape"
+        },
+        {
+          "id": "jaws+space",
+          "keystroke": "Insert+Space"
+        },
+        {
+          "id": "nvda+space",
+          "keystroke": "Insert+Space"
+        },
+        {
+          "id": "vo+space",
+          "keystroke": "Control+Option+Space"
         }
       ],
       "assertionExceptions": [],
-      "keystroke": "Enter",
+      "keystroke": "Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space",
       "presentationNumber": 2.1,
       "settings": "pcCursor"
     }
@@ -27236,7 +27314,7 @@ exports[`all test format versions runs createAllTests successfully 11`] = `
       },
       {
         "testId": "triggerAlert",
-        "command": "enter",
+        "command": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
         "settings": "pcCursor",
         "presentationNumber": 2.1,
         "assertionExceptions": ""
@@ -27308,7 +27386,9 @@ exports[`all test format versions runs createAllTests successfully 11`] = `
     "pcCursor": {
       "jaws": [
         [ "space|2" ],
-        [ "enter|2.1" ]
+        [
+          "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space|2.1"
+        ]
       ]
     },
     "browseMode": {
@@ -27405,7 +27485,7 @@ exports[`all test format versions runs createAllTests successfully 12`] = `
       },
       {
         "testId": "triggerAlert",
-        "command": "enter",
+        "command": "jaws nvda vo del delete esc escape jaws+space nvda+space vo+space",
         "settings": "pcCursor",
         "presentationNumber": 2.1,
         "assertionExceptions": ""

--- a/__test__/__snapshots__/createReviewPages.test.js.snap
+++ b/__test__/__snapshots__/createReviewPages.test.js.snap
@@ -285,7 +285,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                 <li>Space (virtual cursor active)</li>
                 <li>Enter (virtual cursor active)</li>
                 <li>Space (PC cursor active)</li>
-                <li>Enter (PC cursor active)</li>
+                <li>Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active)</li>
             </ul>
           </li>
         </ol>
@@ -353,7 +353,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                   <td>Text &#39;Hello&#39; is conveyed</td>
                 </tr>
           </table>
-          <h4 id="t1-jaws-c4">Enter (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
+          <h4 id="t1-jaws-c4">Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
           <table aria-labelledby="t1-jaws-c4">
             <tr>
               <th>Priority</th>
@@ -7419,7 +7419,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                 <li>Space (virtual cursor active)</li>
                 <li>Enter (virtual cursor active)</li>
                 <li>Space (PC cursor active)</li>
-                <li>Enter (PC cursor active)</li>
+                <li>Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active)</li>
             </ul>
           </li>
         </ol>
@@ -7487,7 +7487,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                   <td>Text &#39;Hello&#39; is conveyed</td>
                 </tr>
           </table>
-          <h4 id="t1-jaws-c4">Enter (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
+          <h4 id="t1-jaws-c4">Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
           <table aria-labelledby="t1-jaws-c4">
             <tr>
               <th>Priority</th>
@@ -14553,7 +14553,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                 <li>Space (virtual cursor active)</li>
                 <li>Enter (virtual cursor active)</li>
                 <li>Space (PC cursor active)</li>
-                <li>Enter (PC cursor active)</li>
+                <li>Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active)</li>
             </ul>
           </li>
         </ol>
@@ -14621,7 +14621,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                   <td>Text &#39;Hello&#39; is conveyed</td>
                 </tr>
           </table>
-          <h4 id="t1-jaws-c4">Enter (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
+          <h4 id="t1-jaws-c4">Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
           <table aria-labelledby="t1-jaws-c4">
             <tr>
               <th>Priority</th>
@@ -21687,7 +21687,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                 <li>Space (virtual cursor active)</li>
                 <li>Enter (virtual cursor active)</li>
                 <li>Space (PC cursor active)</li>
-                <li>Enter (PC cursor active)</li>
+                <li>Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active)</li>
             </ul>
           </li>
         </ol>
@@ -21755,7 +21755,7 @@ exports[`review pages creation runs createReviewPages successfully for all test 
                   <td>Text &#39;Hello&#39; is conveyed</td>
                 </tr>
           </table>
-          <h4 id="t1-jaws-c4">Enter (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
+          <h4 id="t1-jaws-c4">Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
           <table aria-labelledby="t1-jaws-c4">
             <tr>
               <th>Priority</th>
@@ -31773,7 +31773,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
                 <li>Space (virtual cursor active)</li>
                 <li>Enter (virtual cursor active)</li>
                 <li>Space (PC cursor active)</li>
-                <li>Enter (PC cursor active)</li>
+                <li>Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active)</li>
             </ul>
           </li>
         </ol>
@@ -31841,7 +31841,7 @@ exports[`review pages creation runs createReviewPages successfully for v2 tests 
                   <td>Text &#39;Hello&#39; is conveyed</td>
                 </tr>
           </table>
-          <h4 id="t1-jaws-c4">Enter (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
+          <h4 id="t1-jaws-c4">Insert then Insert then Control+Option then Delete then Delete then Escape then Escape then Insert+Space then Insert+Space then Control+Option+Space (PC cursor active): 1 MUST, 0 SHOULD, AND 1 MAY assertions</h4>
           <table aria-labelledby="t1-jaws-c4">
             <tr>
               <th>Priority</th>

--- a/lib/data/parse-command-csv-row.js
+++ b/lib/data/parse-command-csv-row.js
@@ -67,125 +67,6 @@ function parseCommandCSVRow(commandRow) {
   };
 }
 
-function flattenObject(obj, parentKey = '') {
-  const flattened = {};
-
-  for (const key in obj) {
-    if (typeof obj[key] === 'object') {
-      const subObject = flattenObject(obj[key], parentKey + key + '.');
-      Object.assign(flattened, subObject);
-    } else {
-      flattened[parentKey + key] = obj[key];
-    }
-  }
-
-  return flattened;
-}
-
-function sanitizeWhitespace(value) {
-  return value.replace(/\s+/g, ' ').trim();
-}
-
-function sanitizeCommand(command) {
-  return {
-    ...command,
-    command: sanitizeWhitespace(command.command),
-  };
-}
-
-function findValueByKey(keyMappings, keyToFindText) {
-  const keyToFind = keyToFindText.replace(/\s+/g, ' ').trim();
-  const keyMap = Object.keys(keyMappings);
-
-  // Need to specially handle VO modifier key combination
-  if (keyToFind === 'vo')
-    return findValuesByKeys(keyMappings, [keyMappings['modifierAliases.vo']])[0];
-
-  if (keyToFind.includes('modifiers.') || keyToFind.includes('keys.')) {
-    const parts = keyToFind.split('.');
-    const keyToCheck = parts[parts.length - 1]; // value after the '.'
-
-    if (keyMappings[keyToFind])
-      return {
-        value: keyMappings[keyToFind],
-        key: keyToCheck,
-      };
-
-    return null;
-  }
-
-  for (const key of keyMap) {
-    const parts = key.split('.');
-    const parentKey = parts[0];
-    const keyToCheck = parts[parts.length - 1]; // value after the '.'
-
-    if (keyToCheck === keyToFind) {
-      if (parentKey === 'modifierAliases') {
-        return findValueByKey(keyMappings, `modifiers.${keyMappings[key]}`);
-      } else if (parentKey === 'keyAliases') {
-        return findValueByKey(keyMappings, `keys.${keyMappings[key]}`);
-      }
-
-      return {
-        value: keyMappings[key],
-        key: keyToCheck,
-      };
-    }
-  }
-
-  // Return null if the key is not found
-  return null;
-}
-
-function findValuesByKeys(commandsMapping, keysToFind = []) {
-  const result = [];
-
-  const patternSepWithReplacement = (keyToFind, pattern, replacement) => {
-    if (keyToFind.includes(pattern)) {
-      let value = '';
-      let validKeys = true;
-      const keys = keyToFind.split(pattern);
-
-      for (const key of keys) {
-        const keyResult = findValueByKey(commandsMapping, key);
-        if (keyResult) value = value ? `${value}${replacement}${keyResult.value}` : keyResult.value;
-        else validKeys = false;
-      }
-      if (validKeys) return { value, key: keyToFind };
-    }
-
-    return null;
-  };
-
-  const patternSepHandler = keyToFind => {
-    let value = '';
-
-    if (keyToFind.includes(' ') && keyToFind.includes('+')) {
-      const keys = keyToFind.split(' ');
-      for (let [index, key] of keys.entries()) {
-        const keyToFindResult = findValueByKey(commandsMapping, key);
-        if (keyToFindResult) keys[index] = keyToFindResult.value;
-        if (key.includes('+')) keys[index] = patternSepWithReplacement(key, '+', '+').value;
-      }
-      value = keys.join(' then ');
-
-      return { value, key: keyToFind };
-    } else if (keyToFind.includes(' ')) return patternSepWithReplacement(keyToFind, ' ', ' then ');
-    else if (keyToFind.includes('+')) return patternSepWithReplacement(keyToFind, '+', '+');
-  };
-
-  for (const keyToFind of keysToFind) {
-    if (keyToFind.includes(' ') || keyToFind.includes('+')) {
-      result.push(patternSepHandler(keyToFind));
-    } else {
-      const keyToFindResult = findValueByKey(commandsMapping, keyToFind);
-      if (keyToFindResult) result.push(keyToFindResult);
-    }
-  }
-
-  return result;
-}
-
 function parseCommandCSVRowV2({ commands }, commandsJson) {
   const commandsParsed = [];
   const flattenedCommandsJson = flattenObject(commandsJson);
@@ -251,6 +132,127 @@ function parseCommandCSVRowV2({ commands }, commandsJson) {
   );
 
   return commandsParsed;
+}
+
+// Utils
+
+function sanitizeWhitespace(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function sanitizeCommand(command) {
+  return {
+    ...command,
+    command: sanitizeWhitespace(command.command),
+  };
+}
+
+function flattenObject(obj, parentKey = '') {
+  const flattened = {};
+
+  for (const key in obj) {
+    if (typeof obj[key] === 'object') {
+      const subObject = flattenObject(obj[key], parentKey + key + '.');
+      Object.assign(flattened, subObject);
+    } else {
+      flattened[parentKey + key] = obj[key];
+    }
+  }
+
+  return flattened;
+}
+
+function findValuesByKeys(keysMapping, keysToFind = []) {
+  const result = [];
+
+  const patternSepWithReplacement = (keyToFind, pattern, replacement) => {
+    if (keyToFind.includes(pattern)) {
+      let value = '';
+      let validKeys = true;
+      const keys = keyToFind.split(pattern);
+
+      for (const key of keys) {
+        const keyResult = findValueByKey(keysMapping, key);
+        if (keyResult) value = value ? `${value}${replacement}${keyResult.value}` : keyResult.value;
+        else validKeys = false;
+      }
+      if (validKeys) return { value, key: keyToFind };
+    }
+
+    return null;
+  };
+
+  const patternSepHandler = keyToFind => {
+    let value = '';
+
+    if (keyToFind.includes(' ') && keyToFind.includes('+')) {
+      const keys = keyToFind.split(' ');
+      for (let [index, key] of keys.entries()) {
+        const keyToFindResult = findValueByKey(keysMapping, key);
+        if (keyToFindResult) keys[index] = keyToFindResult.value;
+        if (key.includes('+')) keys[index] = patternSepWithReplacement(key, '+', '+').value;
+      }
+      value = keys.join(' then ');
+
+      return { value, key: keyToFind };
+    } else if (keyToFind.includes(' ')) return patternSepWithReplacement(keyToFind, ' ', ' then ');
+    else if (keyToFind.includes('+')) return patternSepWithReplacement(keyToFind, '+', '+');
+  };
+
+  for (const keyToFind of keysToFind) {
+    if (keyToFind.includes(' ') || keyToFind.includes('+')) {
+      result.push(patternSepHandler(keyToFind));
+    } else {
+      const keyToFindResult = findValueByKey(keysMapping, keyToFind);
+      if (keyToFindResult) result.push(keyToFindResult);
+    }
+  }
+
+  return result;
+}
+
+function findValueByKey(keysMapping, keyToFindText) {
+  const keyToFind = keyToFindText.replace(/\s+/g, ' ').trim();
+  const keyMap = Object.keys(keysMapping);
+
+  // Need to specially handle VO modifier key combination
+  if (keyToFind === 'vo')
+    return findValuesByKeys(keysMapping, [keysMapping['modifierAliases.vo']])[0];
+
+  if (keyToFind.includes('modifiers.') || keyToFind.includes('keys.')) {
+    const parts = keyToFind.split('.');
+    const keyToCheck = parts[parts.length - 1]; // value after the '.'
+
+    if (keysMapping[keyToFind])
+      return {
+        value: keysMapping[keyToFind],
+        key: keyToCheck,
+      };
+
+    return null;
+  }
+
+  for (const key of keyMap) {
+    const parts = key.split('.');
+    const parentKey = parts[0];
+    const keyToCheck = parts[parts.length - 1]; // value after the '.'
+
+    if (keyToCheck === keyToFind) {
+      if (parentKey === 'modifierAliases') {
+        return findValueByKey(keysMapping, `modifiers.${keysMapping[key]}`);
+      } else if (parentKey === 'keyAliases') {
+        return findValueByKey(keysMapping, `keys.${keysMapping[key]}`);
+      }
+
+      return {
+        value: keysMapping[key],
+        key: keyToCheck,
+      };
+    }
+  }
+
+  // Return null if the key is not found
+  return null;
 }
 
 module.exports = {

--- a/lib/data/parse-command-csv-row.js
+++ b/lib/data/parse-command-csv-row.js
@@ -147,7 +147,12 @@ function sanitizeCommand(command) {
   };
 }
 
-function flattenObject(obj, parentKey = '') {
+/**
+ * @param {object} obj
+ * @param {string} parentKey
+ * @returns {object}
+ */
+export function flattenObject(obj, parentKey = '') {
   const flattened = {};
 
   for (const key in obj) {
@@ -162,7 +167,12 @@ function flattenObject(obj, parentKey = '') {
   return flattened;
 }
 
-function findValuesByKeys(keysMapping, keysToFind = []) {
+/**
+ * @param {object} keysMapping
+ * @param {string[]} keysToFind
+ * @returns {Object<value: string, key: string>}[]}
+ */
+export function findValuesByKeys(keysMapping, keysToFind = []) {
   const result = [];
 
   const patternSepWithReplacement = (keyToFind, pattern, replacement) => {
@@ -211,9 +221,13 @@ function findValuesByKeys(keysMapping, keysToFind = []) {
   return result;
 }
 
-function findValueByKey(keysMapping, keyToFindText) {
-  const keyToFind = keyToFindText.replace(/\s+/g, ' ').trim();
-  const keyMap = Object.keys(keysMapping);
+/**
+ * @param {object} keysMapping
+ * @param {string} keyToFind
+ * @returns {Object<value: string, key: string>} | null}
+ */
+function findValueByKey(keysMapping, keyToFind) {
+  const keys = Object.keys(keysMapping);
 
   // Need to specially handle VO modifier key combination
   if (keyToFind === 'vo')
@@ -232,7 +246,7 @@ function findValueByKey(keysMapping, keyToFindText) {
     return null;
   }
 
-  for (const key of keyMap) {
+  for (const key of keys) {
     const parts = key.split('.');
     const parentKey = parts[0];
     const keyToCheck = parts[parts.length - 1]; // value after the '.'

--- a/lib/data/parse-command-csv-row.js
+++ b/lib/data/parse-command-csv-row.js
@@ -152,7 +152,7 @@ function sanitizeCommand(command) {
  * @param {string} parentKey
  * @returns {object}
  */
-export function flattenObject(obj, parentKey = '') {
+function flattenObject(obj, parentKey = '') {
   const flattened = {};
 
   for (const key in obj) {
@@ -172,7 +172,7 @@ export function flattenObject(obj, parentKey = '') {
  * @param {string[]} keysToFind
  * @returns {Object<value: string, key: string>}[]}
  */
-export function findValuesByKeys(keysMapping, keysToFind = []) {
+function findValuesByKeys(keysMapping, keysToFind = []) {
   const result = [];
 
   const patternSepWithReplacement = (keyToFind, pattern, replacement) => {

--- a/lib/data/parse-command-csv-row.js
+++ b/lib/data/parse-command-csv-row.js
@@ -223,10 +223,11 @@ export function findValuesByKeys(keysMapping, keysToFind = []) {
 
 /**
  * @param {object} keysMapping
- * @param {string} keyToFind
+ * @param {string} keyToFindText
  * @returns {Object<value: string, key: string>} | null}
  */
-function findValueByKey(keysMapping, keyToFind) {
+function findValueByKey(keysMapping, keyToFindText) {
+  const keyToFind = keyToFindText.replace(/\s+/g, ' ').trim();
   const keys = Object.keys(keysMapping);
 
   // Need to specially handle VO modifier key combination

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -1732,10 +1732,11 @@ export function findValuesByKeys(keysMapping, keysToFind = []) {
 
 /**
  * @param {object} keysMapping
- * @param {string} keyToFind
+ * @param {string} keyToFindText
  * @returns {Object<value: string, key: string>} | null}
  */
-function findValueByKey(keysMapping, keyToFind) {
+function findValueByKey(keysMapping, keyToFindText) {
+  const keyToFind = keyToFindText.replace(/\s+/g, ' ').trim();
   const keys = Object.keys(keysMapping);
 
   // Need to specially handle VO modifier key combination


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1197--aria-at.netlify.app)

This PR does the following:
* Correctly defaults the `flattenObject()` function's `parentKey` param to an empty string. Without this, it was causing incorrect string matching comparisons during the review pages renders. So comparisons against `"undefinedmodifierAliases.vo"` when `"modifierAliases.vo"` was expected, would happen. This also applied to `keyAliases`.
* Consolidation of `flattenObject()`, `findValuesByKeys()` and `findValueByKey()` functions.

This addresses a build issue discussed in #1193.