### PR TITLE
Update internal terminology to match UI

### DIFF
--- a/tests/resources/aria-at-harness.mjs
+++ b/tests/resources/aria-at-harness.mjs
@@ -12,7 +12,7 @@ import {
   userCloseWindow,
   userOpenWindow,
   WhitespaceStyleMap,
-  UnexpectedBehaviorImpactMap,
+  NegativeSideEffectImpactMap,
 } from './aria-at-test-run.mjs';
 import { TestRunExport, TestRunInputOutput } from './aria-at-test-io-format.mjs';
 import { TestWindow } from './aria-at-test-window.mjs';
@@ -438,7 +438,7 @@ function renderVirtualInstructionDocument(doc) {
           )
         )
       ),
-      ...[command.unexpectedBehaviors].map(bind(commandResultUnexpectedBehavior, commandIndex))
+      ...[command.negativeSideEffects].map(bind(commandResultNegativeSideEffect, commandIndex))
     );
   }
 
@@ -446,7 +446,7 @@ function renderVirtualInstructionDocument(doc) {
    * @param {number} commandIndex
    * @param {InstructionDocumentResultsCommandsUnexpected} unexpected
    */
-  function commandResultUnexpectedBehavior(commandIndex, unexpected) {
+  function commandResultNegativeSideEffect(commandIndex, unexpected) {
     return fieldset(
       id(`cmd-${commandIndex}-problem`),
       rich(unexpected.description),
@@ -474,7 +474,7 @@ function renderVirtualInstructionDocument(doc) {
             .replace(/[.,]/g, '')
             .replace(/\s+/g, '-');
 
-          const undesirableBehaviorCheckbox = div(
+          const negativeSideEffectCheckbox = div(
             input(
               type('checkbox'),
               value(failOption.description),
@@ -507,8 +507,8 @@ function renderVirtualInstructionDocument(doc) {
             select(
               id(`${failOptionId}-${commandIndex}-impact`),
               ariaLabel(`Impact for ${failOption.description}`),
-              option(UnexpectedBehaviorImpactMap.MODERATE),
-              option(UnexpectedBehaviorImpactMap.SEVERE),
+              option(NegativeSideEffectImpactMap.MODERATE),
+              option(NegativeSideEffectImpactMap.SEVERE),
               disabled(!failOption.checked),
               onchange(ev =>
                 failOption.impactchange(/** @type {HTMLInputElement} */ (ev.currentTarget).value)
@@ -538,7 +538,7 @@ function renderVirtualInstructionDocument(doc) {
 
           return div(
             className(['problem-option-container', failOption.checked && 'enabled']),
-            undesirableBehaviorCheckbox,
+            negativeSideEffectCheckbox,
             impactSelect,
             detailsTextInput
           );
@@ -615,7 +615,7 @@ function renderVirtualResultsTable(results) {
         ({
           description,
           support,
-          details: { output, passingAssertions, failingAssertions, unexpectedBehaviors },
+          details: { output, passingAssertions, failingAssertions, negativeSideEffects },
         }) =>
           fragment(
             tr(
@@ -625,7 +625,7 @@ function renderVirtualResultsTable(results) {
                 p(rich(output)),
                 commandDetailsList(passingAssertions),
                 commandDetailsList(failingAssertions),
-                commandDetailsList(unexpectedBehaviors)
+                commandDetailsList(negativeSideEffects)
               )
             )
           )

--- a/tests/resources/aria-at-test-io-format.mjs
+++ b/tests/resources/aria-at-test-io-format.mjs
@@ -6,7 +6,7 @@ import {
   AssertionResultMap,
   CommonResultMap,
   createEnumMap,
-  HasUnexpectedBehaviorMap,
+  HasNegativeSideEffectMap,
   TestRun,
   UserActionMap,
 } from './aria-at-test-run.mjs';
@@ -751,7 +751,7 @@ class BehaviorInput {
           priority: Number(assertionTuple[0]),
           assertion: assertionTuple[1],
         })),
-        unexpectedBehaviors: unexpectedInput.behaviors(),
+        negativeSideEffects: unexpectedInput.behaviors(),
       },
     });
   }
@@ -839,7 +839,7 @@ class BehaviorInput {
           }
         ),
         additionalAssertions: [],
-        unexpectedBehaviors: unexpectedInput.behaviors(),
+        negativeSideEffects: unexpectedInput.behaviors(),
       },
     });
   }
@@ -1201,12 +1201,12 @@ export class TestRunInputOutput {
             })),
             unexpected: {
               highlightRequired: false,
-              hasUnexpected: HasUnexpectedBehaviorMap.NOT_SET,
+              hasNegativeSideEffect: HasNegativeSideEffectMap.NOT_SET,
               tabbedBehavior: 0,
-              behaviors: test.unexpectedBehaviors.map(({ description }) => ({
+              behaviors: test.negativeSideEffects.map(({ description }) => ({
                 description,
                 checked: false,
-                impact: UnexpectedBehaviorImpactMap.MODERATE,
+                impact: NegativeSideEffectImpactMap.MODERATE,
                 more: { highlightRequired: false, value: '' },
               })),
             },
@@ -1296,7 +1296,7 @@ export class TestRunInputOutput {
             ({ priority, result }) => priority === 3 && result !== CommonResultMap.PASS
           ),
         },
-        unexpectedCount: countUnexpectedBehaviors(({ checked }) => checked),
+        unexpectedCount: countNegativeSideEffects(({ checked }) => checked),
       },
       commands: state.commands.map(command => ({
         command: command.description,
@@ -1355,7 +1355,7 @@ export class TestRunInputOutput {
      * @param {(behavior: TestRunUnexpected) => boolean} filter
      * @returns {number}
      */
-    function countUnexpectedBehaviors(filter) {
+    function countNegativeSideEffects(filter) {
       return state.commands.reduce(
         (carry, command) => carry + command.unexpected.behaviors.filter(filter).length,
         0
@@ -1422,7 +1422,7 @@ export class TestRunInputOutput {
                 ? 'NO_OUTPUT'
                 : null,
         })),
-        unexpectedBehaviors: command.unexpected.behaviors
+        negativeSideEffects: command.unexpected.behaviors
           .map(behavior =>
             behavior.checked
               ? {
@@ -1480,13 +1480,13 @@ export class TestRunInputOutput {
           unexpected: {
             ...command.unexpected,
             highlightRequired: false,
-            hasUnexpected:
-              scenarioResult.unexpectedBehaviors.length > 0
-                ? 'hasUnexpected'
-                : 'doesNotHaveUnexpected',
+            hasNegativeSideEffect:
+              scenarioResult.negativeSideEffects.length > 0
+                ? 'hasNegativeSideEffect'
+                : 'doesNotHaveNegativeSideEffect',
             tabbedBehavior: 0,
             behaviors: command.unexpected.behaviors.map(behavior => {
-              const behaviorResult = scenarioResult.unexpectedBehaviors.find(
+              const behaviorResult = scenarioResult.negativeSideEffects.find(
                 unexpectedResult => unexpectedResult.text === behavior.description
               );
               return {
@@ -1497,7 +1497,7 @@ export class TestRunInputOutput {
                       highlightRequired: false,
                       impact: behaviorResult
                         ? behavior.impact
-                        : UnexpectedBehaviorImpactMap.MODERATE,
+                        : NegativeSideEffectImpactMap.MODERATE,
                       value: behaviorResult ? behaviorResult.details : '',
                     }
                   : behavior.more,
@@ -1583,7 +1583,7 @@ const AssertionFailJSONMap = createEnumMap({
   FAIL: 'Fail',
 });
 
-const UnexpectedBehaviorImpactMap = createEnumMap({
+const NegativeSideEffectImpactMap = createEnumMap({
   MODERATE: 'Moderate',
   SEVERE: 'Severe',
 });
@@ -1896,7 +1896,7 @@ function findValueByKey(keysMapping, keyToFindText) {
  * @property {string[]} commands
  * @property {BehaviorAssertion[]} assertions
  * @property {BehaviorAssertion[]} additionalAssertions
- * @property {BehaviorUnexpectedItem[]} unexpectedBehaviors
+ * @property {BehaviorUnexpectedItem[]} negativeSideEffects
  */
 
 /** @typedef {{[key: string]: (document: Document) => void}} SetupScripts */
@@ -1958,6 +1958,6 @@ function findValueByKey(keysMapping, keyToFindText) {
 /** @typedef {import('./aria-at-test-run.mjs').TestRunAssertion} TestRunAssertion */
 /** @typedef {import('./aria-at-test-run.mjs').TestRunAdditionalAssertion} TestRunAdditionalAssertion */
 /** @typedef {import('./aria-at-test-run.mjs').TestRunCommand} TestRunCommand */
-/** @typedef {import("./aria-at-test-run.mjs").TestRunUnexpectedBehavior} TestRunUnexpected */
+/** @typedef {import("./aria-at-test-run.mjs").TestRunNegativeSideEffect} TestRunUnexpected */
 
 /** @typedef {import('./aria-at-test-run.mjs').TestPageDocument} TestPageDocument */

--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -12,15 +12,15 @@ export class TestRun {
     /** @type {TestRunHooks} */
     this.hooks = {
       closeTestPage: bindDispatch(userCloseWindow),
-      focusCommandUnexpectedBehavior: bindDispatch(userFocusCommandUnexpectedBehavior),
+      focusCommandNegativeSideEffect: bindDispatch(userFocusCommandNegativeSideEffect),
       openTestPage: bindDispatch(userOpenWindow),
       postResults: () => {},
       setCommandAdditionalAssertion: bindDispatch(userChangeCommandAdditionalAssertion),
       setCommandAssertion: bindDispatch(userChangeCommandAssertion),
-      setCommandHasUnexpectedBehavior: bindDispatch(userChangeCommandHasUnexpectedBehavior),
-      setCommandUnexpectedBehavior: bindDispatch(userChangeCommandUnexpectedBehavior),
-      setCommandUnexpectedBehaviorImpact: bindDispatch(userChangeCommandUnexpectedBehaviorImpact),
-      setCommandUnexpectedBehaviorMore: bindDispatch(userChangeCommandUnexpectedBehaviorMore),
+      setCommandHasNegativeSideEffect: bindDispatch(userChangeCommandHasNegativeSideEffect),
+      setCommandNegativeSideEffect: bindDispatch(userChangeCommandNegativeSideEffect),
+      setCommandNegativeSideEffectImpact: bindDispatch(userChangeCommandNegativeSideEffectImpact),
+      setCommandNegativeSideEffectMore: bindDispatch(userChangeCommandNegativeSideEffectMore),
       setCommandOutput: bindDispatch(userChangeCommandOutput),
       setCommandUntestable: bindDispatch(userChangeCommandUntestable),
       submit: () => submitResult(this),
@@ -227,7 +227,7 @@ export function instructionDocument(resultState, hooks) {
    */
   function commandResult(command, commandIndex) {
     const resultStateCommand = resultState.commands[commandIndex];
-    const resultUnexpectedBehavior = resultStateCommand.unexpected;
+    const resultNegativeSideEffect = resultStateCommand.unexpected;
 
     const {
       commandSettings: { description: settings, text: settingsText, assertionExceptions },
@@ -258,7 +258,7 @@ export function instructionDocument(resultState, hooks) {
           `Executing '${command}' affected behavior that made assertions untestable. If checked, then at least one severe negative side effect must be recorded below.`,
           {
             highlightRequired: resultStateCommand.untestable.highlightRequired,
-            description: '(requires at least one SEVERE undesirable behavior)',
+            description: '(requires at least one SEVERE negative side effect)',
           },
         ],
         value: resultStateCommand.untestable.value,
@@ -286,7 +286,7 @@ export function instructionDocument(resultState, hooks) {
           ),
         ...additionalAssertions.map(bind(additionalAssertionResult, commandIndex)),
       ],
-      unexpectedBehaviors: {
+      negativeSideEffects: {
         description: [
           'Did negative side effects occur?',
           {
@@ -298,58 +298,58 @@ export function instructionDocument(resultState, hooks) {
         passChoice: {
           label: 'No, negative side effects did not occur.',
           checked:
-            resultUnexpectedBehavior.hasUnexpected ===
-            HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+            resultNegativeSideEffect.hasNegativeSideEffect ===
+            HasNegativeSideEffectMap.DOES_NOT_HAVE_UNEXPECTED,
           focus:
             resultState.currentUserAction === 'validateResults' &&
-            resultUnexpectedBehavior.highlightRequired &&
-            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            resultNegativeSideEffect.highlightRequired &&
+            resultNegativeSideEffect.hasNegativeSideEffect === HasNegativeSideEffectMap.NOT_SET &&
             focusFirstRequired(),
           click: () =>
-            hooks.setCommandHasUnexpectedBehavior({
+            hooks.setCommandHasNegativeSideEffect({
               commandIndex,
-              hasUnexpected: HasUnexpectedBehaviorMap.DOES_NOT_HAVE_UNEXPECTED,
+              hasNegativeSideEffect: HasNegativeSideEffectMap.DOES_NOT_HAVE_UNEXPECTED,
             }),
         },
         failChoice: {
           label: 'Yes, negative side effects occured.',
           checked:
-            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+            resultNegativeSideEffect.hasNegativeSideEffect === HasNegativeSideEffectMap.HAS_UNEXPECTED,
           focus:
             resultState.currentUserAction === 'validateResults' &&
-            resultUnexpectedBehavior.highlightRequired &&
-            resultUnexpectedBehavior.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET &&
+            resultNegativeSideEffect.highlightRequired &&
+            resultNegativeSideEffect.hasNegativeSideEffect === HasNegativeSideEffectMap.NOT_SET &&
             focusFirstRequired(),
           click: () =>
-            hooks.setCommandHasUnexpectedBehavior({
+            hooks.setCommandHasNegativeSideEffect({
               commandIndex,
-              hasUnexpected: HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
+              hasNegativeSideEffect: HasNegativeSideEffectMap.HAS_UNEXPECTED,
             }),
           options: {
             header: 'Negative side effects',
-            options: resultUnexpectedBehavior.behaviors.map((behavior, unexpectedIndex) => {
+            options: resultNegativeSideEffect.behaviors.map((behavior, unexpectedIndex) => {
               return {
                 description: behavior.description,
                 impact: behavior.impact,
                 enabled:
-                  resultUnexpectedBehavior.hasUnexpected ===
-                  HasUnexpectedBehaviorMap.HAS_UNEXPECTED,
-                tabbable: resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex,
+                  resultNegativeSideEffect.hasNegativeSideEffect ===
+                  HasNegativeSideEffectMap.HAS_UNEXPECTED,
+                tabbable: resultNegativeSideEffect.tabbedBehavior === unexpectedIndex,
                 checked: behavior.checked,
                 focus:
                   typeof resultState.currentUserAction === 'object' &&
                   resultState.currentUserAction.action === UserObjectActionMap.FOCUS_UNDESIRABLE
                     ? resultState.currentUserAction.commandIndex === commandIndex &&
-                      resultUnexpectedBehavior.tabbedBehavior === unexpectedIndex
+                      resultNegativeSideEffect.tabbedBehavior === unexpectedIndex
                     : resultState.currentUserAction === UserActionMap.VALIDATE_RESULTS &&
-                      resultUnexpectedBehavior.hasUnexpected ===
-                        HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
-                      resultUnexpectedBehavior.behaviors.every(({ checked }) => !checked) &&
+                      resultNegativeSideEffect.hasNegativeSideEffect ===
+                        HasNegativeSideEffectMap.HAS_UNEXPECTED &&
+                      resultNegativeSideEffect.behaviors.every(({ checked }) => !checked) &&
                       focusFirstRequired(),
                 change: checked =>
-                  hooks.setCommandUnexpectedBehavior({ commandIndex, unexpectedIndex, checked }),
+                  hooks.setCommandNegativeSideEffect({ commandIndex, unexpectedIndex, checked }),
                 impactchange: impact =>
-                  hooks.setCommandUnexpectedBehaviorImpact({
+                  hooks.setCommandNegativeSideEffectImpact({
                     commandIndex,
                     unexpectedIndex,
                     impact,
@@ -357,7 +357,7 @@ export function instructionDocument(resultState, hooks) {
                 keydown: key => {
                   const increment = keyToFocusIncrement(key);
                   if (increment) {
-                    hooks.focusCommandUnexpectedBehavior({
+                    hooks.focusCommandNegativeSideEffect({
                       commandIndex,
                       unexpectedIndex,
                       increment,
@@ -387,7 +387,7 @@ export function instructionDocument(resultState, hooks) {
                     behavior.more.highlightRequired &&
                     focusFirstRequired(),
                   change: value =>
-                    hooks.setCommandUnexpectedBehaviorMore({
+                    hooks.setCommandNegativeSideEffectMore({
                       commandIndex,
                       unexpectedIndex,
                       more: value,
@@ -469,13 +469,13 @@ export const UserObjectActionMap = createEnumMap({
  */
 
 /**
- * @typedef {EnumValues<typeof HasUnexpectedBehaviorMap>} HasUnexpectedBehavior
+ * @typedef {EnumValues<typeof HasNegativeSideEffectMap>} HasNegativeSideEffect
  */
 
-export const HasUnexpectedBehaviorMap = createEnumMap({
+export const HasNegativeSideEffectMap = createEnumMap({
   NOT_SET: 'notSet',
-  HAS_UNEXPECTED: 'hasUnexpected',
-  DOES_NOT_HAVE_UNEXPECTED: 'doesNotHaveUnexpected',
+  HAS_UNEXPECTED: 'hasNegativeSideEffect',
+  DOES_NOT_HAVE_UNEXPECTED: 'doesNotHaveNegativeSideEffect',
 });
 
 export const CommonResultMap = createEnumMap({
@@ -504,10 +504,10 @@ export const AssertionResultMap = createEnumMap({
 });
 
 /**
- * @typedef {EnumValues<typeof UnexpectedBehaviorImpactMap>} UnexpectedBehaviorImpact
+ * @typedef {EnumValues<typeof NegativeSideEffectImpactMap>} NegativeSideEffectImpact
  */
 
-export const UnexpectedBehaviorImpactMap = createEnumMap({
+export const NegativeSideEffectImpactMap = createEnumMap({
   MODERATE: 'Moderate',
   SEVERE: 'Severe',
 });
@@ -547,12 +547,12 @@ export function userChangeCommandOutput({ commandIndex, atOutput }) {
 export function userChangeCommandUntestable({ commandIndex, isUntestable }) {
   return function (state) {
     // When the user indicates that a command is untestable, they are tacitly
-    // signalling that there was at least one unexpected behavior.
-    let newState = userChangeCommandHasUnexpectedBehavior({
+    // signalling that there was at least one negative side effect.
+    let newState = userChangeCommandHasNegativeSideEffect({
       commandIndex,
-      hasUnexpected: isUntestable
-        ? HasUnexpectedBehaviorMap.HAS_UNEXPECTED
-        : HasUnexpectedBehaviorMap.NOT_SET,
+      hasNegativeSideEffect: isUntestable
+        ? HasNegativeSideEffectMap.HAS_UNEXPECTED
+        : HasNegativeSideEffectMap.NOT_SET,
     })(state);
 
     const total = newState.commands[commandIndex].assertions.length;
@@ -642,10 +642,10 @@ export function userChangeCommandAdditionalAssertion({
 /**
  * @param {object} props
  * @param {number} props.commandIndex
- * @param {HasUnexpectedBehavior} props.hasUnexpected
+ * @param {HasNegativeSideEffect} props.hasNegativeSideEffect
  * @returns {(state: TestRunState) => TestRunState}
  */
-export function userChangeCommandHasUnexpectedBehavior({ commandIndex, hasUnexpected }) {
+export function userChangeCommandHasNegativeSideEffect({ commandIndex, hasNegativeSideEffect }) {
   return function (state) {
     return {
       ...state,
@@ -657,10 +657,10 @@ export function userChangeCommandHasUnexpectedBehavior({ commandIndex, hasUnexpe
               ...command,
               unexpected: {
                 ...command.unexpected,
-                hasUnexpected: hasUnexpected,
-                tabbedBehavior: hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED ? 0 : -1,
+                hasNegativeSideEffect: hasNegativeSideEffect,
+                tabbedBehavior: hasNegativeSideEffect === HasNegativeSideEffectMap.HAS_UNEXPECTED ? 0 : -1,
                 behaviors: command.unexpected.behaviors.map(behavior =>
-                  // If `hasUnexpected` is being re-set to the existing value,
+                  // If `hasNegativeSideEffect` is being re-set to the existing value,
                   // that indicates the user has triggered this update to
                   // "hasUnepected" by a means other than the input element
                   // dedicated to this state. Retain any existing "behavior"
@@ -671,7 +671,7 @@ export function userChangeCommandHasUnexpectedBehavior({ commandIndex, hasUnexpe
                   // side effects have occurred along with corresponding
                   // behaviors. If they subsequently indicate that the scenario
                   // is untestable, the behavior data should be retained.
-                  command.unexpected.hasUnexpected === hasUnexpected
+                  command.unexpected.hasNegativeSideEffect === hasNegativeSideEffect
                     ? behavior
                     : {
                         ...behavior,
@@ -693,7 +693,7 @@ export function userChangeCommandHasUnexpectedBehavior({ commandIndex, hasUnexpe
  * @param {boolean} props.checked
  * @returns {(state: TestRunState) => TestRunState}
  */
-export function userChangeCommandUnexpectedBehavior({ commandIndex, unexpectedIndex, checked }) {
+export function userChangeCommandNegativeSideEffect({ commandIndex, unexpectedIndex, checked }) {
   return function (state) {
     return {
       ...state,
@@ -727,7 +727,7 @@ export function userChangeCommandUnexpectedBehavior({ commandIndex, unexpectedIn
  * @param {string} props.impact
  * @returns {(state: TestRunState) => TestRunState}
  */
-export function userChangeCommandUnexpectedBehaviorImpact({
+export function userChangeCommandNegativeSideEffectImpact({
   commandIndex,
   unexpectedIndex,
   impact,
@@ -746,7 +746,7 @@ export function userChangeCommandUnexpectedBehaviorImpact({
                 behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
                   unexpectedI !== unexpectedIndex
                     ? unexpected
-                    : /** @type {TestRunUnexpectedBehavior} */ ({
+                    : /** @type {TestRunNegativeSideEffect} */ ({
                         ...unexpected,
                         impact: impact,
                       })
@@ -765,7 +765,7 @@ export function userChangeCommandUnexpectedBehaviorImpact({
  * @param {string} props.more
  * @returns {(state: TestRunState) => TestRunState}
  */
-export function userChangeCommandUnexpectedBehaviorMore({ commandIndex, unexpectedIndex, more }) {
+export function userChangeCommandNegativeSideEffectMore({ commandIndex, unexpectedIndex, more }) {
   return function (state) {
     return {
       ...state,
@@ -780,7 +780,7 @@ export function userChangeCommandUnexpectedBehaviorMore({ commandIndex, unexpect
                 behaviors: command.unexpected.behaviors.map((unexpected, unexpectedI) =>
                   unexpectedI !== unexpectedIndex
                     ? unexpected
-                    : /** @type {TestRunUnexpectedBehavior} */ ({
+                    : /** @type {TestRunNegativeSideEffect} */ ({
                         ...unexpected,
                         more: {
                           ...unexpected.more,
@@ -873,8 +873,8 @@ function isSomeFieldRequired(state) {
   return state.commands.some(
     command =>
       command.atOutput.value.trim() === '' ||
-      command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
-      (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+      command.unexpected.hasNegativeSideEffect === HasNegativeSideEffectMap.NOT_SET ||
+      (command.unexpected.hasNegativeSideEffect === HasNegativeSideEffectMap.HAS_UNEXPECTED &&
         (command.unexpected.behaviors.every(({ checked }) => !checked) ||
           command.unexpected.behaviors.some(
             behavior => behavior.checked && behavior.more && behavior.more.value.trim() === ''
@@ -896,7 +896,7 @@ function needsSevereImpact(command) {
  */
 function commandHasSevereImpact(command) {
   return (
-    command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+    command.unexpected.hasNegativeSideEffect === HasNegativeSideEffectMap.HAS_UNEXPECTED &&
     command.unexpected.behaviors.some(behavior => behavior.checked && behavior.impact === 'SEVERE')
   );
 }
@@ -951,7 +951,7 @@ function resultsTableDocument(state) {
 
         let passingAssertions = ['No passing assertions'];
         let failingAssertions = ['No failing assertions'];
-        let unexpectedBehaviors = ['None'];
+        let negativeSideEffects = ['None'];
 
         if (allAssertions.some(({ result }) => result)) {
           passingAssertions = allAssertions
@@ -964,7 +964,7 @@ function resultsTableDocument(state) {
             .map(({ description }) => description);
         }
         if (command.unexpected.behaviors.some(({ checked }) => checked)) {
-          unexpectedBehaviors = command.unexpected.behaviors
+          negativeSideEffects = command.unexpected.behaviors
             .filter(({ checked }) => checked)
             .map(({ description, more, impact }) => {
               let result = `${description} (`;
@@ -1004,9 +1004,9 @@ function resultsTableDocument(state) {
               description: 'Failing Assertions:',
               items: failingAssertions,
             },
-            unexpectedBehaviors: {
+            negativeSideEffects: {
               description: 'Other behaviors that create negative impact:',
-              items: unexpectedBehaviors,
+              items: negativeSideEffects,
             },
           },
         };
@@ -1040,7 +1040,7 @@ export function userCloseWindow() {
  * @param {TestRunFocusIncrement} props.increment
  * @returns {(state: TestRunState) => TestRunState}
  */
-export function userFocusCommandUnexpectedBehavior({ commandIndex, unexpectedIndex, increment }) {
+export function userFocusCommandNegativeSideEffect({ commandIndex, unexpectedIndex, increment }) {
   return function (state) {
     const unexpectedLength = state.commands[commandIndex].unexpected.behaviors.length;
     const incrementValue = increment === 'next' ? 1 : -1;
@@ -1095,8 +1095,8 @@ export function userValidateState() {
           unexpected: {
             ...command.unexpected,
             highlightRequired:
-              command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
-              (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
+              command.unexpected.hasNegativeSideEffect === HasNegativeSideEffectMap.NOT_SET ||
+              (command.unexpected.hasNegativeSideEffect === HasNegativeSideEffectMap.HAS_UNEXPECTED &&
                 command.unexpected.behaviors.every(({ checked }) => !checked)),
             behaviors: command.unexpected.behaviors.map(unexpected => {
               return unexpected.more
@@ -1247,7 +1247,7 @@ export function userValidateState() {
  * @property {InstructionDocumentResultsCommandsATOutput} atOutput
  * @property {InstructionDocumentResultsCommandsAssertionsHeader} assertionsHeader
  * @property {InstructionDocumentResultsCommandsAssertion[]} assertions
- * @property {InstructionDocumentResultsCommandsUnexpected} unexpectedBehaviors
+ * @property {InstructionDocumentResultsCommandsUnexpected} negativeSideEffects
  */
 
 /**
@@ -1316,17 +1316,17 @@ export function userValidateState() {
 /**
  * @typedef TestRunHooks
  * @property {() => void} closeTestPage
- * @property {(options: {commandIndex: number, unexpectedIndex: number, increment: TestRunFocusIncrement}) => void} focusCommandUnexpectedBehavior
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, increment: TestRunFocusIncrement}) => void} focusCommandNegativeSideEffect
  * @property {() => void} openTestPage
  * @property {() => void} postResults
  * @property {(options: {commandIndex: number, additionalAssertionIndex: number, result: AdditionalAssertionResult}) => void} setCommandAdditionalAssertion
  * @property {(options: {commandIndex: number, assertionIndex: number, result: AssertionResult}) => void} setCommandAssertion
- * @property {(options: {commandIndex: number, hasUnexpected: HasUnexpectedBehavior}) => void } setCommandHasUnexpectedBehavior
+ * @property {(options: {commandIndex: number, hasNegativeSideEffect: HasNegativeSideEffect}) => void } setCommandHasNegativeSideEffect
  * @property {(options: {commandIndex: number, atOutput: string}) => void} setCommandOutput
  * @property {(options: {commandIndex: number, isUntestable: boolean}) => void} setCommandUntestable
- * @property {(options: {commandIndex: number, unexpectedIndex: number, checked}) => void } setCommandUnexpectedBehavior
- * @property {(options: {commandIndex: number, unexpectedIndex: number, impact: string}) => void } setCommandUnexpectedBehaviorImpact
- * @property {(options: {commandIndex: number, unexpectedIndex: number, more: string}) => void } setCommandUnexpectedBehaviorMore
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, checked}) => void } setCommandNegativeSideEffect
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, impact: string}) => void } setCommandNegativeSideEffectImpact
+ * @property {(options: {commandIndex: number, unexpectedIndex: number, more: string}) => void } setCommandNegativeSideEffectMore
  * @property {() => void} submit
  */
 
@@ -1359,7 +1359,7 @@ export function userValidateState() {
  */
 
 /**
- * @typedef TestRunUnexpectedBehavior
+ * @typedef TestRunNegativeSideEffect
  * @property {string} description
  * @property {boolean} checked
  * @property {object} [more]
@@ -1371,9 +1371,9 @@ export function userValidateState() {
 /**
  * @typedef TestRunUnexpectedGroup
  * @property {boolean} highlightRequired
- * @property {HasUnexpectedBehavior} hasUnexpected
+ * @property {HasNegativeSideEffect} hasNegativeSideEffect
  * @property {number} tabbedBehavior
- * @property {TestRunUnexpectedBehavior[]} behaviors
+ * @property {TestRunNegativeSideEffect[]} behaviors
  */
 
 /**
@@ -1435,7 +1435,7 @@ export function userValidateState() {
  * @property {Description} table.commands[].details.output
  * @property {ResultsTableDetailsList} table.commands[].details.passingAssertions
  * @property {ResultsTableDetailsList} table.commands[].details.failingAssertions
- * @property {ResultsTableDetailsList} table.commands[].details.unexpectedBehaviors
+ * @property {ResultsTableDetailsList} table.commands[].details.negativeSideEffects
  */
 
 /**

--- a/tests/resources/types/aria-at-test-result.js
+++ b/tests/resources/types/aria-at-test-result.js
@@ -32,9 +32,9 @@
  * @property {string} scenarioResults[].assertionResults[].assertion.text
  * @property {boolean | null} scenarioResults[].assertionResults[].result
  * @property {AriaATTestResult.AssertionFailedReasonJSON | null} [scenarioResults[].assertionResults[].failedReason]
- * @property {object[]} scenarioResults[].unexpectedBehaviors
- * @property {string} scenarioResults[].unexpectedBehaviors[].id
- * @property {string} scenarioResults[].unexpectedBehaviors[].text
- * @property {string} scenarioResults[].unexpectedBehaviors[].impact
- * @property {string} scenarioResults[].unexpectedBehaviors[].details
+ * @property {object[]} scenarioResults[].negativeSideEffects
+ * @property {string} scenarioResults[].negativeSideEffects[].id
+ * @property {string} scenarioResults[].negativeSideEffects[].text
+ * @property {string} scenarioResults[].negativeSideEffects[].impact
+ * @property {string} scenarioResults[].negativeSideEffects[].details
  */

--- a/tests/resources/types/aria-at-test-run.js
+++ b/tests/resources/types/aria-at-test-run.js
@@ -46,8 +46,8 @@
 
 /**
  * @typedef {"notSet"
- *   | "hasUnexpected"
- *   | "doesNotHaveUnexpected"} AriaATTestRun.HasUnexpectedBehavior
+ *   | "hasNegativeSideEffect"
+ *   | "doesNotHaveNegativeSideEffect"} AriaATTestRun.HasNegativeSideEffect
  */
 
 /**
@@ -87,7 +87,7 @@
  * @property {AriaATTestRun.AdditionalAssertionResult} commands[].additionalAssertions[].result
  * @property {object} commands[].unexpected
  * @property {boolean} commands[].unexpected.highlightRequired
- * @property {AriaATTestRun.HasUnexpectedBehavior} commands[].unexpected.hasUnexpected
+ * @property {AriaATTestRun.HasNegativeSideEffect} commands[].unexpected.hasNegativeSideEffect
  * @property {number} commands[].unexpected.tabbedBehavior
  * @property {object[]} commands[].unexpected.behaviors
  * @property {string} commands[].unexpected.behaviors[].description


### PR DESCRIPTION
Rename "unexpected behaviors" and "undesirable behaviors" to "negative side effects".

The modifications in patch were generated with the following command:

    git ls-files -z tests/resources |
      xargs -0 sed -i \
        -e 's/\(unexpected\|undesirable\)\([- ]\)behavior/negative\2side\2effect/g' \
        -e 's/\(Unexpected\|Undesirable\) behavior/Negative side effect/g' \
        -e 's/\(Unexpected\|Undesirable\) Behavior/Negative Side Effect/g' \
        -e 's/\(unexpected\|undesirable\)Behavior/negativeSideEffect/g' \
        -e 's/\(Unexpected\|Undesirable\)Behavior/NegativeSideEffect/g' \
        -e 's/\(has\|Has\|doesNotHave\)Unexpected/\1NegativeSideEffect/g'

This patch depends on https://github.com/w3c/aria-at-app/pull/1498