### PR TITLE
support.json: Revise HTML AAM spec ref link text

### DIFF
--- a/tests/support.json
+++ b/tests/support.json
@@ -281,7 +281,7 @@
     },
     "htmlAam": {
       "baseUrl": "https://www.w3.org/TR/html-aam-1.0/",
-      "linkText": "Accessibility API Mapping",
+      "linkText": "HTML-AAM Specification",
       "fragmentIds": {
         "@abbr": "#att-abbr",
         "@accept": "#att-accept",


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1337--aria-at.netlify.app)

The link text for HTML element mappings is currently like 'button accessibility API mapping'. It does not clearly state that the element is an HTML button. This changes it to be like 'button HTML-AAM specification'. That is the name of the spec that is being referenced. This makes the link text shorter, more accurate, and easier to understand.