### PR TITLE
chore: add workflow to notify app when changes have been made to tests

### DIFF
--- a/.github/workflows/notify-app-on-test-change.yml
+++ b/.github/workflows/notify-app-on-test-change.yml
@@ -2,7 +2,7 @@ name: Notify App about test changes
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'tests/**'
 

--- a/.github/workflows/notify-app-on-test-change.yml
+++ b/.github/workflows/notify-app-on-test-change.yml
@@ -1,0 +1,37 @@
+name: Notify App about test changes
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/**'
+
+jobs:
+  check-and-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for test changes
+        id: check-changes
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep -q "^tests/"; then
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger aria-at-app workflow
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: 'TODO: ADD ONCE APPROACH IS ACCEPTED'
+          repository: w3c/aria-at-app
+          event-type: update-test-snapshots
+          client-payload: |
+            {
+              "ref": "${{ github.sha }}",
+              "commit_message": "${{ github.event.head_commit.message }}"
+            }


### PR DESCRIPTION
This PR adds a workflow that notifies the app repo about any updates to the test folder. This does not have a secret currently and will be left in `DRAFT` without the secret until the approach is broadly agreed upon.

related to [aria-at-app/#1359](https://github.com/w3c/aria-at-app/pull/1359).