### PR TITLE
feat: More robust test build error catching and logging

### DIFF
--- a/lib/data/parse-test-csv-row.js
+++ b/lib/data/parse-test-csv-row.js
@@ -110,12 +110,14 @@ function parseTestCSVRowV2({ tests, assertions, scripts, commands }) {
     // Create assertions value
     const assertionsValue = test.assertions
       ? test.assertions.split(' ').map(assertion => {
-          // TODO: Return error if foundAssertion is empty
           let foundAssertion = {};
+          let assertionId = assertion;
+
           assertions.forEach(e => {
             if (assertion.includes(':')) {
-              const [priority, assertionId] = assertion.split(':');
-              if (e.assertionId === assertionId) {
+              const [priority, id] = assertion.split(':');
+              assertionId = id;
+              if (e.assertionId === id) {
                 foundAssertion = {
                   ...e,
                   priority: Number(priority),
@@ -128,6 +130,14 @@ function parseTestCSVRowV2({ tests, assertions, scripts, commands }) {
               };
             }
           });
+
+          // Throw error if foundAssertion is empty (assertion ID not found)
+          if (Object.keys(foundAssertion).length === 0) {
+            throw new Error(
+              `Assertion ID "${assertionId}" referenced in tests.csv does not exist in assertions.csv`
+            );
+          }
+
           return foundAssertion;
         })
       : undefined;

--- a/lib/data/process-test-directory/index.js
+++ b/lib/data/process-test-directory/index.js
@@ -370,7 +370,7 @@ const processTestDirectory = async config => {
   const createLoggedValidator = (originalValidator, csvFileName) => {
     let rowIndex = 0;
     return row => {
-      utils.log(`Validating row ${rowIndex} in ${csvFileName} for test plan "${testPlanName}".`);
+      log(`Validating row ${rowIndex} in ${csvFileName} for test plan "${testPlanName}".`);
 
       // Track which columns have been accessed
       const accessedColumns = new Set();
@@ -383,7 +383,7 @@ const processTestDirectory = async config => {
             Object.prototype.hasOwnProperty.call(target, prop) &&
             !accessedColumns.has(prop)
           ) {
-            utils.log(`Processing ${csvFileName} column: ${prop}`);
+            log(`Processing ${csvFileName} column: ${prop}`);
             accessedColumns.add(prop);
           }
           return target[prop];

--- a/lib/data/process-test-directory/index.js
+++ b/lib/data/process-test-directory/index.js
@@ -83,6 +83,7 @@ function validateTestsKeys(row) {
       'Missing one of required testId, title, presentationNumber, instructions, assertions'
     );
   }
+
   if (!idFormat.test(row.testId))
     throw new Error('testId does not match the expected format: ' + row.testId);
   if (!titleFormat.test(row.title))
@@ -129,6 +130,7 @@ function validateAssertionsKeys(row) {
       'Missing one of required assertionId, priority, assertionStatement, assertionPhrase'
     );
   }
+
   if (!idFormat.test(row.assertionId))
     throw new Error('assertionId does not match the expected format: ' + row.assertionId);
   if (!priorityFormat.test(row.priority))
@@ -356,17 +358,83 @@ const processTestDirectory = async config => {
     return row;
   }
 
-  const [testsCsv, assertionsCsv, scriptsCsv, referencesCsv, ...atCommandsCsvs] = await Promise.all(
-    [
-      utils.readCSVFile('data/tests.csv', validateTestsKeys),
-      utils.readCSVFile('data/assertions.csv', validateAssertionsKeys),
-      utils.readCSVFile('data/scripts.csv', validateScriptsKeys),
-      utils.readCSVFile('data/references.csv', validateReferencesKeys),
-      ...atCommandsCsvFilePaths.map(({ atKey }) =>
-        utils.readCSVFile(`data/${atKey}-commands.csv`, validateCommandsKeys)
-      ),
-    ]
+  const [scriptsCsv, referencesCsv, ...atCommandsCsvs] = await Promise.all([
+    utils.readCSVFile('data/scripts.csv', validateScriptsKeys),
+    utils.readCSVFile('data/references.csv', validateReferencesKeys),
+    ...atCommandsCsvFilePaths.map(({ atKey }) =>
+      utils.readCSVFile(`data/${atKey}-commands.csv`, validateCommandsKeys)
+    ),
+  ]);
+
+  // Generic function to create a logged validator that tracks column access
+  const createLoggedValidator = (originalValidator, csvFileName) => {
+    let rowIndex = 0;
+    return row => {
+      utils.log(`Validating row ${rowIndex} in ${csvFileName} for test plan "${testPlanName}".`);
+
+      // Track which columns have been accessed
+      const accessedColumns = new Set();
+
+      // Create a proxy that logs when properties are accessed during validation
+      const loggedRow = new Proxy(row, {
+        get(target, prop) {
+          if (
+            typeof prop === 'string' &&
+            Object.prototype.hasOwnProperty.call(target, prop) &&
+            !accessedColumns.has(prop)
+          ) {
+            utils.log(`Processing ${csvFileName} column: ${prop}`);
+            accessedColumns.add(prop);
+          }
+          return target[prop];
+        },
+      });
+
+      // Run the original validator with the logged proxy
+      const result = originalValidator(loggedRow);
+      rowIndex++;
+      return result;
+    };
+  };
+
+  // Process assertions.csv first to get assertionIds
+  const validateAssertionsKeysWithLogging = createLoggedValidator(
+    validateAssertionsKeys,
+    'data/assertions.csv'
   );
+  const assertionsCsv = await utils.readCSVFile(
+    'data/assertions.csv',
+    validateAssertionsKeysWithLogging
+  );
+  const assertionIds = new Set(assertionsCsv.map(row => row.assertionId));
+
+  // Create a validator for tests.csv that includes assertionIds validation
+  const validateTestsKeysWithAssertions = createLoggedValidator(row => {
+    // Use original validation function (no duplication!)
+    validateTestsKeys(row);
+
+    // Additional validation for assertions column against assertionIds
+    if (row.assertions) {
+      const assertionRefs = row.assertions.trim().split(/\s+/);
+      for (const assertionRef of assertionRefs) {
+        // Extract assertionId from priority:assertionId format
+        const parts = assertionRef.split(':');
+        if (parts.length === 2) {
+          const [priority, assertionId] = parts;
+          if (!assertionIds.has(assertionId)) {
+            throw new Error(
+              `Assertion ID "${assertionId}" referenced in tests.csv does not exist in assertions.csv`
+            );
+          }
+        }
+      }
+    }
+
+    return row;
+  }, 'data/tests.csv');
+
+  // Now process tests.csv with the enhanced validator
+  const testsCsv = await utils.readCSVFile('data/tests.csv', validateTestsKeysWithAssertions);
 
   /**
    *
@@ -566,12 +634,45 @@ const processTestDirectory = async config => {
     atKey,
     commands: atCommandsCsvs[index],
   }));
-  const testsParsed = parseTestCSVRow({
-    tests: testsCsv,
-    assertions: assertionsCsv,
-    scripts: scriptsCsv,
-    commands: parsedAtCommandsCsvs,
-  });
+
+  // Parse test CSV with proper error handling for missing assertions
+  let testsParsed;
+  try {
+    testsParsed = parseTestCSVRow({
+      tests: testsCsv,
+      assertions: assertionsCsv,
+      scripts: scriptsCsv,
+      commands: parsedAtCommandsCsvs,
+    });
+  } catch (error) {
+    // Find which test row caused the error by examining the error message
+    const errorMessage = error.message;
+    let testRowIndex = -1;
+
+    // Try to find the test that caused the error
+    if (errorMessage.includes('does not exist in assertions.csv')) {
+      // Parse the assertion ID from the error message
+      const match = errorMessage.match(/Assertion ID "([^"]+)"/);
+      if (match) {
+        const assertionId = match[1];
+
+        // Find which test row contains this assertion
+        for (let i = 0; i < testsCsv.length; i++) {
+          const test = testsCsv[i];
+          if (test.assertions && test.assertions.includes(assertionId)) {
+            testRowIndex = i;
+            break;
+          }
+        }
+      }
+    }
+
+    // Throw error with proper line number context
+    const lineNumber = testRowIndex >= 0 ? testRowIndex + 2 : 'unknown'; // +2 for header and 0-based index
+    throw new Error(
+      `Error parsing ${path.join(testPlanDirectory, 'data/tests.csv')} line ${lineNumber}: ${errorMessage}`
+    );
+  }
   const scriptsSource = loadScriptsSource(scriptsRecord);
   const commandsParsed = parseCommandCSVRow(
     {


### PR DESCRIPTION
### Overview

This PR adds adds more informative test processing errors.
addresses #1257 

- Catches and surfaces processing errors with file paths and line numbers
- Shows which row and column is being processed in real-time when --verbose flag is used
- Validates that assertion IDs referenced in `tests.csv` actually exist in `assertions.csv`
- Modified CSV processing to throw errors immediately instead of logging warnings and continuing

### Example

An alert `assertions.csv` with an invalid priority
<details>
<summary>
invalid alert assertions.csv
</summary>

```csv
assertionId,priority,assertionStatement,assertionPhrase,refIds
roleAlert,3,Role 'alert' is conveyed,convey role 'alert',
textHello,invalid_priority,Text 'Hello' is conveyed,convey text 'Hello',
```
</details>

The output would be:
<details>
<summary>
Shell output
</summary>

```bash
aria-at % node scripts/create-all-tests/index.js --verbose --validate --testplan=alert
Successfully parsed /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/scripts.csv
Successfully parsed /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/references.csv
Successfully parsed /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/jaws-commands.csv
Successfully parsed /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/nvda-commands.csv
Successfully parsed /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/voiceover_macos-commands.csv
Validating row 0 in data/assertions.csv for test plan "alert".
Processing data/assertions.csv column: assertionId
Processing data/assertions.csv column: priority
Processing data/assertions.csv column: assertionStatement
Processing data/assertions.csv column: assertionPhrase
Validating row 1 in data/assertions.csv for test plan "alert".
Processing data/assertions.csv column: assertionId
Processing data/assertions.csv column: priority
Processing data/assertions.csv column: assertionStatement
Processing data/assertions.csv column: assertionPhrase
WARNING: Error parsing /Users/stalgia/Desktop/Work/aria-at/tests/alert/data/assertions.csv line 3: Error: pri
ority does not match the expected format: invalid_priority
ERROR: Unhandled exception thrown while processing "alert".

message: Cannot read properties of undefined (reading 'map')
stacktrace: TypeError: Cannot read properties of undefined (reading 'map')
    at processTestDirectory (/Users/stalgia/Desktop/Work/aria-at/lib/data/process-test-directory/index.js:409
:46)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.all (index 0)
    at async createAllTests (/Users/stalgia/Desktop/Work/aria-at/scripts/create-all-tests/createAllTests.js:8
5:25)
```
</details>