### PR TITLE
Fix formatting in `ensure-build-directory-is-absent` workflow

### DIFF
--- a/.github/workflows/ensure-build-directory-is-absent.yml
+++ b/.github/workflows/ensure-build-directory-is-absent.yml
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
 
       - name: Verify that the "build" directory is absent
-        run: "[ ! -d build ]"
+        run: '[ ! -d build ]'


### PR DESCRIPTION
Missed formatting with newly introduced workflow file