### PR TITLE
Menu Button with aria-activedescendant: Fix refIds in assertions.csv

### DIFF
--- a/tests/menu-button-actions-active-descendant/data/assertions.csv
+++ b/tests/menu-button-actions-active-descendant/data/assertions.csv
@@ -1,15 +1,15 @@
 assertionId,priority,assertionStatement,assertionPhrase,refIds
 nameActions,1,"Name of the menu button, 'Actions', is conveyed","convey name of the menu button, 'Actions'",button
-nameMenuActions,3,"Name of the menu, 'Actions', is conveyed","convey name of the menu, 'Actions'",menu aria-labelledby
-nameFocusedItemAction1,1,"Name of the focused item, 'Action 1', is conveyed","convey name of the focused item, 'Action 1'",aria-activedescendant
-nameFocusedItemAction2,1,"Name of the focused item, 'Action 2', is conveyed","convey name of the focused item, 'Action 2'",aria-activedescendant
-nameFocusedItemAction4,1,"Name of the focused item, 'Action 4', is conveyed","convey name of the focused item, 'Action 4'",aria-activedescendant
+nameMenuActions,3,"Name of the menu, 'Actions', is conveyed","convey name of the menu, 'Actions'",aria-labelledby
+nameFocusedItemAction1,1,"Name of the focused item, 'Action 1', is conveyed","convey name of the focused item, 'Action 1'",menuitem aria-activedescendant
+nameFocusedItemAction2,1,"Name of the focused item, 'Action 2', is conveyed","convey name of the focused item, 'Action 2'",menuitem aria-activedescendant
+nameFocusedItemAction4,1,"Name of the focused item, 'Action 4', is conveyed","convey name of the focused item, 'Action 4'",menuitem aria-activedescendant
 numberItemsMenu4,2,"Number of items in the menu,'(4', is conveyed","convey number of items in the menu, '4'",aria-setsize
 roleFocusedItemMenuItem,2,"Role of the focused item, 'menu item', is conveyed","convey role of the focused item, 'menu item'",menuitem
 roleMenu,3,Role 'menu' is conveyed,convey role 'menu',menu
 roleMenuButton,1,Role 'menu button' is conveyed,convey role 'menu button',button aria-haspopup
 stateCollapsed,2,State 'collapsed' is conveyed,convey state 'collapsed',aria-expanded
-interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},
-positionFocusedItemMenu1,2,"Position of the focused item in the menu, '1', is conveyed","convey position of the focused item in the menu, '1'",aria-posinset aria-activedescendant
-positionFocusedItemMenu2,2,"Position of the focused item in the menu, '2', is conveyed","convey position of the focused item in the menu, '2'",aria-posinset aria-activedescendant
-positionFocusedItemMenu4,2,"Position of the focused item in the menu, '4', is conveyed","convey position of the focused item in the menu, '4'",aria-posinset aria-activedescendant
+interactionModeEnabled,2,Screen reader switched from reading mode to interaction mode|{screenReader} switched from {readingMode} to {interactionMode},switch from reading mode to interaction mode|switch from {readingMode} to {interactionMode},menu
+positionFocusedItemMenu1,2,"Position of the focused item in the menu, '1', is conveyed","convey position of the focused item in the menu, '1'",aria-posinset
+positionFocusedItemMenu2,2,"Position of the focused item in the menu, '2', is conveyed","convey position of the focused item in the menu, '2'",aria-posinset
+positionFocusedItemMenu4,2,"Position of the focused item in the menu, '4', is conveyed","convey position of the focused item in the menu, '4'",aria-posinset


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1321--aria-at.netlify.app)

1. Remove extraneous references to activedescendant from posinset and setsize assertions.
2. Add menuitem reference to menuitem name assertions.
3. Add menu reference to mode switching assertion since it is the composite role driving the switching.