### PR TITLE
fix: correct ARIA attribute refIds for radio group with activedescendant assertions

### DIFF
--- a/tests/radiogroup-aria-activedescendant/data/assertions.csv
+++ b/tests/radiogroup-aria-activedescendant/data/assertions.csv
@@ -1,16 +1,16 @@
 assertionId,priority,assertionStatement,assertionPhrase,refIds
 groupBoundary,1,Group boundary is conveyed,convey group boundary,radiogroup
-interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},
+interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},radiogroup
 nameDeepDish,1,"Name of the radio button, 'Deep dish', is conveyed","convey name of the radio button, 'Deep dish'",radio
 nameGroupPizzaCrust,1,"Name of the group, 'Pizza Crust', is conveyed","convey name of the group, 'Pizza Crust'",aria-labelledby
 nameNavigateBackFromHere,1,"Name of the link, 'Navigate backwards from here', is conveyed","convey name of the link, 'Navigate backwards from here'",htmlLink
 nameNavigateForwardsFromHere,1,"Name of the link, 'Navigate forwards from here', is conveyed","convey name of the link, 'Navigate forwards from here'",htmlLink
 nameRegularCrust,1,"Name of the radio button, 'Regular crust', is conveyed","convey name of the radio button, 'Regular crust'",radio
 nameThinCrust,1,"Name of the radio button, 'Thin crust', is conveyed","convey name of the radio button, 'Thin crust'",radio
-numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-activedescendant aria-setsize radio
-positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-activedescendant aria-posinset radio
-positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-activedescendant aria-posinset radio
-positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-activedescendant aria-posinset radio
+numberRadioButtonsGroup3,2,"Number of radio buttons in the group, 3, is conveyed","convey number of radio buttons in the group, 3",aria-setsize
+positionRadio1,2,"Position of the radio button, 1, is conveyed","convey position of the radio button, 1",aria-posinset
+positionRadio2,2,"Position of the radio button, 2, is conveyed","convey position of the radio button, 2",aria-posinset
+positionRadio3,2,"Position of the radio button, 3, is conveyed","convey position of the radio button, 3",aria-posinset
 roleGroup,2,Role 'group' is conveyed,convey role 'group',radiogroup
 roleLink,1,Role 'link' is conveyed,convey role 'link',htmlLink
 roleRadio,1,Role 'radio button' is conveyed,convey role 'radio button',radio


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1320--aria-at.netlify.app)

In assertions.csv in the test plan for radio group with aria-activedescendant:
1. Remove extraneous references to activedescendant and radio role from posinset and setsize assertions.
2. Add composite "radiogroup" to the mode switching assertion.