### PR TITLE
chore: group Dependabot minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: 'github-actions'
     open-pull-requests-limit: 99
     directory: '/'


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1218--aria-at.netlify.app)

Will create grouped updates from Dependabot for minor bumps, but leave the major updates as separate PRs