### PR TITLE
chore: format `support.json`; update `lint-staged` rules; include pinned linting dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@babel/preset-env": "^7.26.7",
         "babel-jest": "^29.7.0",
         "eslint": "^9.19.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-n": "^17.15.1",
         "eslint-plugin-prettier": "^5.2.1",
         "globals": "^15.14.0",
@@ -3662,14 +3663,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -9787,12 +9790,10 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {}
     },
     "eslint-plugin-es-x": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/preset-env": "^7.26.7",
     "babel-jest": "^29.7.0",
     "eslint": "^9.19.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-n": "^17.15.1",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^15.14.0",
@@ -57,7 +58,7 @@
   },
   "homepage": "https://github.com/w3c/aria-at#readme",
   "lint-staged": {
-    "*.js": "eslint --cache --fix"
+    "**/*.{js,css,json,md,yml}": "npm run lint:fix"
   },
   "engines": {
     "node": ">=20.x"

--- a/tests/support.json
+++ b/tests/support.json
@@ -283,7 +283,7 @@
       "baseUrl": "https://www.w3.org/TR/html-aam-1.0/",
       "linkText": "Accessibility API Mapping",
       "fragmentIds": {
-                "@abbr": "#att-abbr",
+        "@abbr": "#att-abbr",
         "@accept": "#att-accept",
         "@acceptCharset": "#att-accept-charset",
         "@accesskey": "#att-accesskey",


### PR DESCRIPTION
This PR:
* Properly formats the `support.json` following [this comment](https://github.com/w3c/aria-at/pull/1299#discussion_r2372896169)
* Updates `lint-staged` rules so it would have captured the above concern
* When verifying changes locally, noticed the `eslint-config-prettier` was missing but `eslint-plugin-prettier` required it