### PR TITLE
Display proper error message when `untestable` is checked and no `SEVERE` impact negative side effects have been set

### DIFF
--- a/tests/resources/aria-at-test-run.mjs
+++ b/tests/resources/aria-at-test-run.mjs
@@ -1090,7 +1090,7 @@ export function userValidateState() {
           },
           untestable: {
             ...command.untestable,
-            highlightRequired: false,
+            highlightRequired: needsSevereImpact(command),
           },
           unexpected: {
             ...command.unexpected,


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1295--aria-at.netlify.app)

Address https://github.com/w3c/aria-at-app/issues/1487
Address https://github.com/w3c/aria-at/issues/1278#issuecomment-3183836860