### PR TITLE
Minimal Data Grid Test Plan: remove y and shift+y VoiceOver Commands

### DIFF
--- a/tests/apg/minimal-data-grid/data/voiceover_macos-commands.csv
+++ b/tests/apg/minimal-data-grid/data/voiceover_macos-commands.csv
@@ -9,10 +9,8 @@ reqInfoAboutGridCell,ctrl+opt+f3,,,14
 reqInfoAboutGridCell,ctrl+opt+f4,,,14.1
 navToNextColumnGrid,right,arrowQuickKeyNavOff,,20
 navToNextColumnGrid,ctrl+opt+right,,,20.1
-navToNextColumnGrid,y,singleQuickKeyNavOn,,20.2
 navToPrevColumnGrid,left,arrowQuickKeyNavOff,,23
 navToPrevColumnGrid,ctrl+opt+left,,,23.1
-navToPrevColumnGrid,shift+y,singleQuickKeyNavOn,,23.2
 navToNextRowGrid,down,arrowQuickKeyNavOff,,38
 navToNextRowGrid,ctrl+opt+down,,,38.1
 navToPrevRowGrid,up,arrowQuickKeyNavOff,,41


### PR DESCRIPTION
[Preview Tests](https://deploy-preview-1374--aria-at.netlify.app)

Resolve#1372 and # 1373.

The next and previous column quick keys do not appear to be supported by default