### PR TITLE
ci: pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/generate-and-commit-files.yml
+++ b/.github/workflows/generate-and-commit-files.yml
@@ -13,13 +13,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
       - name: Generate test and review files
         run: npm run build
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
         if: ${{ matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]' }}
         with:
           commit_message: Generate .html source files with scripts automatically

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -6,7 +6,7 @@ jobs:
   update_pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: tzkhan/pr-update-action@v2
+      - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9 # v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           head-branch-regex: '.*'


### PR DESCRIPTION
There was a ecosystem issue by tj-actions the other week which caused secrets to be spilled from CI logs. That action didn't affect this repo, but since it is part of the recommended hardening, I run `npx pin-github-action .github/workflows/` to pin them. Dependabot should still create PRs to bump them as needed