### PR TITLE
Checkbox Test Plan: Attempt to work around app issue 1660 by changing the order VO commands are presented

### DIFF
--- a/tests/apg/checkbox/data/voiceover_macos-commands.csv
+++ b/tests/apg/checkbox/data/voiceover_macos-commands.csv
@@ -1,20 +1,20 @@
 testId,command,settings,assertionExceptions,presentationNumber
-navForwardsToNotCheckedCheckbox,c,singleQuickKeyNavOn,,2
-navForwardsToNotCheckedCheckbox,ctrl+opt+right ctrl+opt+right,,1:roleGroup 1:nameSandwichCondiments 1:listBoundary,3
-navForwardsToNotCheckedCheckbox,tab,,,3.1
-navForwardsToNotCheckedCheckbox,j,singleQuickKeyNavOn,,3.2
-navBackToNotCheckedCheckbox,shift+c,singleQuickKeyNavOn,,5
-navBackToNotCheckedCheckbox,ctrl+opt+left,,,6
-navBackToNotCheckedCheckbox,shift+tab,,,6.1
-navBackToNotCheckedCheckbox,shift+j,singleQuickKeyNavOn,,6.2
-navForwardsToCheckedCheckbox,c,singleQuickKeyNavOn,,8
-navForwardsToCheckedCheckbox,ctrl+opt+right ctrl+opt+right,,1:roleGroup 1:nameSandwichCondiments 1:listBoundary,9
-navForwardsToCheckedCheckbox,tab,,,9.1
-navForwardsToCheckedCheckbox,j,singleQuickKeyNavOn,,9.2
-navBackToCheckedCheckbox,shift+c,singleQuickKeyNavOn,,11
-navBackToCheckedCheckbox,ctrl+opt+left,,,12
-navBackToCheckedCheckbox,shift+tab,,,12.1
-navBackToCheckedCheckbox,shift+j,singleQuickKeyNavOn,,12.2
+navForwardsToNotCheckedCheckbox,tab,,,3
+navForwardsToNotCheckedCheckbox,ctrl+opt+right ctrl+opt+right,,1:roleGroup 1:nameSandwichCondiments 1:listBoundary,3.1
+navForwardsToNotCheckedCheckbox,c,singleQuickKeyNavOn,,3.2
+navForwardsToNotCheckedCheckbox,j,singleQuickKeyNavOn,,3.3
+navBackToNotCheckedCheckbox,shift+tab,,,6
+navBackToNotCheckedCheckbox,ctrl+opt+left,,,6.1
+navBackToNotCheckedCheckbox,shift+c,singleQuickKeyNavOn,,6.2
+navBackToNotCheckedCheckbox,shift+j,singleQuickKeyNavOn,,6.3
+navForwardsToCheckedCheckbox,tab,,,9
+navForwardsToCheckedCheckbox,ctrl+opt+right ctrl+opt+right,,1:roleGroup 1:nameSandwichCondiments 1:listBoundary,9.1
+navForwardsToCheckedCheckbox,c,singleQuickKeyNavOn,,9.2
+navForwardsToCheckedCheckbox,j,singleQuickKeyNavOn,,9.3
+navBackToCheckedCheckbox,shift+tab,,,12
+navBackToCheckedCheckbox,ctrl+opt+left,,,12.1
+navBackToCheckedCheckbox,shift+c,singleQuickKeyNavOn,,12.2
+navBackToCheckedCheckbox,shift+j,singleQuickKeyNavOn,,12.3
 reqInfoAboutNotCheckedCheckbox,ctrl+opt+f3,,2:roleGroup 2:nameSandwichCondiments,15
 reqInfoAboutNotCheckedCheckbox,ctrl+opt+f4,,2:roleGroup 2:nameSandwichCondiments,15.1
 reqInfoAboutCheckedCheckbox,ctrl+opt+f3,,2:roleGroup 2:nameSandwichCondiments,18


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1359--aria-at.netlify.app)

Experiment to test whether changing the order of presentation of VO commands for tests 1 through 4 could somehow work around w3c/aria-at-app#1660, which is preventing the 'j' and 'shift+j' commands from rendering in the runner, test plan review, and report.