### PR TITLE
Alert: add mising reference to alert role in assertions.csv

### DIFF
--- a/tests/alert/data/assertions.csv
+++ b/tests/alert/data/assertions.csv
@@ -1,3 +1,3 @@
 assertionId,priority,assertionStatement,assertionPhrase,refIds
-roleAlert,3,Role 'alert' is conveyed,convey role 'alert',
-textHello,1,Text 'Hello' is conveyed,convey text 'Hello',
+roleAlert,3,Role 'alert' is conveyed,convey role 'alert',alert
+textHello,1,Text 'Hello' is conveyed,convey text 'Hello',alert

--- a/tests/alert/data/references.csv
+++ b/tests/alert/data/references.csv
@@ -6,5 +6,3 @@ reference,metadata,reference/2022-4-8_144013/alert.html,Test Case Page for Alert
 designPattern,metadata,https://www.w3.org/WAI/ARIA/apg/patterns/alert/,APG Pattern: Alert
 example,metadata,https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert/,APG Example: Alert
 alert,aria,alert,alert
-aria-live,aria,aria-live,aria-live
-aria-atomic,aria,aria-atomic,aria-atomic


### PR DESCRIPTION
* Add missing reference to 'alert' role to assertions.
* Remove unused 'aria-atomic' and aria--live' lines from references.csv. These attributes are not explicitly used or tested in the 'Alert' example.

[Preview Tests](https://deploy-preview-1332--aria-at.netlify.app)

