### PR TITLE
Fix paths for built `*.collected.json` and `*.collected.html`

### DIFF
--- a/__test__/__snapshots__/createAllTests.test.js.snap
+++ b/__test__/__snapshots__/createAllTests.test.js.snap
@@ -442,7 +442,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 5`] = 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-01-navigate-forwards-into-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -633,7 +633,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 7`] = 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-01-navigate-forwards-into-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -964,7 +964,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 11`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-02-navigate-forwards-into-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -1125,7 +1125,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 13`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-02-navigate-forwards-into-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -1416,7 +1416,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 17`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-navigate-forwards-into-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -1719,7 +1719,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 21`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-04-navigate-backwards-into-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -1900,7 +1900,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 23`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-04-navigate-backwards-into-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -2219,7 +2219,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 27`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navigate-backwards-into-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -2380,7 +2380,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 29`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navigate-backwards-into-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -2669,7 +2669,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 33`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navigate-backwards-into-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -2970,7 +2970,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 37`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-07-navigate-forwards-out-of-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -3141,7 +3141,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 39`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-07-navigate-forwards-out-of-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -3441,7 +3441,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 43`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-08-navigate-forwards-out-of-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -3602,7 +3602,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 45`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-08-navigate-forwards-out-of-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -3882,7 +3882,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 49`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-navigate-forwards-out-of-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -4174,7 +4174,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 53`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-10-navigate-backwards-out-of-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -4345,7 +4345,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 55`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-10-navigate-backwards-out-of-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -4649,7 +4649,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 59`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-navigate-backwards-out-of-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -4810,7 +4810,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 61`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-navigate-backwards-out-of-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -5094,7 +5094,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 65`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-12-navigate-backwards-out-of-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -5392,7 +5392,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 69`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -5591,7 +5591,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 71`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -5937,7 +5937,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 75`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -6116,7 +6116,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 77`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -6442,7 +6442,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 81`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -6789,7 +6789,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 85`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -6979,7 +6979,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 87`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -7307,7 +7307,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 91`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -7477,7 +7477,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 93`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -7785,7 +7785,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 97`] =
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -8114,7 +8114,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 101`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -8275,7 +8275,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 103`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -8548,7 +8548,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 107`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -8819,7 +8819,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 111`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -8980,7 +8980,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 113`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -9253,7 +9253,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 117`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -9524,7 +9524,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 121`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -9699,7 +9699,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 123`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -9994,7 +9994,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 127`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -10277,7 +10277,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 131`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -10452,7 +10452,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 133`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -10753,7 +10753,7 @@ exports[`V1 test format version runs createAllTests successfully (banner) 137`] 
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -11181,7 +11181,7 @@ exports[`V2 test format version runs createAllTests successfully (alert) 5`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-jaws.collected.json");
     </script>
   </body>
@@ -11485,7 +11485,7 @@ exports[`V2 test format version runs createAllTests successfully (alert) 7`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-nvda.collected.json");
     </script>
   </body>
@@ -11753,7 +11753,7 @@ exports[`V2 test format version runs createAllTests successfully (alert) 9`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-voiceover_macos.collected.json");
     </script>
   </body>
@@ -12570,7 +12570,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-jaws.collected.json");
     </script>
   </body>
@@ -12856,7 +12856,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-nvda.collected.json");
     </script>
   </body>
@@ -13142,7 +13142,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -13800,7 +13800,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-jaws.collected.json");
     </script>
   </body>
@@ -14086,7 +14086,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-nvda.collected.json");
     </script>
   </body>
@@ -14372,7 +14372,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -15033,7 +15033,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-jaws.collected.json");
     </script>
   </body>
@@ -15301,7 +15301,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-nvda.collected.json");
     </script>
   </body>
@@ -15569,7 +15569,7 @@ exports[`V2 test format version runs createAllTests successfully (command-button
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -16457,7 +16457,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-jaws.collected.json");
     </script>
   </body>
@@ -16832,7 +16832,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-nvda.collected.json");
     </script>
   </body>
@@ -17207,7 +17207,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -18015,7 +18015,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-jaws.collected.json");
     </script>
   </body>
@@ -18386,7 +18386,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-nvda.collected.json");
     </script>
   </body>
@@ -18757,7 +18757,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -19569,7 +19569,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-jaws.collected.json");
     </script>
   </body>
@@ -19915,7 +19915,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-nvda.collected.json");
     </script>
   </body>
@@ -20261,7 +20261,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -20981,7 +20981,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-jaws.collected.json");
     </script>
   </body>
@@ -21211,7 +21211,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-nvda.collected.json");
     </script>
   </body>
@@ -21441,7 +21441,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-voiceover_macos.collected.json");
     </script>
   </body>
@@ -21995,7 +21995,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-jaws.collected.json");
     </script>
   </body>
@@ -22225,7 +22225,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-nvda.collected.json");
     </script>
   </body>
@@ -22455,7 +22455,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-voiceover_macos.collected.json");
     </script>
   </body>
@@ -23009,7 +23009,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-jaws.collected.json");
     </script>
   </body>
@@ -23221,7 +23221,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-nvda.collected.json");
     </script>
   </body>
@@ -23433,7 +23433,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-voiceover_macos.collected.json");
     </script>
   </body>
@@ -23837,7 +23837,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-jaws.collected.json");
     </script>
   </body>
@@ -24049,7 +24049,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-nvda.collected.json");
     </script>
   </body>
@@ -24261,7 +24261,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-voiceover_macos.collected.json");
     </script>
   </body>
@@ -24665,7 +24665,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-jaws.collected.json");
     </script>
   </body>
@@ -24877,7 +24877,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-nvda.collected.json");
     </script>
   </body>
@@ -25089,7 +25089,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-voiceover_macos.collected.json");
     </script>
   </body>
@@ -25493,7 +25493,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-jaws.collected.json");
     </script>
   </body>
@@ -25705,7 +25705,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-nvda.collected.json");
     </script>
   </body>
@@ -25917,7 +25917,7 @@ exports[`V2 test format version runs createAllTests successfully (horizontal-sli
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-voiceover_macos.collected.json");
     </script>
   </body>
@@ -26460,7 +26460,7 @@ exports[`all test format versions runs createAllTests successfully 5`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-jaws.collected.json");
     </script>
   </body>
@@ -26764,7 +26764,7 @@ exports[`all test format versions runs createAllTests successfully 7`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-nvda.collected.json");
     </script>
   </body>
@@ -27032,7 +27032,7 @@ exports[`all test format versions runs createAllTests successfully 9`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-triggerAlert-voiceover_macos.collected.json");
     </script>
   </body>
@@ -27990,7 +27990,7 @@ exports[`all test format versions runs createAllTests successfully 17`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-01-navigate-forwards-into-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -28181,7 +28181,7 @@ exports[`all test format versions runs createAllTests successfully 19`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-01-navigate-forwards-into-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -28512,7 +28512,7 @@ exports[`all test format versions runs createAllTests successfully 23`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-02-navigate-forwards-into-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -28673,7 +28673,7 @@ exports[`all test format versions runs createAllTests successfully 25`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-02-navigate-forwards-into-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -28964,7 +28964,7 @@ exports[`all test format versions runs createAllTests successfully 29`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-03-navigate-forwards-into-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -29267,7 +29267,7 @@ exports[`all test format versions runs createAllTests successfully 33`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-04-navigate-backwards-into-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -29448,7 +29448,7 @@ exports[`all test format versions runs createAllTests successfully 35`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-04-navigate-backwards-into-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -29767,7 +29767,7 @@ exports[`all test format versions runs createAllTests successfully 39`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navigate-backwards-into-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -29928,7 +29928,7 @@ exports[`all test format versions runs createAllTests successfully 41`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navigate-backwards-into-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -30217,7 +30217,7 @@ exports[`all test format versions runs createAllTests successfully 45`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navigate-backwards-into-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -30518,7 +30518,7 @@ exports[`all test format versions runs createAllTests successfully 49`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-07-navigate-forwards-out-of-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -30689,7 +30689,7 @@ exports[`all test format versions runs createAllTests successfully 51`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-07-navigate-forwards-out-of-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -30989,7 +30989,7 @@ exports[`all test format versions runs createAllTests successfully 55`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-08-navigate-forwards-out-of-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -31150,7 +31150,7 @@ exports[`all test format versions runs createAllTests successfully 57`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-08-navigate-forwards-out-of-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -31430,7 +31430,7 @@ exports[`all test format versions runs createAllTests successfully 61`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-navigate-forwards-out-of-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -31722,7 +31722,7 @@ exports[`all test format versions runs createAllTests successfully 65`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-10-navigate-backwards-out-of-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -31893,7 +31893,7 @@ exports[`all test format versions runs createAllTests successfully 67`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-10-navigate-backwards-out-of-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -32197,7 +32197,7 @@ exports[`all test format versions runs createAllTests successfully 71`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-navigate-backwards-out-of-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -32358,7 +32358,7 @@ exports[`all test format versions runs createAllTests successfully 73`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-navigate-backwards-out-of-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -32642,7 +32642,7 @@ exports[`all test format versions runs createAllTests successfully 77`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-12-navigate-backwards-out-of-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -32940,7 +32940,7 @@ exports[`all test format versions runs createAllTests successfully 81`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -33139,7 +33139,7 @@ exports[`all test format versions runs createAllTests successfully 83`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-navigate-forwards-to-a-button-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -33485,7 +33485,7 @@ exports[`all test format versions runs createAllTests successfully 87`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -33664,7 +33664,7 @@ exports[`all test format versions runs createAllTests successfully 89`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-14-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -33990,7 +33990,7 @@ exports[`all test format versions runs createAllTests successfully 93`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-navigate-forwards-to-a-button-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -34337,7 +34337,7 @@ exports[`all test format versions runs createAllTests successfully 97`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -34527,7 +34527,7 @@ exports[`all test format versions runs createAllTests successfully 99`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-16-navigate-backwards-to-a-button-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -34855,7 +34855,7 @@ exports[`all test format versions runs createAllTests successfully 103`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-jaws.collected.json");
     </script>
   </body>
@@ -35025,7 +35025,7 @@ exports[`all test format versions runs createAllTests successfully 105`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-nvda.collected.json");
     </script>
   </body>
@@ -35333,7 +35333,7 @@ exports[`all test format versions runs createAllTests successfully 109`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-18-navigate-backwards-to-a-button-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -35662,7 +35662,7 @@ exports[`all test format versions runs createAllTests successfully 113`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -35823,7 +35823,7 @@ exports[`all test format versions runs createAllTests successfully 115`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-navigate-forwards-to-an-image-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -36096,7 +36096,7 @@ exports[`all test format versions runs createAllTests successfully 119`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-20-navigate-forwards-to-an-image-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -36367,7 +36367,7 @@ exports[`all test format versions runs createAllTests successfully 123`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -36528,7 +36528,7 @@ exports[`all test format versions runs createAllTests successfully 125`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-navigate-backwards-to-an-image-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -36801,7 +36801,7 @@ exports[`all test format versions runs createAllTests successfully 129`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-22-navigate-backwards-to-an-image-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -37072,7 +37072,7 @@ exports[`all test format versions runs createAllTests successfully 133`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -37247,7 +37247,7 @@ exports[`all test format versions runs createAllTests successfully 135`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-23-navigate-forwards-to-a-heading-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -37542,7 +37542,7 @@ exports[`all test format versions runs createAllTests successfully 139`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-24-navigate-forwards-to-a-heading-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -37825,7 +37825,7 @@ exports[`all test format versions runs createAllTests successfully 143`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading-jaws.collected.json");
     </script>
   </body>
@@ -38000,7 +38000,7 @@ exports[`all test format versions runs createAllTests successfully 145`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-25-navigate-backwards-to-a-heading-inside-a-banner-landmark-reading-nvda.collected.json");
     </script>
   </body>
@@ -38301,7 +38301,7 @@ exports[`all test format versions runs createAllTests successfully 149`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-26-navigate-backwards-to-a-heading-inside-a-banner-landmark-interaction-voiceover_macos.collected.json");
     </script>
   </body>
@@ -38807,7 +38807,7 @@ exports[`all test format versions runs createAllTests successfully 157`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-jaws.collected.json");
     </script>
   </body>
@@ -39093,7 +39093,7 @@ exports[`all test format versions runs createAllTests successfully 159`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-nvda.collected.json");
     </script>
   </body>
@@ -39379,7 +39379,7 @@ exports[`all test format versions runs createAllTests successfully 161`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -40037,7 +40037,7 @@ exports[`all test format versions runs createAllTests successfully 165`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-jaws.collected.json");
     </script>
   </body>
@@ -40323,7 +40323,7 @@ exports[`all test format versions runs createAllTests successfully 167`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-nvda.collected.json");
     </script>
   </body>
@@ -40609,7 +40609,7 @@ exports[`all test format versions runs createAllTests successfully 169`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -41270,7 +41270,7 @@ exports[`all test format versions runs createAllTests successfully 173`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-jaws.collected.json");
     </script>
   </body>
@@ -41538,7 +41538,7 @@ exports[`all test format versions runs createAllTests successfully 175`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-nvda.collected.json");
     </script>
   </body>
@@ -41806,7 +41806,7 @@ exports[`all test format versions runs createAllTests successfully 177`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutButton-voiceover_macos.collected.json");
     </script>
   </body>
@@ -42694,7 +42694,7 @@ exports[`all test format versions runs createAllTests successfully 185`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-jaws.collected.json");
     </script>
   </body>
@@ -43069,7 +43069,7 @@ exports[`all test format versions runs createAllTests successfully 187`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-nvda.collected.json");
     </script>
   </body>
@@ -43444,7 +43444,7 @@ exports[`all test format versions runs createAllTests successfully 189`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-05-navForwardsToSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -44252,7 +44252,7 @@ exports[`all test format versions runs createAllTests successfully 193`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-jaws.collected.json");
     </script>
   </body>
@@ -44623,7 +44623,7 @@ exports[`all test format versions runs createAllTests successfully 195`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-nvda.collected.json");
     </script>
   </body>
@@ -44994,7 +44994,7 @@ exports[`all test format versions runs createAllTests successfully 197`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-06-navBackToSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -45806,7 +45806,7 @@ exports[`all test format versions runs createAllTests successfully 201`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-jaws.collected.json");
     </script>
   </body>
@@ -46152,7 +46152,7 @@ exports[`all test format versions runs createAllTests successfully 203`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-nvda.collected.json");
     </script>
   </body>
@@ -46498,7 +46498,7 @@ exports[`all test format versions runs createAllTests successfully 205`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-09-reqInfoAboutSlider-voiceover_macos.collected.json");
     </script>
   </body>
@@ -47218,7 +47218,7 @@ exports[`all test format versions runs createAllTests successfully 209`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-jaws.collected.json");
     </script>
   </body>
@@ -47448,7 +47448,7 @@ exports[`all test format versions runs createAllTests successfully 211`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-nvda.collected.json");
     </script>
   </body>
@@ -47678,7 +47678,7 @@ exports[`all test format versions runs createAllTests successfully 213`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-11-incrementSliderByOneStep-voiceover_macos.collected.json");
     </script>
   </body>
@@ -48232,7 +48232,7 @@ exports[`all test format versions runs createAllTests successfully 217`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-jaws.collected.json");
     </script>
   </body>
@@ -48462,7 +48462,7 @@ exports[`all test format versions runs createAllTests successfully 219`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-nvda.collected.json");
     </script>
   </body>
@@ -48692,7 +48692,7 @@ exports[`all test format versions runs createAllTests successfully 221`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-13-decrementSliderByOneStep-voiceover_macos.collected.json");
     </script>
   </body>
@@ -49246,7 +49246,7 @@ exports[`all test format versions runs createAllTests successfully 225`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-jaws.collected.json");
     </script>
   </body>
@@ -49458,7 +49458,7 @@ exports[`all test format versions runs createAllTests successfully 227`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-nvda.collected.json");
     </script>
   </body>
@@ -49670,7 +49670,7 @@ exports[`all test format versions runs createAllTests successfully 229`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-15-incrementSliderByTenSteps-voiceover_macos.collected.json");
     </script>
   </body>
@@ -50074,7 +50074,7 @@ exports[`all test format versions runs createAllTests successfully 233`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-jaws.collected.json");
     </script>
   </body>
@@ -50286,7 +50286,7 @@ exports[`all test format versions runs createAllTests successfully 235`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-nvda.collected.json");
     </script>
   </body>
@@ -50498,7 +50498,7 @@ exports[`all test format versions runs createAllTests successfully 237`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-17-decrementSliderByTenSteps-voiceover_macos.collected.json");
     </script>
   </body>
@@ -50902,7 +50902,7 @@ exports[`all test format versions runs createAllTests successfully 241`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-jaws.collected.json");
     </script>
   </body>
@@ -51114,7 +51114,7 @@ exports[`all test format versions runs createAllTests successfully 243`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-nvda.collected.json");
     </script>
   </body>
@@ -51326,7 +51326,7 @@ exports[`all test format versions runs createAllTests successfully 245`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-19-decrementSliderToMinimumValue-voiceover_macos.collected.json");
     </script>
   </body>
@@ -51730,7 +51730,7 @@ exports[`all test format versions runs createAllTests successfully 249`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-jaws.collected.json");
     </script>
   </body>
@@ -51942,7 +51942,7 @@ exports[`all test format versions runs createAllTests successfully 251`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-nvda.collected.json");
     </script>
   </body>
@@ -52154,7 +52154,7 @@ exports[`all test format versions runs createAllTests successfully 253`] = `
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "test-21-incrementSliderToMaximumValue-voiceover_macos.collected.json");
     </script>
   </body>

--- a/lib/data/templates/collected-test.html.js
+++ b/lib/data/templates/collected-test.html.js
@@ -91,7 +91,7 @@ function renderHTML(test, testFileName) {
   </head>
   <body>
     <script type="module">
-      import {loadCollectedTestAsync} from "../../resources/aria-at-harness.mjs";
+      import {loadCollectedTestAsync} from "../../../resources/aria-at-harness.mjs";
       loadCollectedTestAsync(new URL(location + "/..").pathname, "${testFileName}");
     </script>
   </body>

--- a/resources/aria-at-harness.mjs
+++ b/resources/aria-at-harness.mjs
@@ -128,7 +128,7 @@ export async function loadCollectedTestAsync(testRoot, testFileName) {
 
   // v2 commands.json
   // eslint-disable-next-line n/no-unsupported-features/node-builtins -- fetch is experimental till Node.js 21
-  const commandsJsonResponse = await fetch('../commands.json');
+  const commandsJsonResponse = await fetch('../../commands.json');
   if (commandsJsonResponse.ok) {
     const commandsJson = await commandsJsonResponse.json();
     testRunIO.setAllCommandsInputFromJSON(commandsJson);


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1341--aria-at.netlify.app)

Address invalid renders of `*.collected.html` pages such as [/tests/apg/accordion/test-05-navForwardsToExpandedAccordionHeader-jaws.collected.html](https://aria-at.netlify.app/tests/apg/accordion/test-05-navForwardsToExpandedAccordionHeader-jaws.collected.html)