### PR TITLE
Proper bind for `utils.addTestError` func when validating parsed tests

### DIFF
--- a/lib/data/process-test-directory/index.js
+++ b/lib/data/process-test-directory/index.js
@@ -691,7 +691,7 @@ const processTestDirectory = async config => {
   };
   const testsValidated = testsParsed.map(test =>
     validateTest(test, testLookups, {
-      addTestError: utils.addTestError.bind(null, test.testId),
+      addTestError: utils.addTestError.bind(utils, test.testId),
     })
   );
 

--- a/lib/data/process-test-directory/v1.js
+++ b/lib/data/process-test-directory/v1.js
@@ -504,7 +504,7 @@ const processTestDirectory = async config => {
   };
   const testsValidated = testsParsed.map(test =>
     validateTest(test, testLookups, {
-      addTestError: utils.addTestError.bind(null, test.testId),
+      addTestError: utils.addTestError.bind(utils, test.testId),
     })
   );
 


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1339--aria-at.netlify.app)

`addTestError` was bound with null, causing `Cannot read properties of null (reading 'errorCount')` when accessing `this.errorCount` and `this.errors`. This PR ensures it's bind is attached to the instantiated `Utils` instance instead